### PR TITLE
Pull down mozilla-pipeline-schemas in pom.xml

### DIFF
--- a/ingestion-beam/.gitignore
+++ b/ingestion-beam/.gitignore
@@ -7,3 +7,4 @@ derby.log
 .DS_Store
 tmp/
 GeoLite2-City.mmdb
+src/main/resources/schemas/

--- a/ingestion-beam/bin/update-schemas
+++ b/ingestion-beam/bin/update-schemas
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Pulls down the current dev branch of mozilla-pipeline-schemas
+# and extracts the schemas/ directory into our Java resources/
+# directory so that the schemas are available in our Beam pipelines.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+BRANCH="dev"
+TARFILE="$BRANCH.tar.gz"
+TAR_URL="https://github.com/mozilla-services/mozilla-pipeline-schemas/archive/$TARFILE"
+
+rm -rf src/main/resources/schemas
+tar -xzf <(curl -sL $TAR_URL) \
+    --strip-components=1 \
+    -C src/main/resources/ \
+    mozilla-pipeline-schemas-$BRANCH/schemas

--- a/ingestion-beam/pom.xml
+++ b/ingestion-beam/pom.xml
@@ -137,11 +137,21 @@
                         <goals>
                             <goal>java</goal>
                         </goals>
+                        <configuration>
+                            <mainClass>${exec.mainClass}</mainClass>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>Copy in schema resources from mozilla-pipeline-schemas</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${basedir}/bin/update-schemas</executable>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <mainClass>${exec.mainClass}</mainClass>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Closes #56

This seems like a simpler approach to maintain compared to packaging
and uploading a versioned jar from mozilla-pipeline-schemas as suggested in
https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/201

With this approach, we'll always pull the latest version, which comes with
the downside of a bad update to the other repo unexpectedly breaking builds
here, but it's in line with practices we already have in place elsewhere
and it ensures we don't lag in schema version.