### PR TITLE
Logic and display cleanup around BigQuery output

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/MapElementsWithErrors.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/MapElementsWithErrors.java
@@ -82,10 +82,16 @@ public abstract class MapElementsWithErrors<InputT, OutputT>
 
     @ProcessElement
     public void processElementOrError(@Element InputT element, MultiOutputReceiver out) {
+      OutputT processed = null;
+      boolean exceptionWasThrown = false;
       try {
-        out.get(successTag).output(processElement(element));
+        processed = processElement(element);
       } catch (Exception e) {
+        exceptionWasThrown = true;
         out.get(errorTag).output(processError(element, e));
+      }
+      if (!exceptionWasThrown) {
+        out.get(successTag).output(processed);
       }
     }
   }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -34,6 +34,7 @@ public class PubsubMessageToTableRow
     this.tableSpecTemplate = tableSpecTemplate;
   }
 
+  @Override
   protected KV<TableDestination, TableRow> processElement(PubsubMessage element)
       throws IOException {
     Map<String, String> attributes = Optional.ofNullable(element.getAttributeMap()) //


### PR DESCRIPTION
A few things I noticed while debugging BigQuery output, mostly adding descriptions to transforms that are cryptic in the Dataflow UI.