### PR TITLE
Use factory pattern and separate contract-tests in ingestion-edge

### DIFF
--- a/ingestion-edge/Dockerfile
+++ b/ingestion-edge/Dockerfile
@@ -9,4 +9,4 @@ CMD $CMD_PREFIX gunicorn \
   --log-file - \
   --worker-class ${GUNICORN_WORKER_CLASS:-sync} \
   --max-requests ${GUNICORN_MAX_REQUESTS:-0} \
-  ingestion_edge.app:app
+  ingestion_edge.wsgi:app

--- a/ingestion-edge/contract-tests/__init__.py
+++ b/ingestion-edge/contract-tests/__init__.py
@@ -1,0 +1,1 @@
+"""Contract Tests."""

--- a/ingestion-edge/contract-tests/conftest.py
+++ b/ingestion-edge/contract-tests/conftest.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+# importing from private module _pytest for types only
+import _pytest.fixtures
+import _pytest.config.argparsing
+import pytest
+import requests
+
+
+def pytest_addoption(parser: _pytest.config.argparsing.Parser):
+    parser.addoption(
+        "--server",
+        dest="server",
+        default="http://web:8000",
+        help="Server to run tests against",
+    )
+    parser.addoption(
+        "--no-create-pubsub-resources",
+        action="store_false",
+        dest="create_pubsub_resources",
+        default=True,
+        help="Don't create PubSub resources for tests",
+    )
+    parser.addoption(
+        "--no-verify",
+        action="store_false",
+        dest="verify",
+        default=None,
+        help="Don't verify SSL certs",
+    )
+
+
+@pytest.fixture
+def create_pubsub_resources(request: _pytest.fixtures.SubRequest) -> bool:
+    return request.config.getoption("create_pubsub_resources")
+
+
+@pytest.fixture
+def server(request: _pytest.fixtures.SubRequest) -> str:
+    return request.config.getoption("server")
+
+
+@pytest.fixture
+def requests_session(request: _pytest.fixtures.SubRequest) -> requests.Session:
+    session = requests.Session()
+    session.verify = request.config.getoption("verify")
+    return session

--- a/ingestion-edge/contract-tests/test_api.py
+++ b/ingestion-edge/contract-tests/test_api.py
@@ -1,0 +1,109 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+from datetime import datetime
+from dateutil.parser import parse
+from google.api_core.exceptions import AlreadyExists
+from google.cloud.pubsub import PublisherClient, SubscriberClient
+from ingestion_edge.config import Route, ROUTE_TABLE
+import requests
+import pytest
+
+created_topics = set()
+created_subscriptions = set()
+publisher = PublisherClient()
+subscriber = SubscriberClient()
+
+
+def _topic_to_subscription(topic: str):
+    """Get the testing subscription name for a topic"""
+    return topic.replace("/topics/", "/subscriptions/test_")
+
+
+def _create_pubsub_resources(topic: str):
+    """Create pubsub topic and subscription if they don't exist"""
+    if topic not in created_topics:
+        try:
+            publisher.create_topic(topic)
+        except AlreadyExists:
+            pass
+        created_topics.add(topic)
+
+    subscription = _topic_to_subscription(topic)
+    if subscription not in created_subscriptions:
+        try:
+            subscriber.create_subscription(subscription, topic)
+        except AlreadyExists:
+            pass
+        created_subscriptions.add(subscription)
+
+
+def test_dockerflow(requests_session: requests.Session, server: str):
+    r = requests_session.get(server + "/__heartbeat__")
+    r.raise_for_status()
+    assert r.json() == {"checks": {}, "details": {}, "status": "ok"}
+
+    r = requests_session.get(server + "/__lbheartbeat__")
+    r.raise_for_status()
+    assert r.text == ""
+
+    r = requests_session.get(server + "/__version__")
+    r.raise_for_status()
+    assert sorted(r.json().keys()) == ["build", "commit", "source", "version"]
+
+
+@pytest.mark.parametrize("route", ROUTE_TABLE)
+def test_publish(
+    create_pubsub_resources: bool,
+    requests_session: requests.Session,
+    server: str,
+    route: Route,
+):
+    # create pubsub resources
+    if create_pubsub_resources:
+        _create_pubsub_resources(route.topic)
+
+    # test route
+    subscription = _topic_to_subscription(route.topic)
+    for method in route.methods:
+        # fast forward subscriber to HEAD
+        while True:
+            resp = subscriber.pull(
+                subscription,
+                100,
+                timeout=0.1,
+            )
+            if not resp.received_messages:
+                break
+            subscriber.acknowledge(
+                subscription,
+                [message.ack_id for message in resp.received_messages],
+            )
+
+        # submit request to edge
+        uri = route.rule.replace("<path:suffix>", "test")
+        data = "test"
+        req_time = datetime.utcnow()
+        r = requests_session.request(method, server + uri, data=data)
+        r.raise_for_status()
+
+        # validate message delivered to pubsub
+        resp = subscriber.pull(subscription, 1, timeout=0.1)
+        assert len(resp.received_messages) == 1
+        assert resp.received_messages[0].message.data == b"test"
+        attrs = resp.received_messages[0].message.attributes
+        assert "submission_timestamp" in attrs
+        rec_time = parse(attrs.pop("submission_timestamp")[:-1])
+        assert (req_time - rec_time).total_seconds() < 1
+        assert "remote_addr" in attrs
+        attrs.pop("remote_addr")
+        assert attrs == {
+            "args": "",
+            "content_length": str(len(data)),
+            "host": server.split("://", 1)[1],
+            "method": method.upper(),
+            "protocol": server.split("://", 1)[0],
+            "uri": uri,
+            "user_agent": "python-requests/" + requests.__version__,
+        }

--- a/ingestion-edge/docker-compose.override.yml
+++ b/ingestion-edge/docker-compose.override.yml
@@ -13,7 +13,7 @@ services:
     - --host=0.0.0.0
     - --port=8000
     environment:
-    - FLASK_APP=ingestion_edge.app:app
+    - FLASK_APP=ingestion_edge.create_app:create_app
     ports:
     - 8000:8000
     volumes:

--- a/ingestion-edge/docker-compose.yml
+++ b/ingestion-edge/docker-compose.yml
@@ -10,17 +10,40 @@ services:
     image: &image ingestion-edge:build
     environment:
     - &emulator_host PUBSUB_EMULATOR_HOST=pubsub:8085
-    - &route_table ROUTE_TABLE=[["/submit/<path:suffix>","projects/test/topics/test"]]
+    - &route_table >-
+      ROUTE_TABLE=[
+        [
+          "/submit",
+          "projects/test/topics/ingestion"
+        ],
+        [
+          "/submit/<path:suffix>",
+          "projects/test/topics/ingestion",
+          ["PoSt", "pUt"]
+        ],
+        [
+          "/submit/telemetry/<path:suffix>",
+          "projects/test/topics/telemetry"
+        ],
+        [
+          "/submit/sslreports",
+          "projects/test/topics/tls_error_reports",
+          ["post", "put"]
+        ],
+        [
+          "/stub/<path:suffix>",
+          "projects/test/topics/stub_installer",
+          ["GET"]
+        ]
+      ]
   test:
     image: *image
     entrypoint: py.test
     command:
-    - --create-pubsub-resources
     - --flake8
     - --docstyle
     - --mypy
     - --mypy-ignore-missing-imports
-    - --server=http://web:8000
     depends_on:
     - pubsub
     - web

--- a/ingestion-edge/ingestion_edge/config.py
+++ b/ingestion-edge/ingestion_edge/config.py
@@ -8,24 +8,11 @@ Some configuration is hard-coded here, but most is provided via
 environment variables.
 """
 
+from dataclasses import dataclass
 from logging.config import dictConfig
 from os import environ
-from typing import List, Tuple
+from typing import Tuple
 import json
-
-Route = Tuple[str, str, List[str]]
-
-
-def _route(path: str, topic: str, methods: List[str]=["POST", "PUT"]) -> Route:
-    return path, topic, methods
-
-
-ROUTE_TABLE = [
-    _route(*value)
-    for value in json.loads(environ.get("ROUTE_TABLE", "[]"))
-]
-
-QUEUE_PATH = environ.get("QUEUE_PATH", "queue")
 
 dictConfig({
     'version': 1,
@@ -49,3 +36,20 @@ dictConfig({
         },
     }
 })
+
+
+@dataclass
+class Route:
+    """Dataclass for entries in ROUTE_TABLE."""
+
+    rule: str
+    topic: str
+    methods: Tuple = ("POST", "PUT")
+
+
+ROUTE_TABLE = [
+    Route(*route)
+    for route in json.loads(environ.get("ROUTE_TABLE", "[]"))
+]
+
+QUEUE_PATH = environ.get("QUEUE_PATH", "queue")

--- a/ingestion-edge/ingestion_edge/create_app.py
+++ b/ingestion-edge/ingestion_edge/create_app.py
@@ -5,9 +5,15 @@
 """Definition of our Flask application."""
 
 from flask import Flask
+from . import config, publish
 from .dockerflow import dockerflow
-from .publish import publish
 
-app = Flask(__name__)
-app.register_blueprint(publish)
-dockerflow.init_app(app)
+
+def create_app(**kwargs) -> Flask:
+    """Generate Flask application."""
+    app = Flask(__name__)
+    app.config.from_object(config)
+    app.config.update(**kwargs)
+    dockerflow.init_app(app)
+    publish.init_app(app)
+    return app

--- a/ingestion-edge/ingestion_edge/wsgi.py
+++ b/ingestion-edge/ingestion_edge/wsgi.py
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Instantiated Flask app for WSGI."""
+
+from .create_app import create_app
+
+app = create_app()

--- a/ingestion-edge/requirements.txt
+++ b/ingestion-edge/requirements.txt
@@ -1,7 +1,7 @@
 blinker==1.4
 dockerflow==2018.4.0
 Flask==1.0.2
-google-cloud-pubsub==0.37.1
+google-cloud-pubsub==0.38.0
 gunicorn==19.9.0
 persist-queue==0.4.0
 pytest-mypy==0.3.2

--- a/ingestion-edge/tests/conftest.py
+++ b/ingestion-edge/tests/conftest.py
@@ -2,47 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import _pytest.fixtures
-import _pytest.config.argparsing
+from flask.testing import FlaskClient
+from ingestion_edge.create_app import create_app
+from tempfile import TemporaryDirectory
+from typing import Generator
 import pytest
-import requests
-
-
-def pytest_addoption(parser: _pytest.config.argparsing.Parser):
-    parser.addoption(
-        "--server",
-        dest="server",
-        default="http://localhost:8000",
-        help="Server to run tests against",
-    )
-    parser.addoption(
-        "--create-pubsub-resources",
-        action="store_true",
-        dest="create_pubsub_resources",
-        default=False,
-        help="Create PubSub resources for tests",
-    )
-    parser.addoption(
-        "--no-verify",
-        action="store_false",
-        dest="verify",
-        default=None,
-        help="Don't verify SSL certs",
-    )
 
 
 @pytest.fixture
-def create_pubsub_resources(request: _pytest.fixtures.SubRequest) -> bool:
-    return request.config.getoption("create_pubsub_resources")
-
-
-@pytest.fixture
-def server(request: _pytest.fixtures.SubRequest) -> str:
-    return request.config.getoption("server")
-
-
-@pytest.fixture
-def requests_session(request: _pytest.fixtures.SubRequest) -> requests.Session:
-    session = requests.Session()
-    session.verify = request.config.getoption("verify")
-    return session
+def client() -> Generator[FlaskClient, None, None]:
+    with TemporaryDirectory() as tmp:
+        app = create_app(QUEUE_PATH=tmp, TESTING=True)
+        with app.test_client() as client:
+            yield client

--- a/ingestion-edge/tests/test_api.py
+++ b/ingestion-edge/tests/test_api.py
@@ -4,107 +4,59 @@
 
 from datetime import datetime
 from dateutil.parser import parse
-from typing import List
-import requests
+from flask.testing import FlaskClient
+from ingestion_edge.config import Route, ROUTE_TABLE
+from typing import Dict, List, Tuple
+from unittest.mock import patch
+import pytest
 
 
-def test_dockerflow(requests_session: requests.Session, server: str):
-    r = requests_session.get(server + "/__heartbeat__")
-    r.raise_for_status()
-    assert r.json() == {"checks": {}, "details": {}, "status": "ok"}
+def test_dockerflow(client: FlaskClient):
+    r = client.get("/__heartbeat__")
+    assert r.status_code == 200
+    assert r.json == {"checks": {}, "details": {}, "status": "ok"}
 
-    r = requests_session.get(server + "/__lbheartbeat__")
-    r.raise_for_status()
-    assert r.text == ""
+    r = client.get("/__lbheartbeat__")
+    assert r.status_code == 200
+    assert not r.data
 
-    r = requests_session.get(server + "/__version__")
-    r.raise_for_status()
-    assert sorted(r.json().keys()) == ["build", "commit", "source", "version"]
+    r = client.get("/__version__")
+    assert r.status_code == 200
+    assert sorted(r.json.keys()) == ["build", "commit", "source", "version"]
 
 
-def test_publish(
-    create_pubsub_resources: bool,
-    requests_session: requests.Session,
-    server: str,
-):
-    from ingestion_edge.conf import ROUTE_TABLE
-    from ingestion_edge.publish import client as publisher
-    from google.cloud.pubsub import SubscriberClient
+@pytest.mark.parametrize('route', ROUTE_TABLE)
+def test_publish(client: FlaskClient, route: Route):
+    messages: List[Tuple[str, bytes, Dict[str, str]]] = []
 
-    subscriber = SubscriberClient()
+    def _publish(*args):
+        messages.append(args)
 
-    def topic_to_subscription(topic: str):
-        return topic.replace("/topics/", "/subscriptions/test_")
-
-    # create topics and subscriptions if they don't yet exist
-    if create_pubsub_resources:
-        topics = set(map(lambda route: route[1], ROUTE_TABLE))
-
-        # get list of topics that already exist
-        projects = {route[1].split("/topics/", 1)[0] for route in ROUTE_TABLE}
-        all_topics: List[str] = []
-        for project in projects:
-            all_topics += [t.name for t in publisher.list_topics(project)]
-        existing_topics = set(all_topics).intersection(topics)
-
-        # create new subscriptions to existing topics if needed
-        for topic in existing_topics:
-            subscription = topic_to_subscription(topic)
-            if subscription not in publisher.list_topic_subscriptions(topic):
-                subscriber.create_subscription(subscription, topic)
-
-        # create new topics and subscriptions if needed
-        for topic in topics - existing_topics:
-            publisher.create_topic(topic)
-            subscription = topic_to_subscription(topic)
-            subscriber.create_subscription(subscription, topic)
-
-    # test route table
-    for path, topic, methods in ROUTE_TABLE:
-        subscription = topic_to_subscription(topic)
-        for method in methods:
-            # fast forward subscriber to HEAD
-            while True:
-                resp = subscriber.pull(
-                    subscription,
-                    100,
-                    timeout=0.1,
-                )
-                if not resp.received_messages:
-                    break
-                subscriber.acknowledge(
-                    subscription,
-                    [message.ack_id for message in resp.received_messages],
-                )
-
-            # submit request to edge
-            uri = path.replace("<path:suffix>", "test")
-            body = "test"
+    with patch('ingestion_edge.publish._publish', new=_publish):
+        # test route
+        for method in route.methods:
+            # submit request
+            uri = route.rule.replace("<path:suffix>", "test")
+            req_data = "test"
             req_time = datetime.utcnow()
-            r = getattr(requests_session, method.lower())(server + uri, body)
-            r.raise_for_status()
+            r = getattr(client, method.lower())(uri, data=req_data)
+            assert r.status_code == 200
 
-            # validate message delivered to pubsub
-            resp = subscriber.pull(subscription, 1, timeout=0.1)
-            assert len(resp.received_messages) == 1
-            assert resp.received_messages[0].message.data == b"test"
-            attributes = resp.received_messages[0].message.attributes
-            expect = {
+            # validate message
+            assert len(messages) == 1
+            topic, rec_data, attrs = messages.pop()
+            assert topic == route.topic
+            assert rec_data == b"test"
+            assert "submission_timestamp" in attrs
+            rec_time = parse(attrs.pop("submission_timestamp")[:-1])
+            assert (req_time - rec_time).total_seconds() < 1
+            assert attrs == {
                 "args": "",
-                "content_length": str(len(body)),
-                "host": server.split("://", 1)[1],
-                "method": method,
-                "protocol": server.split("://", 1)[0],
-                "remote_addr": lambda x: True,
-                "submission_timestamp": lambda x: (
-                    req_time - parse(x[:-1])
-                ).total_seconds() < 1,
+                "content_length": str(len(req_data)),
+                "host": "localhost",
+                "method": method.upper(),
+                "protocol": "http",
+                "remote_addr": "127.0.0.1",
                 "uri": uri,
-                "user_agent": "python-requests/" + requests.__version__,
+                "user_agent": client.environ_base['HTTP_USER_AGENT'],
             }
-            for key, validate in expect.items():
-                assert key in attributes
-                if type(validate) is str:
-                    assert attributes[key] == validate
-                else:
-                    assert validate(attributes[key])


### PR DESCRIPTION
I went to make unit tests and realized that our flask app should probably use flask's app.config and the flask factory pattern to make it more configurable during testing.

r? on the idea because it's a non-trivial change