### PR TITLE
Move decompress step before ParsePayload

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -45,9 +45,9 @@ public class Decoder extends Sink {
         .addErrorCollectionTo(errorCollections).output() //
         .apply("parseUri", new ParseUri()) //
         .addErrorCollectionTo(errorCollections).output() //
+        .apply("decompress", new GzipDecompress()) //
         .apply("parsePayload", new ParsePayload()) //
         .addErrorCollectionTo(errorCollections).output() //
-        .apply("decompress", new GzipDecompress()) //
         .apply("geoCityLookup",
             new GeoCityLookup(options.getGeoCityDatabase(), options.getGeoCityFilter()))
         .apply("parseUserAgent", new ParseUserAgent()) //

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/DecoderMainTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/DecoderMainTest.java
@@ -94,4 +94,23 @@ public class DecoderMainTest {
         matchesInAnyOrder(expectedErrorOutputLines));
   }
 
+  @Test
+  public void testGzippedPayload() throws Exception {
+    String outputPath = outputFolder.getRoot().getAbsolutePath();
+    String resourceDir = "src/test/resources/testdata/decoder-integration";
+    String input = resourceDir + "/gzipped.ndjson";
+    String output = outputPath + "/out/out";
+    String errorOutput = outputPath + "/error/error";
+
+    Decoder.main(new String[] { "--inputFileFormat=json", "--inputType=file", "--input=" + input,
+        "--outputFileFormat=json", "--outputType=file", "--output=" + output,
+        "--errorOutputType=file", "--errorOutput=" + errorOutput, "--includeStackTrace=false",
+        "--geoCityDatabase=GeoLite2-City.mmdb", "--seenMessagesSource=none",
+        "--redisUri=" + redis.uri });
+
+    List<String> outputLines = Lines.files(output + "*.ndjson");
+    List<String> expectedOutputLines = Lines.files(resourceDir + "/output.ndjson");
+    assertThat("Main output differed from expectation", outputLines,
+        matchesInAnyOrder(expectedOutputLines));
+  }
 }

--- a/ingestion-beam/src/test/resources/testdata/decoder-integration/gzipped.ndjson
+++ b/ingestion-beam/src/test/resources/testdata/decoder-integration/gzipped.ndjson
@@ -1,0 +1,2 @@
+{"attributeMap":{"host":"test1","uri":"/submit/test/test/1/2c3a0767-d84a-4d02-8a92-fa54a3376048"},"payload":"H4sIAKnBGlwAA6uuBQBDv6ajAgAAAA=="}
+{"attributeMap":{"host":"test2","remote_addr":"8.8.8.8","uri":"/submit/test/test/1/2c3a0767-d84a-4d02-8a92-fa54a3376049"},"payload":"H4sIAKnBGlwAA6uuBQBDv6ajAgAAAA=="}


### PR DESCRIPTION
This was broken; the ParsePayload transform was getting gzipped content that couldn't be parsed as a JSON object.

Added a test to exercise gzipped payloads in the Decoder.