### PR TITLE
Set default log level to WARNING

### DIFF
--- a/ingestion-beam/pom.xml
+++ b/ingestion-beam/pom.xml
@@ -194,6 +194,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.12.4</version>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>java.util.logging.config.file</name>
+                            <value>src/test/resources/logging.properties</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ingestion-beam/src/test/resources/logging.properties
+++ b/ingestion-beam/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+.level=WARNING


### PR DESCRIPTION
yauaa and beam are needlessly noisy when log level is INFO