### PR TITLE
Add PubsubIntegrationTest to ingestion-beam

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,9 +104,11 @@ jobs:
           - ~/.m2
         key: maven-repo-v1-{{ .Branch }}-{{ checksum "ingestion-beam/pom.xml" }}
 
-  ingestion-beam-bigquery:
+  ingestion-beam-bigquery: &beam_integration_test
     docker:
     - image: maven
+      environment:
+      - TARGET_SYSTEM: BigQuery
     steps:
     - run:
         name: Early return if this build is from a forked PR
@@ -130,11 +132,18 @@ jobs:
         command: |
           export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
           echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-          cd ingestion-beam && mvn clean compile test-compile surefire:test -Dtest=BigQueryIntegrationTest
+          cd ingestion-beam && mvn clean compile test-compile surefire:test -Dtest=${TARGET_SYSTEM}IntegrationTest
     - run:
         name: Report code coverage
         command: bash <(curl -s https://codecov.io/bash) -F ingestion_beam
     # We don't save_cache here; we let the ingestion-beam job cover that.
+
+  ingestion-beam-pubsub:
+    <<: *beam_integration_test
+    docker:
+    - image: maven
+      environment:
+      - TARGET_SYSTEM: Pubsub
 
 workflows:
   version: 2
@@ -146,3 +155,4 @@ workflows:
     - ingestion-edge
     - ingestion-beam
     - ingestion-beam-bigquery
+    - ingestion-beam-pubsub

--- a/ingestion-beam/pom.xml
+++ b/ingestion-beam/pom.xml
@@ -17,7 +17,7 @@
         <!-- Keep these dependency versions in sync with those pulled in by beam;
              check https://mvnrepository.com/artifact/org.apache.beam -->
         <beam.version>2.8.0</beam.version>
-        <google-cloud.version>1.32.0</google-cloud.version>
+        <google-cloud.version>1.49.0</google-cloud.version>
         <jackson.version>2.9.5</jackson.version>
     </properties>
 
@@ -53,6 +53,13 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
             <version>${google-cloud.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-pubsub</artifactId>
+            <version>${google-cloud.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.maxmind.geoip2</groupId>

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/ErrorOutputType.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/ErrorOutputType.java
@@ -38,7 +38,7 @@ public enum ErrorOutputType {
     public PTransform<PCollection<PubsubMessage>, ? extends POutput> write(
         SinkOptions.Parsed options) {
       return OutputType.writeFile(options.getErrorOutput(), FORMAT,
-          options.getParsedWindowDuration());
+          options.getParsedWindowDuration(), options.getErrorOutputNumShards());
     }
   },
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
@@ -42,7 +42,7 @@ public interface SinkOptions extends PipelineOptions {
 
   void setOutputType(OutputType value);
 
-  @Description("File format for --outputType=file|stdout; must be one of "
+  @Description("File format for --outputType=file|stdout; must be one of"
       + " json (each line contains payload[String] and attributeMap[String,String]) or"
       + " text (each line is payload)")
   @Default.Enum("json")
@@ -50,11 +50,27 @@ public interface SinkOptions extends PipelineOptions {
 
   void setOutputFileFormat(OutputFileFormat value);
 
+  @Description("Number of output shards for --outputType=file; defaults to 0 (automatic)"
+      + " for batch running, but must be set to an explicit value for stream processing"
+      + " (--inputType=pubsub)")
+  @Default.Integer(0)
+  Integer getOutputNumShards();
+
+  void setOutputNumShards(Integer value);
+
   @Description("Type of --errorOutput; must be one of [pubsub, file]")
   @Default.Enum("pubsub")
   ErrorOutputType getErrorOutputType();
 
   void setErrorOutputType(ErrorOutputType value);
+
+  @Description("Number of output shards for --errorOutputType=file; defaults to 0 (automatic)"
+      + " for batch running, but must be set to an explicit value for stream processing"
+      + " (--inputType=pubsub)")
+  @Default.Integer(0)
+  Integer getErrorOutputNumShards();
+
+  void setErrorOutputNumShards(Integer value);
 
   @Description("Fixed window duration. Defaults to 10m. Allowed formats are: "
       + "Ns (for seconds, example: 5s), Nm (for minutes, example: 12m), "

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/BigQueryIntegrationTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/BigQueryIntegrationTest.java
@@ -39,6 +39,8 @@ import org.junit.rules.TemporaryFolder;
  * {@code -Dtest=BigQueryIntegrationTest}. Credentials can be provided by initializing a
  * configuration in the gcloud command-line tool or by providing a path to service account
  * credentials in environment variable {@code GOOGLE_APPLICATION_CREDENTIALS}.
+ *
+ * <p>The provided credentials are assumed to have "BigQuery Admin" privileges.
  */
 public class BigQueryIntegrationTest {
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/PubsubIntegrationTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/PubsubIntegrationTest.java
@@ -1,0 +1,193 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry;
+
+import static com.mozilla.telemetry.matchers.Lines.matchesInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.PushConfig;
+import com.mozilla.telemetry.matchers.Lines;
+import com.mozilla.telemetry.options.InputFileFormat;
+import com.mozilla.telemetry.options.InputType;
+import com.mozilla.telemetry.options.OutputFileFormat;
+import com.mozilla.telemetry.options.OutputType;
+import com.mozilla.telemetry.options.SinkOptions;
+import com.mozilla.telemetry.transforms.MapElementsWithErrors.ToPubsubMessageFrom;
+import com.mozilla.telemetry.util.Json;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.beam.runners.direct.DirectOptions;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Duration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test suite that accesses Pub/Sub in GCP.
+ *
+ * <p>Because this requires credentials, this suite is excluded by default in the surefire
+ * configuration, but can be enabled by passing command-line option
+ * {@code -Dtest=PubsubIntegrationTest}. Credentials can be provided by initializing a
+ * configuration in the gcloud command-line tool or by providing a path to service account
+ * credentials in environment variable {@code GOOGLE_APPLICATION_CREDENTIALS}.
+ *
+ * <p>The provided credentials are assumed to have "Pub/Sub Admin" privileges.
+ *
+ * <p>We contact real Pub/Sub here rather than using the emulator because Google's Java SDK
+ * lacks built-in support for the emulator. Using the emulator is possible, but requires
+ * significant configuration code, as seen in
+ * <a href="https://github.com/googleapis/google-cloud-java/blob/d971c35c944a5a9e200ac4c94ca926024c71677c/TESTING.md#testing-code-that-uses-pubsub">TESTING.md</a>.
+ */
+public class PubsubIntegrationTest {
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
+  private String projectId;
+  private String topicId;
+  private String subscriptionId;
+  private ProjectTopicName topicName;
+  private ProjectSubscriptionName subscriptionName;
+
+  /**
+   * Create a Pub/Sub topic and subscription.
+   */
+  @Before
+  public void initializePubsubResources() throws Exception {
+    projectId = ServiceOptions.getDefaultProjectId();
+    topicId = "test-topic-" + UUID.randomUUID().toString();
+    subscriptionId = "test-subscription-" + UUID.randomUUID().toString();
+    topicName = ProjectTopicName.of(projectId, topicId);
+    subscriptionName = ProjectSubscriptionName.of(projectId, subscriptionId);
+
+    TopicAdminClient.create().createTopic(topicName);
+    SubscriptionAdminClient.create().createSubscription(subscriptionName, topicName,
+        PushConfig.getDefaultInstance(), 0);
+  }
+
+  /** Clean up all the Pub/Sub resources we created. */
+  @After
+  public void deletePubsubResources() throws Exception {
+    SubscriptionAdminClient.create().deleteSubscription(subscriptionName);
+    TopicAdminClient.create().deleteTopic(topicName);
+  }
+
+  @Test(timeout = 30000)
+  public void canReadPubsubInput() throws Exception {
+    List<String> inputLines = Lines.resources("testdata/basic-messages-nonempty.ndjson");
+    publishLines(inputLines);
+
+    pipeline.getOptions().as(DirectOptions.class).setBlockOnRun(false);
+
+    SinkOptions.Parsed sinkOptions = pipeline.getOptions().as(SinkOptions.Parsed.class);
+    sinkOptions.setInput(StaticValueProvider.of(subscriptionName.toString()));
+
+    PCollection<String> output = pipeline.apply(InputType.pubsub.read(sinkOptions))
+        .get(ToPubsubMessageFrom.mainTag).apply("encodeJson", OutputFileFormat.json.encode());
+
+    PAssert.that(output).containsInAnyOrder(inputLines);
+
+    // This runs in the background and returns immediately due to setBlockOnRun above.
+    PipelineResult result = pipeline.run();
+
+    // The wait here is determined empirically; it's not entirely clear why it takes this long.
+    System.err.println("Waiting 15 seconds to make sure we've processed all messages...");
+    result.waitUntilFinish(Duration.millis(15000));
+    System.err.println("Done waiting; now cancelling the pipeline so the test can finish.");
+    result.cancel();
+  }
+
+  @Test(timeout = 30000)
+  public void canSendPubsubOutput() throws Exception {
+    List<String> inputLines = Lines.resources("testdata/basic-messages-nonempty.ndjson");
+
+    pipeline.getOptions().as(DirectOptions.class).setBlockOnRun(false);
+
+    SinkOptions.Parsed sinkOptions = pipeline.getOptions().as(SinkOptions.Parsed.class);
+    sinkOptions.setOutput(StaticValueProvider.of(topicName.toString()));
+
+    pipeline.apply(Create.of(inputLines)).apply(InputFileFormat.json.decode())
+        .get(ToPubsubMessageFrom.mainTag).apply(OutputType.pubsub.write(sinkOptions));
+
+    PipelineResult result = pipeline.run();
+
+    System.err.println("Waiting for subscriber to receive messages published in the pipeline...");
+    List<String> received = receiveLines(4);
+    assertThat(received, matchesInAnyOrder(inputLines));
+    result.cancel();
+  }
+
+  private void publishLines(List<String> lines) throws Exception {
+    Publisher publisher = Publisher.newBuilder(topicName).build();
+    lines.forEach(line -> {
+      try {
+        org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage msg = Json.readPubsubMessage(line);
+        Map<String, String> attributes = Optional.ofNullable(msg.getAttributeMap())
+            .orElse(ImmutableMap.of());
+        com.google.pubsub.v1.PubsubMessage outgoing = com.google.pubsub.v1.PubsubMessage
+            .newBuilder().putAllAttributes(attributes)
+            .setData(ByteString.copyFrom(msg.getPayload())).build();
+        publisher.publish(outgoing);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    });
+    publisher.shutdown();
+  }
+
+  private List<String> receiveLines(int expectedMessageCount) throws Exception {
+    List<String> received = new CopyOnWriteArrayList<>();
+    ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(projectId,
+        subscriptionId);
+
+    MessageReceiver receiver = new MessageReceiver() {
+
+      @Override
+      public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+        try {
+          String encoded = Json.asString(new org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage(
+              message.getData().toByteArray(), message.getAttributesMap()));
+          received.add(encoded);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+        consumer.ack();
+      }
+    };
+    Subscriber subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+    subscriber.startAsync();
+    while (received.size() < expectedMessageCount) {
+      Thread.sleep(100);
+    }
+    subscriber.stopAsync();
+
+    return received;
+  }
+
+}

--- a/ingestion-beam/src/test/resources/testdata/basic-messages-nonempty.ndjson
+++ b/ingestion-beam/src/test/resources/testdata/basic-messages-nonempty.ndjson
@@ -1,0 +1,4 @@
+{"attributeMap":{"host":"test"},"payload":"dGVzdA=="}
+{"attributeMap":{"host":"testA"},"payload":"dGVzdA=="}
+{"attributeMap":{"host":"testB"},"payload":""}
+{"attributeMap":{"host":"testC"},"payload":"dGVzdA=="}


### PR DESCRIPTION
Adds one test case each for exercising InputType.pubsub and OutputType.pubsub

Also introduces `numShards` options, since sharding specification is required when an unbounded source is involved.

Closes #207