### PR TITLE
Report HTTP version as protocol

### DIFF
--- a/ingestion-edge/ingestion_edge/publish.py
+++ b/ingestion-edge/ingestion_edge/publish.py
@@ -92,7 +92,7 @@ async def submit(
         for key, value in dict(
             submission_timestamp=datetime.utcnow().isoformat() + "Z",
             uri=request.path,
-            protocol=request.scheme,
+            protocol="HTTP/" + request.version,
             method=request.method,
             args=request.query_string,
             remote_addr=request.ip,

--- a/ingestion-edge/tests/integration/publish/helpers.py
+++ b/ingestion-edge/tests/integration/publish/helpers.py
@@ -45,7 +45,7 @@ class IntegrationTest:
     args: str = ""
     data: bytes = b""
     headers: Dict[str, Optional[bytes]] = field(default_factory=dict)
-    protocol: str = "http"
+    protocol: str = "HTTP/1.1"
     uri_suffix: str = "."  # may 404 on ""
 
     @property

--- a/ingestion-edge/tests/unit/publish/test_submit.py
+++ b/ingestion-edge/tests/unit/publish/test_submit.py
@@ -25,7 +25,7 @@ class MockRequest:
     method: str = "method"
     path: str = "path"
     query_string: str = "query_string"
-    scheme: str = "scheme"
+    version: str = "version"
 
 
 class ListQueue(list):
@@ -65,7 +65,7 @@ def validate(start_time: datetime, response: HTTPResponse, q: ListQueue):
         "header": "header",
         "host": "host",
         "method": "method",
-        "protocol": "scheme",
+        "protocol": "HTTP/version",
         "remote_addr": "ip",
         "uri": "path",
     }


### PR DESCRIPTION
I noticed that this is what the current edge reports, and also `request.scheme` could only be `http` or `websocket` which isn't useful because we only use http.