### PR TITLE
Update CI to use a smaller image for gcloud emulators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           --detach
           --network ingestion-edge
           --name pubsub
-          google/cloud-sdk
+          mozilla/gcloud-sdk-emulators
           gcloud beta emulators pubsub start --host-port 0.0.0.0:$PUBSUB_PORT
         environment: *env
     - run:


### PR DESCRIPTION
I created [mozilla/docker-gcloud-sdk-emulators](https://github.com/mozilla/docker-gcloud-sdk-emulators) so that there would be an image based off google/cloud-sdk:alpine with the beta emulators installed, to save 500MB in image downloads on every CircleCI run.