### PR TITLE
Add run methods to Sink and Decoder returning PipelineResult

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -16,6 +16,7 @@ import com.mozilla.telemetry.transforms.ParseSubmissionTimestamp;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Flatten;
@@ -31,11 +32,27 @@ public class Decoder extends Sink {
    * @param args command line arguments
    */
   public static void main(String[] args) {
-    // Register options class so that `--help=DecoderOptions` works.
-    PipelineOptionsFactory.register(DecoderOptions.class);
+    run(args);
+  }
 
+  /**
+   * Execute an Apache Beam pipeline and return the {@code PipelineResult}.
+   *
+   * @param args command line arguments
+   */
+  public static PipelineResult run(String[] args) {
     final DecoderOptions.Parsed options = DecoderOptions.parseDecoderOptions(
         PipelineOptionsFactory.fromArgs(args).withValidation().as(DecoderOptions.class));
+    // register options class so that `--help=DecoderOptions` works
+    PipelineOptionsFactory.register(DecoderOptions.class);
+
+    return run(options);
+  }
+
+  /**
+   * Execute an Apache Beam pipeline and return the {@code PipelineResult}.
+   */
+  public static PipelineResult run(DecoderOptions.Parsed options) {
     final Pipeline pipeline = Pipeline.create(options);
     final List<PCollection<PubsubMessage>> errorCollections = new ArrayList<>();
 
@@ -69,6 +86,6 @@ public class Decoder extends Sink {
     PCollectionList.of(errorCollections).apply(Flatten.pCollections()).apply("write error output",
         options.getErrorOutputType().write(options));
 
-    pipeline.run();
+    return pipeline.run();
   }
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Sink.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Sink.java
@@ -9,6 +9,7 @@ import com.mozilla.telemetry.transforms.ParseSubmissionTimestamp;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Flatten;
@@ -23,11 +24,28 @@ public class Sink {
    * @param args command line arguments
    */
   public static void main(String[] args) {
+    run(args);
+  }
+
+  /**
+   * Execute an Apache Beam pipeline and return the {@code PipelineResult}.
+   *
+   * @param args command line arguments
+   */
+  public static PipelineResult run(String[] args) {
     // register options class so that `--help=SinkOptions` works
     PipelineOptionsFactory.register(SinkOptions.class);
 
     final SinkOptions.Parsed options = SinkOptions.parseSinkOptions(
         PipelineOptionsFactory.fromArgs(args).withValidation().as(SinkOptions.class));
+
+    return run(options);
+  }
+
+  /**
+   * Execute an Apache Beam pipeline and return the {@code PipelineResult}.
+   */
+  public static PipelineResult run(SinkOptions.Parsed options) {
     final Pipeline pipeline = Pipeline.create(options);
     final List<PCollection<PubsubMessage>> errorCollections = new ArrayList<>();
 
@@ -42,7 +60,7 @@ public class Sink {
     PCollectionList.of(errorCollections).apply(Flatten.pCollections()).apply("write error output",
         options.getErrorOutputType().write(options));
 
-    pipeline.run();
+    return pipeline.run();
   }
 
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/BigQueryIntegrationTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/BigQueryIntegrationTest.java
@@ -26,6 +26,7 @@ import com.mozilla.telemetry.Sink;
 import com.mozilla.telemetry.matchers.Lines;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.beam.sdk.PipelineResult;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -88,9 +89,11 @@ public class BigQueryIntegrationTest {
     String input = Resources.getResource("testdata/json-payload.ndjson").getPath();
     String output = String.format("%s:%s", projectId, tableSpec);
 
-    Sink.main(new String[] { "--inputFileFormat=text", "--inputType=file", "--input=" + input,
-        "--outputFileFormat=text", "--outputType=bigquery", "--output=" + output,
-        "--errorOutputType=stderr" });
+    PipelineResult result = Sink.run(new String[] { "--inputFileFormat=text", "--inputType=file",
+        "--input=" + input, "--outputFileFormat=text", "--outputType=bigquery",
+        "--output=" + output, "--errorOutputType=stderr" });
+
+    result.waitUntilFinish();
 
     assertThat(stringValuesQuery("SELECT clientId FROM " + tableSpec),
         matchesInAnyOrder(ImmutableList.of("abc123", "abc123", "def456")));
@@ -114,9 +117,11 @@ public class BigQueryIntegrationTest {
     String output = String.format("%s:%s", projectId, tableSpec);
     String errorOutput = outputPath + "/error/out";
 
-    Sink.main(new String[] { "--inputFileFormat=text", "--inputType=file", "--input=" + input,
-        "--outputFileFormat=text", "--outputType=bigquery", "--output=" + output,
-        "--errorOutputType=file", "--errorOutput=" + errorOutput });
+    PipelineResult result = Sink.run(new String[] { "--inputFileFormat=text", "--inputType=file",
+        "--input=" + input, "--outputFileFormat=text", "--outputType=bigquery",
+        "--output=" + output, "--errorOutputType=file", "--errorOutput=" + errorOutput });
+
+    result.waitUntilFinish();
 
     assertTrue(stringValuesQuery("SELECT clientId FROM " + tableSpec).isEmpty());
 


### PR DESCRIPTION
Also updates BigQueryIntegrationTest to call `waitUntilFinish` on the result, which should hopefully clear up the flakiness described in #263