### PR TITLE
Support GCS paths for geoCityDatabase

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/File.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/File.java
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.io.fs.ResourceId;
+
+public class File {
+
+  /**
+   * Fetch a single local or remote file using Beam's {@link FileSystems} machinery.
+   *
+   * @param spec a path on the local file system or in GCS (gs://bucket/path)
+   * @return the file contents as {@link InputStream}
+   */
+  public static InputStream inputStream(String spec) throws IOException {
+    MatchResult match = FileSystems.match(spec);
+    if (match.metadata().isEmpty()) {
+      throw new IllegalArgumentException("No file found matching " + spec);
+    }
+    if (match.metadata().size() > 1) {
+      throw new IllegalArgumentException(
+          "Multiple files found matching " + spec + " when only one was expected");
+
+    }
+
+    ResourceId resourceId = match.metadata().get(0).resourceId();
+    ReadableByteChannel channel = FileSystems.open(resourceId);
+    return Channels.newInputStream(channel);
+  }
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/util/FileTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/util/FileTest.java
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.util;
+
+import static org.junit.Assert.assertThat;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public class FileTest {
+
+  @Test
+  public void inputStreamLocalTest() throws Exception {
+    InputStream inputStream = File.inputStream("README.md");
+    int size = 0;
+    while (inputStream.read() != -1) {
+      size++;
+    }
+    assertThat(size, Matchers.greaterThan(100)); // README.md is at least 100 bytes.
+  }
+
+  @Test(expected = FileNotFoundException.class)
+  public void inputStreamThrowsOnMissingFile() throws Exception {
+    File.inputStream("nonexistent.txt");
+  }
+
+  @Test(expected = FileNotFoundException.class)
+  public void inputStreamThrowsOnDirectory() throws Exception {
+    File.inputStream("bin");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void inputStreamThrowsOnMultipleMatches() throws Exception {
+    File.inputStream("bin/*");
+  }
+
+}


### PR DESCRIPTION
We also add a util.File class to contain the logic for digging into Beam's facilities for resolving paths in different storage backends.

This does not directly test accessing a path in GCS, but it is using Beam's facilities for accessing storage, so I'm not convinced that a test hitting GCS would be constructive here. If Beam's FileIO is able to contact GCS using the FileSystems machinery, then this code will be too.

Fixes #138 