### PR TITLE
Bind RedisServer to localhost in tests

### DIFF
--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/DecoderTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/DecoderTest.java
@@ -255,7 +255,8 @@ public class DecoderTest {
   public void deduplicate() throws IOException {
     int redisPort = new redis.embedded.ports.EphemeralPortProvider().next();
     // create testing redis server
-    final RedisServer redis = new RedisServer(redisPort);
+    final RedisServer redis = RedisServer.builder().port(redisPort).setting("bind 127.0.0.1")
+        .build();
     final URI redisUri = URI.create("redis://localhost:" + redisPort);
     redis.start();
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DeduplicateTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DeduplicateTest.java
@@ -34,7 +34,8 @@ public class DeduplicateTest {
   public void testOutput() throws IOException {
     int redisPort = new redis.embedded.ports.EphemeralPortProvider().next();
     // create testing redis server
-    final RedisServer redis = new RedisServer(redisPort);
+    final RedisServer redis = RedisServer.builder().port(redisPort).setting("bind 127.0.0.1")
+        .build();
     final URI redisUri = URI.create("redis://localhost:" + redisPort);
     redis.start();
 


### PR DESCRIPTION
On my machine, each run of tests would cause a MacOS popup every time
an embedded RedisServer is initialized, warning about a process establishing
an incoming network connection. By binding to localhost, the OS doesn't get
worried.

Solution documented in
https://github.com/kstyrc/embedded-redis/issues/45#issuecomment-116592376