### PR TITLE
Use TestPipeline.newProvider() in tests

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/Deduplicate.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/Deduplicate.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.options.ValueProvider;
-import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.transforms.PTransform;
 import redis.clients.jedis.Jedis;
 
@@ -62,16 +61,8 @@ public abstract class Deduplicate extends MapElementsWithErrors.ToPubsubMessageF
     return new RemoveDuplicates(uri);
   }
 
-  public static Deduplicate removeDuplicates(URI uri) {
-    return new RemoveDuplicates(StaticValueProvider.of(uri));
-  }
-
   public static Deduplicate markAsSeen(ValueProvider<URI> uri, ValueProvider<Integer> ttlSeconds) {
     return new MarkAsSeen(uri, ttlSeconds);
-  }
-
-  public static Deduplicate markAsSeen(URI uri, Integer ttlSeconds) {
-    return markAsSeen(StaticValueProvider.of(uri), StaticValueProvider.of(ttlSeconds));
   }
 
   /*

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/PubsubIntegrationTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/PubsubIntegrationTest.java
@@ -36,7 +36,6 @@ import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.beam.runners.direct.DirectOptions;
 import org.apache.beam.sdk.PipelineResult;
-import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
@@ -105,7 +104,7 @@ public class PubsubIntegrationTest {
     pipeline.getOptions().as(DirectOptions.class).setBlockOnRun(false);
 
     SinkOptions.Parsed sinkOptions = pipeline.getOptions().as(SinkOptions.Parsed.class);
-    sinkOptions.setInput(StaticValueProvider.of(subscriptionName.toString()));
+    sinkOptions.setInput(pipeline.newProvider(subscriptionName.toString()));
 
     PCollection<String> output = pipeline.apply(InputType.pubsub.read(sinkOptions)).output()
         .apply("encodeJson", OutputFileFormat.json.encode());
@@ -129,7 +128,7 @@ public class PubsubIntegrationTest {
     pipeline.getOptions().as(DirectOptions.class).setBlockOnRun(false);
 
     SinkOptions.Parsed sinkOptions = pipeline.getOptions().as(SinkOptions.Parsed.class);
-    sinkOptions.setOutput(StaticValueProvider.of(topicName.toString()));
+    sinkOptions.setOutput(pipeline.newProvider(topicName.toString()));
 
     pipeline.apply(Create.of(inputLines)).apply(InputFileFormat.json.decode()).output()
         .apply(OutputType.pubsub.write(sinkOptions));


### PR DESCRIPTION
We've seen some cases in the past where a change deployed to Dataflow
leads to "Value only available at runtime" errors because tests are using
a StaticValueProvider that's available at compile time whereas real
execution doesn't have the value available.

TestPipeline.newProvider() exists for this purpose. You pass in a literal
value, but it won't be available for access until runtime, better simulating
the real execution context.

This change removes usage of StaticValueProvider for all tests where a
TestPipeline is available.