### PR TITLE
Remove empty lines between getters and setters in options

### DIFF
--- a/ingestion-beam/checkstyle/checks.xml
+++ b/ingestion-beam/checkstyle/checks.xml
@@ -8,7 +8,7 @@
     https://github.com/checkstyle/checkstyle/blob/checkstyle-8.12/src/xdocs/google_style.xml
 
     To see what we've customized, run a diff like the following (bash syntax):
-    diff checkstyle.xml <(curl -s https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-8.12/src/xdocs/google_style.xml)
+    diff checks.xml <(curl -s https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-8.12/src/xdocs/google_style.xml)
  -->
 
 <!--

--- a/ingestion-beam/checkstyle/suppressions.xml
+++ b/ingestion-beam/checkstyle/suppressions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.0//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+
+<suppressions>
+    <suppress checks="EmptyLineSeparator"
+              files="Sink.java"/>
+    <suppress checks="EmptyLineSeparator"
+              files="Decoder.java"/>
+</suppressions>

--- a/ingestion-beam/pom.xml
+++ b/ingestion-beam/pom.xml
@@ -158,7 +158,9 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.0.0</version>
                 <configuration>
-                    <configLocation>checkstyle.xml</configLocation>
+                    <configLocation>checkstyle/checks.xml</configLocation>
+                    <suppressionsLocation>checkstyle/suppressions.xml</suppressionsLocation>
+                    <suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -27,7 +27,6 @@ public class Decoder extends Sink {
     @Description("Path to GeoIP2-City.mmdb")
     @Required
     String getGeoCityDatabase();
-
     void setGeoCityDatabase(String value);
   }
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Sink.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Sink.java
@@ -34,7 +34,6 @@ public class Sink {
     @Description("Type of --input; must be one of [pubsub, file]")
     @Default.Enum("pubsub")
     InputType getInputType();
-
     void setInputType(InputType value);
 
     @Description("File format for --inputType=file; must be one of"
@@ -42,13 +41,11 @@ public class Sink {
         + " text (each line is payload)")
     @Default.Enum("json")
     InputFileFormat getInputFileFormat();
-
     void setInputFileFormat(InputFileFormat value);
 
     @Description("Type of --output; must be one of [pubsub, file, stdout]")
     @Default.Enum("file")
     OutputType getOutputType();
-
     void setOutputType(OutputType value);
 
     @Description("File format for --outputType=file|stdout; must be one of "
@@ -56,13 +53,11 @@ public class Sink {
         + " text (each line is payload)")
     @Default.Enum("json")
     OutputFileFormat getOutputFileFormat();
-
     void setOutputFileFormat(OutputFileFormat value);
 
     @Description("Type of --errorOutput; must be one of [pubsub, file]")
     @Default.Enum("pubsub")
     ErrorOutputType getErrorOutputType();
-
     void setErrorOutputType(ErrorOutputType value);
 
     @Description("Fixed window duration. Defaults to 10m. "
@@ -72,7 +67,6 @@ public class Sink {
         + "Nh (for hours, example: 2h).")
     @Default.String("10m")
     String getWindowDuration();
-
     void setWindowDuration(String value);
 
     /* Note: Dataflow templates accept ValueProvider options at runtime, and
@@ -83,19 +77,16 @@ public class Sink {
     @Description("Input to read from (path to file, PubSub subscription, etc.)")
     @Required
     ValueProvider<String> getInput();
-
     void setInput(ValueProvider<String> value);
 
     @Description("Output to write to (path to file or directory, Pubsub topic, etc.)")
     @Required
     ValueProvider<String> getOutput();
-
     void setOutput(ValueProvider<String> value);
 
     @Description("Error output to write to (path to file or directory, Pubsub topic, etc.)")
     @Required
     ValueProvider<String> getErrorOutput();
-
     void setErrorOutput(ValueProvider<String> value);
   }
 


### PR DESCRIPTION
We add a suppressions.xml file and make our options code in line with Beam examples.