### PR TITLE
Send records to error output if BQ table does not exist.

### DIFF
--- a/ingestion-beam/pom.xml
+++ b/ingestion-beam/pom.xml
@@ -53,7 +53,6 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
             <version>${google-cloud.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/ingestion-beam/src/test/resources/testdata/json-payload-attributes.ndjson
+++ b/ingestion-beam/src/test/resources/testdata/json-payload-attributes.ndjson
@@ -1,3 +1,3 @@
 {"attributeMap":{"document_type":"my-test"},"payload":"eyJjbGllbnRJZCI6ImFiYzEyMyIsInR5cGUiOiJtYWluIn0="}
 {"attributeMap":null,"payload":"eyJjbGllbnRJZCI6ImFiYzEyMyIsInR5cGUiOiJldmVudCJ9"}
-{"attributeMap":null,"payload":"eyJjbGllbnRJZCI6ImRlZjQ1NiIsInR5cGUiOiJtYWluIn0="}
+{"attributeMap":{"document_type":"nonexistent"},"payload":"eyJjbGllbnRJZCI6ImRlZjQ1NiIsInR5cGUiOiJtYWluIn0="}


### PR DESCRIPTION
This will be necessary to unblock moving to batch loading for BigQuery,
since BigQueryIO raises a pipeline execution exception in case of nonexistent
table or any single row being rejected.

Once this is merged, I will take down the BQ sink Dataflow job, delete
placeholder tables we had previously created, and launch a new job.
This may significantly improve performance of the sink as well, since we
won't be sending a large volume of data we know won't validate given current
table schemas.