### PR TITLE
Filter large payloads to error output when writing to BigQuery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,8 @@ jobs:
 
   ingestion-beam:
     docker:
-    - image: maven
+    # Pin the maven image due to observed VM aborts on CircleCI 2018-01-08.
+    - image: maven@sha256:955e28c9a64b439591adfd43da77586c8bcd45f51627bf9144e297386c6a6be3
     steps:
     - checkout
     - restore_cache: &restore_cache_beam
@@ -94,7 +95,8 @@ jobs:
 
   ingestion-beam-integration:
     docker:
-    - image: maven
+    # Pin the maven image due to observed VM aborts on CircleCI 2018-01-08.
+    - image: maven@sha256:955e28c9a64b439591adfd43da77586c8bcd45f51627bf9144e297386c6a6be3
     steps:
     - run:
         name: Early return if this build is from a forked PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
         command: |
           export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
           echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+          export MAVEN_OPTS="-Xms512m -Xmx1024m"
           cd ingestion-beam && mvn clean test -Dtest=*IntegrationTest
     - run:
         name: Report code coverage

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/LimitPayloadSize.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/LimitPayloadSize.java
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.transforms;
+
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+
+public class LimitPayloadSize extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMessage> {
+
+  /** Exception to throw for messages whose payloads exceed the configured size limit. */
+  public static class PayloadTooLargeException extends Exception {
+
+    public PayloadTooLargeException(String message) {
+      super(message);
+    }
+  }
+
+  /** Return a transform that will send messages to error output if payload exceeds maxBytes. */
+  public static LimitPayloadSize toBytes(int maxBytes) {
+    return new LimitPayloadSize(maxBytes);
+  }
+
+  /** Return a transform that will send messages to error output if payload exceeds mb megabytes. */
+  public static LimitPayloadSize toMB(int mb) {
+    return new LimitPayloadSize(mb * 1024 * 1024);
+  }
+
+  @Override
+  protected PubsubMessage processElement(PubsubMessage message) throws Exception {
+    int numBytes = message.getPayload() == null ? 0 : message.getPayload().length;
+    if (numBytes > maxBytes) {
+      countPayloadTooLarge.inc();
+      throw new PayloadTooLargeException("Message payload is " + numBytes + "bytes, larger than the"
+          + " configured limit of " + maxBytes);
+    }
+    return message;
+  }
+
+  ////////
+
+  private final int maxBytes;
+
+  private final Counter countPayloadTooLarge = Metrics.counter(LimitPayloadSize.class,
+      "payload-too-large");
+
+  private LimitPayloadSize(int maxBytes) {
+    this.maxBytes = maxBytes;
+  }
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/BigQueryIntegrationTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/BigQueryIntegrationTest.java
@@ -25,11 +25,9 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import com.mozilla.telemetry.Sink;
 import com.mozilla.telemetry.matchers.Lines;
-import java.io.PrintWriter;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.PipelineResult;
-import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -134,9 +132,9 @@ public class BigQueryIntegrationTest {
 
   @Test
   public void canRecoverFailedInserts() throws Exception {
-    final String table = "table_with_required_col";
-    final String tableSpec = String.format("%s.%s", dataset, table);
-    final TableId tableId = TableId.of(dataset, table);
+    String table = "table_with_required_col";
+    String tableSpec = String.format("%s.%s", dataset, table);
+    TableId tableId = TableId.of(dataset, table);
 
     bigquery.create(DatasetInfo.newBuilder(dataset).build());
 
@@ -146,16 +144,9 @@ public class BigQueryIntegrationTest {
                 .setMode(Mode.REQUIRED).build())))
         .build());
 
-    final String input = outputPath + "/input.ndjson";
-
-    try (PrintWriter writer = new PrintWriter(input, "UTF-8")) {
-      writer.println("{\"clientId\":\"abc123\",\"type\":\"main\"}");
-      writer.println("{\"clientId\":\"abc123\",\"type\":\"main\",\"extra_required_field\":\"hi\""
-          + "\"huge_field\":\"" + StringUtils.repeat("abcdefghij", 103 * 1024) + "\"}");
-    }
-
-    final String output = String.format("%s:%s", projectId, tableSpec);
-    final String errorOutput = outputPath + "/error/out";
+    String input = Resources.getResource("testdata/json-payload.ndjson").getPath();
+    String output = String.format("%s:%s", projectId, tableSpec);
+    String errorOutput = outputPath + "/error/out";
 
     PipelineResult result = Sink.run(new String[] { "--inputFileFormat=text", "--inputType=file",
         "--input=" + input, "--outputType=bigquery", "--output=" + output, "--errorOutputType=file",
@@ -165,8 +156,9 @@ public class BigQueryIntegrationTest {
 
     assertTrue(stringValuesQuery("SELECT clientId FROM " + tableSpec).isEmpty());
 
+    List<String> expectedErrorLines = Lines.resources("testdata/json-payload-wrapped.ndjson");
     List<String> errorOutputLines = Lines.files(outputPath + "/error/out*.ndjson");
-    assertThat(errorOutputLines, Matchers.hasSize(2));
+    assertThat(errorOutputLines, Matchers.hasSize(expectedErrorLines.size()));
   }
 
   private List<String> stringValuesQuery(String query) throws InterruptedException {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/LimitPayloadSizeTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/LimitPayloadSizeTest.java
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.transforms;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.mozilla.telemetry.options.InputFileFormat;
+import java.util.List;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LimitPayloadSizeTest {
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testLimit() {
+    List<String> passingPayloads = ImmutableList.of("", "abcdefg",
+        StringUtils.repeat("abcdefg", 50));
+    List<String> failingPayloads = ImmutableList.of(StringUtils.repeat("abcdefghij", 51));
+
+    ResultWithErrors<PCollection<PubsubMessage>> result = pipeline //
+        .apply(Create.of(Iterables.concat(passingPayloads, failingPayloads))) //
+        .apply(InputFileFormat.text.decode()).output() //
+        .apply(LimitPayloadSize.toBytes(500));
+
+    PAssert
+        .that(result.output().apply("get success payload",
+            MapElements.into(TypeDescriptors.strings()).via(m -> new String(m.getPayload())))) //
+        .containsInAnyOrder(passingPayloads);
+    PAssert
+        .that(result.errors().apply("get failure payload",
+            MapElements.into(TypeDescriptors.strings()).via(m -> new String(m.getPayload())))) //
+        .containsInAnyOrder(failingPayloads);
+
+    pipeline.run();
+  }
+}


### PR DESCRIPTION
We found that the pipeline was throwing runtime exceptions due to 404 responses relating to payloads over 10 MB.