### PR TITLE
Add section defining edge pubsub topics

### DIFF
--- a/docs/edge.md
+++ b/docs/edge.md
@@ -125,7 +125,12 @@ incidence of such things.
 Since the actual message is not examined by the edge server the only failures
 that occur are defined by the response status codes above. Messages are only
 forwarded to the pipeline when a response code of 200 is returned to the
- client.
+client.
+
+### PubSub Topics
+
+All messages that sent a response code of 200 are forwarded to a single PubSub
+topic for validation and landfill.
 
 ### GeoIP Lookups
 


### PR DESCRIPTION
fixes #2

> What (if any) submissions are explicitly rejected by the edge

This is already defined by the sections `Bad Messages` and `POST/PUT Response codes`

> What (if any) submissions are accepted, but published to topics without any consumers

Added `PubSub Topics` section in the PR to cover this (answer is none)

> We currently are not planning to drop anything at the edge, but we should document that. We may need to do so in the future if we see malicious submissions or activity.

Also already covered by the `Bad Messages` section