### PR TITLE
Fix METADATA_HEADERS documentation

### DIFF
--- a/ingestion-edge/README.md
+++ b/ingestion-edge/README.md
@@ -58,8 +58,8 @@ environment variables:
 - `MINIMUM_DISK_FREE_BYTES`: an integer indicating the threshold of free bytes
   on the filesystem where `QUEUE_PATH` is mounted below which `/__heartbeat__`
   will fail, defaults to `0` which disables the check
-- `METADATA_HEADERS`: a comma separated list of headers to preserve as PubSub
-  message attributes, defaults to `["Content-Length", "Date", "DNT", "User-Agent",
+- `METADATA_HEADERS`: a JSON list of headers to preserve as PubSub message
+  attributes, defaults to `["Content-Length", "Date", "DNT", "User-Agent",
   "X-Forwarded-For", "X-Pingsender-Version", "X-Pipeline-Proxy"]`
 
 ## Testing


### PR DESCRIPTION
got ahead of myself and missed a spot that still said comma separated