### PR TITLE
Add exception_class attribute to failure messages

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/FailureMessage.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/FailureMessage.java
@@ -44,6 +44,7 @@ public class FailureMessage {
 
   private static Map<String, String> errorAttributes(Object caller, Throwable e) {
     return ImmutableMap.of("error_type", caller.toString(), "error_message", e.toString(),
-        "stack_trace", Arrays.toString(e.getStackTrace()));
+        "exception_class", e.getClass().getName(), "stack_trace",
+        Arrays.toString(e.getStackTrace()));
   }
 }


### PR DESCRIPTION
This could be very helpful for filtering through error data if we discover particular cases we want to recover from.