### PR TITLE
 Don't catch Throwable in MapElementsWithErrors

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/OutputType.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/OutputType.java
@@ -222,8 +222,8 @@ public enum OutputType {
 
     @Override
     public ResultWithErrors<? extends POutput> expand(PCollection<PubsubMessage> input) {
-      return ResultWithErrors.of(input.apply(inner),
-          input.getPipeline().apply(Create.empty(PubsubMessageWithAttributesCoder.of())));
+      return ResultWithErrors.of(input.apply(inner), input.getPipeline()
+          .apply("Empty error collection", Create.empty(PubsubMessageWithAttributesCoder.of())));
     }
   }
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/MapElementsWithErrors.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/MapElementsWithErrors.java
@@ -39,9 +39,9 @@ public abstract class MapElementsWithErrors<InputT, OutputT>
    *
    * @param element that should be processed.
    * @return an instance of {@code OutputT} that goes into {@code mainTag}.
-   * @throws Throwable if the element should go into the {@code errorTag}.
+   * @throws Exception if the element should go into the {@code errorTag}.
    */
-  protected abstract OutputT processElement(InputT element) throws Throwable;
+  protected abstract OutputT processElement(InputT element) throws Exception;
 
   /**
    * Method that returns one error PubsubMessage from an exception thrown by {@code processElement}.
@@ -52,26 +52,26 @@ public abstract class MapElementsWithErrors<InputT, OutputT>
    * @param e exception thrown by {@code processElement}.
    * @return a {@link PubsubMessage} that holds {@code element} and {@code e}.
    */
-  protected abstract PubsubMessage processError(InputT element, Throwable e);
+  protected abstract PubsubMessage processError(InputT element, Exception e);
 
   /**
    * Default processError method for {@code InputT} == {@link PubsubMessage}.
    */
-  protected PubsubMessage processError(PubsubMessage element, Throwable e) {
+  protected PubsubMessage processError(PubsubMessage element, Exception e) {
     return FailureMessage.of(this, element, e);
   }
 
   /**
    * Default processError method for {@code InputT} == {@link String}.
    */
-  protected PubsubMessage processError(String element, Throwable e) {
+  protected PubsubMessage processError(String element, Exception e) {
     return FailureMessage.of(this, element, e);
   }
 
   /**
    * Default processError method for {@code InputT} == {@code byte[]}.
    */
-  protected PubsubMessage processError(byte[] element, Throwable e) {
+  protected PubsubMessage processError(byte[] element, Exception e) {
     return FailureMessage.of(this, element, e);
   }
 
@@ -84,7 +84,7 @@ public abstract class MapElementsWithErrors<InputT, OutputT>
     public void processElementOrError(@Element InputT element, MultiOutputReceiver out) {
       try {
         out.get(successTag).output(processElement(element));
-      } catch (Throwable e) {
+      } catch (Exception e) {
         out.get(errorTag).output(processError(element, e));
       }
     }


### PR DESCRIPTION
In testing the Decoder, I've seen some records in the error collection due to
OutOfMemoryError. We likely want the worker to fail in this case rather than
send the message to error output.

In general, it's a bit dangerous to catch Throwable since system Errors
(which don't inherit from exception) are generally due to some unrecoverable
state that means the process needs to go down quickly.