### PR TITLE
Add a default processElement for input PubsubMessage

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Sink.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Sink.java
@@ -6,7 +6,7 @@ package com.mozilla.telemetry;
 
 import com.mozilla.telemetry.options.SinkOptions;
 import com.mozilla.telemetry.transforms.CompositeTransform;
-import com.mozilla.telemetry.transforms.DecodePubsubMessages;
+import com.mozilla.telemetry.transforms.MapElementsWithErrors.ToPubsubMessageFrom;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -38,8 +38,8 @@ public class Sink {
         .apply("input", options.getInputType().read(options))
         .apply("write input parsing errors",
             CompositeTransform.of((PCollectionTuple input) -> {
-              input.get(DecodePubsubMessages.errorTag).apply(errorOutput);
-              return input.get(DecodePubsubMessages.mainTag);
+              input.get(ToPubsubMessageFrom.errorTag).apply(errorOutput);
+              return input.get(ToPubsubMessageFrom.mainTag);
             }))
         .apply("write main output", options.getOutputType().write(options))
         .apply("write output errors", errorOutput);

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/AddMetadata.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/AddMetadata.java
@@ -13,6 +13,7 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 public class AddMetadata extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMessage> {
   private static final byte[] METADATA_PREFIX = "{\"metadata\":".getBytes();
 
+  @Override
   protected PubsubMessage processElement(PubsubMessage element) throws IOException {
     // Get payload
     final byte[] payload = element.getPayload();

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -31,6 +31,7 @@ public class ParseUri extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMe
     return map;
   }
 
+  @Override
   protected PubsubMessage processElement(PubsubMessage element) throws InvalidUriException {
     // Copy attributes
     final Map<String, String> attributes = new HashMap<>(element.getAttributeMap());

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ValidateSchema.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ValidateSchema.java
@@ -54,6 +54,7 @@ public class ValidateSchema extends MapElementsWithErrors.ToPubsubMessageFrom<Pu
     return schemas.get(name);
   }
 
+  @Override
   protected PubsubMessage processElement(PubsubMessage element)
       throws SchemaNotFoundException, IOException {
     // Throws IOException if not a valid json object

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/InputType.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/InputType.java
@@ -5,7 +5,7 @@
 package com.mozilla.telemetry.options;
 
 import com.mozilla.telemetry.transforms.CompositeTransform;
-import com.mozilla.telemetry.transforms.DecodePubsubMessages;
+import com.mozilla.telemetry.transforms.MapElementsWithErrors;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -19,7 +19,7 @@ public enum InputType {
     public PTransform<PBegin, PCollectionTuple> read(SinkOptions options) {
       return CompositeTransform.of(input -> input
           .apply(PubsubIO.readMessagesWithAttributes().fromSubscription(options.getInput()))
-          .apply(DecodePubsubMessages.alreadyDecoded())
+          .apply(MapElementsWithErrors.ToPubsubMessageFrom.identity())
       );
     }
   },

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/DecodePubsubMessages.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/DecodePubsubMessages.java
@@ -37,14 +37,6 @@ public abstract class DecodePubsubMessages
     return new Json();
   }
 
-  /**
-   * Pass-through for pre-decoded PubsubMessages. It simply routes all inputs to the mainTag.
-   *
-   * <p>This is necessary to provide a uniform interface for different input sources.
-   */
-  public static AlreadyDecoded alreadyDecoded() {
-    return new AlreadyDecoded();
-  }
 
   /*
    * Concrete subclasses.
@@ -59,13 +51,6 @@ public abstract class DecodePubsubMessages
   public static class Json extends DecodePubsubMessages {
     protected PubsubMessage processElement(String element) throws IOException {
       return com.mozilla.telemetry.utils.Json.readPubsubMessage(element);
-    }
-  }
-
-  public static class AlreadyDecoded extends ToPubsubMessageFrom<PubsubMessage> {
-
-    protected PubsubMessage processElement(PubsubMessage element) {
-      return element;
     }
   }
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/MapElementsWithErrors.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/MapElementsWithErrors.java
@@ -107,7 +107,6 @@ public abstract class MapElementsWithErrors<InputT, OutputT>
     return output;
   }
 
-
   /**
    * Define {@link MapElementsWithErrors} for {@code OutputT} of {@link PubsubMessage}.
    */
@@ -125,6 +124,24 @@ public abstract class MapElementsWithErrors<InputT, OutputT>
       PCollectionTuple output = super.expand(input);
       output.get(mainTag).setCoder(PubsubMessageWithAttributesCoder.of());
       return output;
+    }
+
+    /*
+     * Static factory methods for subclasses.
+     */
+
+    public static Identity identity() {
+      return new Identity();
+    }
+
+    /*
+     * Static subclasses.
+     */
+
+    public static class Identity extends ToPubsubMessageFrom<PubsubMessage> {
+      protected PubsubMessage processElement(PubsubMessage element) {
+        return element;
+      }
     }
   }
 }


### PR DESCRIPTION
this makes `new MapElementsWithErrors.ToPubsubMessageFrom<PubsubMessage>(){}` work as an identity transform, and also forces us to use `@Override` on `processElement`, which I think improves readability.

Not 100% sure I want this. I was trying to make a reusable identity transform for `ToPubsubMessageFrom<PubsubMessage>`, and I _kind of_ achieved that.