### PR TITLE
Check for null bytes in CompressPayload

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/CompressPayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/CompressPayload.java
@@ -45,6 +45,9 @@ public class CompressPayload
 
   @VisibleForTesting
   static PubsubMessage compress(PubsubMessage message, Compression compression) {
+    if (message == null || message.getPayload() == null) {
+      return message;
+    }
     byte[] bytes = message.getPayload();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     // We use a try-with-resources statement to ensure everything gets closed appropriately.

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/CompressPayloadTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/CompressPayloadTest.java
@@ -4,6 +4,7 @@
 
 package com.mozilla.telemetry.transforms;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
@@ -22,5 +23,11 @@ public class CompressPayloadTest {
     PubsubMessage message = new PubsubMessage(text.getBytes(), new HashMap<>());
     byte[] compressedBytes = CompressPayload.compress(message, Compression.GZIP).getPayload();
     assertThat(ArrayUtils.toObject(compressedBytes), Matchers.arrayWithSize(68));
+  }
+
+  @Test
+  public void testCompressNullBytes() {
+    PubsubMessage message = new PubsubMessage(null, new HashMap<>());
+    assertNull(CompressPayload.compress(message, Compression.GZIP).getPayload());
   }
 }


### PR DESCRIPTION
@whd found NullPointerExceptions due to constructing a ByteArrayInputStream with a null argument.

I'm guessing this is happening in pubsub error output, but haven't yet tracked down what component is generating null payloads.