### PR TITLE
Drop duplicate messages

### DIFF
--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DeduplicateTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DeduplicateTest.java
@@ -85,7 +85,7 @@ public class DeduplicateTest {
 
     // errorTag contains duplicate ids
     final PCollection<String> error = output.errors().apply("get duplicate ids", mapMessagesToId);
-    PAssert.that(error).containsInAnyOrder(duplicatedId, invalidId);
+    PAssert.that(error).containsInAnyOrder(invalidId);
 
     // run RemoveDuplicates
     pipeline.run();


### PR DESCRIPTION
Currently, duplicate messages go to error output, but we have no particular reason to save them.

cc @whd 