### PR TITLE
ingestion-beam style cleanup

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -55,12 +55,12 @@ public class Decoder extends Sink {
     // Trailing comments are used below to prevent rewrapping by google-java-format.
     PCollection<PubsubMessage> deduplicated = pipeline //
         .apply(options.getInputType().read(options)).errorsTo(errorCollections) //
-        .apply(new ParseUri()).errorsTo(errorCollections) //
+        .apply(ParseUri.of()).errorsTo(errorCollections) //
         .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())) //
-        .apply(new ParsePayload()).errorsTo(errorCollections) //
-        .apply(new GeoCityLookup(options.getGeoCityDatabase(), options.getGeoCityFilter()))
-        .apply(new ParseUserAgent()) //
-        .apply(new AddMetadata()).errorsTo(errorCollections) //
+        .apply(ParsePayload.of()).errorsTo(errorCollections) //
+        .apply(GeoCityLookup.of(options.getGeoCityDatabase(), options.getGeoCityFilter()))
+        .apply(ParseUserAgent.of()) //
+        .apply(AddMetadata.of()).errorsTo(errorCollections) //
         .apply(Deduplicate.removeDuplicates(options.getParsedRedisUri())).ignoreDuplicates() //
         .errorsTo(errorCollections);
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/AddMetadata.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/AddMetadata.java
@@ -20,7 +20,9 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
  */
 public class AddMetadata extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMessage> {
 
-  private static final byte[] METADATA_PREFIX = "{\"metadata\":".getBytes();
+  public static AddMetadata of() {
+    return INSTANCE;
+  }
 
   @Override
   protected PubsubMessage processElement(PubsubMessage element) throws IOException {
@@ -48,4 +50,13 @@ public class AddMetadata extends MapElementsWithErrors.ToPubsubMessageFrom<Pubsu
     payloadWithMetadata.write(payload, 1, payload.length - 1);
     return new PubsubMessage(payloadWithMetadata.toByteArray(), element.getAttributeMap());
   }
+
+  ////////
+
+  private static final AddMetadata INSTANCE = new AddMetadata();
+  private static final byte[] METADATA_PREFIX = "{\"metadata\":".getBytes();
+
+  private AddMetadata() {
+  }
+
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/GeoCityLookup.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/GeoCityLookup.java
@@ -43,12 +43,20 @@ import org.apache.beam.sdk.values.PCollection;
 public class GeoCityLookup
     extends PTransform<PCollection<PubsubMessage>, PCollection<PubsubMessage>> {
 
+  public static GeoCityLookup of(ValueProvider<String> geoCityDatabase,
+      ValueProvider<String> geoCityFilter) {
+    return new GeoCityLookup(geoCityDatabase, geoCityFilter);
+  }
+
+  /////////
+
   private static final Pattern GEO_NAME_PATTERN = Pattern.compile("^(\\d+).*");
 
   private final ValueProvider<String> geoCityDatabase;
   private final ValueProvider<String> geoCityFilter;
 
-  public GeoCityLookup(ValueProvider<String> geoCityDatabase, ValueProvider<String> geoCityFilter) {
+  private GeoCityLookup(ValueProvider<String> geoCityDatabase,
+      ValueProvider<String> geoCityFilter) {
     this.geoCityDatabase = geoCityDatabase;
     this.geoCityFilter = geoCityFilter;
   }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -32,6 +32,12 @@ import org.json.JSONObject;
  */
 public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMessage> {
 
+  public static ParsePayload of() {
+    return INSTANCE;
+  }
+
+  ////////
+
   private final Distribution parseTimer = Metrics.distribution(ParsePayload.class,
       "json-parse-millis");
   private final Distribution validateTimer = Metrics.distribution(ParsePayload.class,
@@ -50,7 +56,11 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
     }
   }
 
+  private static final ParsePayload INSTANCE = new ParsePayload();
   private static final Map<String, Schema> schemas = new HashMap<>();
+
+  private ParsePayload() {
+  }
 
   @VisibleForTesting
   public static int numLoadedSchemas() {

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -11,6 +11,12 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 
 public class ParseUri extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMessage> {
 
+  public static ParseUri of() {
+    return INSTANCE;
+  }
+
+  ////////
+
   private static class InvalidUriException extends Exception {
 
     InvalidUriException() {
@@ -24,6 +30,11 @@ public class ParseUri extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMe
 
   private static class NullUriException extends InvalidUriException {
   }
+
+  private ParseUri() {
+  }
+
+  private static final ParseUri INSTANCE = new ParseUri();
 
   private static final String TELEMETRY_URI_PREFIX = "/submit/telemetry/";
   private static final String[] TELEMETRY_URI_SUFFIX_ELEMENTS = new String[] { "document_id",

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUserAgent.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUserAgent.java
@@ -23,6 +23,12 @@ import org.apache.beam.sdk.values.PCollection;
 public class ParseUserAgent
     extends PTransform<PCollection<PubsubMessage>, PCollection<PubsubMessage>> {
 
+  public static ParseUserAgent of() {
+    return INSTANCE;
+  }
+
+  ////////
+
   private static class Field implements Serializable {
 
     private final String attribute;
@@ -44,6 +50,9 @@ public class ParseUserAgent
   private static final Field USER_AGENT_OS = new Field("user_agent_os", "OperatingSystemName");
   private static final Field USER_AGENT_VERSION = new Field("user_agent_version", "AgentVersion");
   private static final Set<String> parseFailures = Sets.newHashSet("Unknown", "??");
+
+  private static final Fn FN = new Fn();
+  private static final ParseUserAgent INSTANCE = new ParseUserAgent();
 
   private static class Fn extends SimpleFunction<PubsubMessage, PubsubMessage> {
 
@@ -78,10 +87,12 @@ public class ParseUserAgent
     }
   }
 
-  private static final Fn FN = new Fn();
-
   @Override
   public PCollection<PubsubMessage> expand(PCollection<PubsubMessage> input) {
     return input.apply(MapElements.via(FN));
   }
+
+  private ParseUserAgent() {
+  }
+
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/CompressPayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/CompressPayload.java
@@ -14,7 +14,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessageWithAttributesCoder;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -30,9 +29,8 @@ public class CompressPayload
 
   @Override
   public PCollection<PubsubMessage> expand(PCollection<? extends PubsubMessage> input) {
-    return input.apply(
-        MapElements.into(new TypeDescriptor<PubsubMessage>(PubsubMessageWithAttributesCoder.class) {
-        }).via(message -> compress(message, compression.get())));
+    return input.apply(MapElements.into(TypeDescriptor.of(PubsubMessage.class))
+        .via(message -> compress(message, compression.get())));
   }
 
   ////////

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/WithErrors.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/WithErrors.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessageWithAttributesCoder;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PInput;
@@ -85,7 +84,6 @@ public class WithErrors {
     @Override
     public void finishSpecifyingOutput(String transformName, PInput input,
         PTransform<?, ?> transform) {
-      errors().setCoder(PubsubMessageWithAttributesCoder.of());
     }
   }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DeduplicateTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DeduplicateTest.java
@@ -39,8 +39,8 @@ public class DeduplicateTest {
 
     // Create new PubsubMessage with element as document_id attribute
     final MapElements<String, PubsubMessage> mapStringsToId = MapElements
-        .into(new TypeDescriptor<PubsubMessage>() {
-        }).via(element -> new PubsubMessage(new byte[0], ImmutableMap.of("document_id", element)));
+        .into(TypeDescriptor.of(PubsubMessage.class))
+        .via(element -> new PubsubMessage(new byte[0], ImmutableMap.of("document_id", element)));
 
     // Extract document_id attribute from PubsubMessage
     final MapElements<PubsubMessage, String> mapMessagesToId = MapElements

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/GeoCityLookupTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/GeoCityLookupTest.java
@@ -67,10 +67,11 @@ public class GeoCityLookupTest {
             + ",\"geo_subdivision1\":\"CA\"" //
             + "},\"payload\":\"\"}");
 
-    final PCollection<String> output = pipeline.apply(Create.of(input))
-        .apply("decodeJson", InputFileFormat.json.decode()).output()
-        .apply("geoCityLookup", new GeoCityLookup(pipeline.newProvider("GeoLite2-City.mmdb"), null))
-        .apply("encodeJson", OutputFileFormat.json.encode());
+    final PCollection<String> output = pipeline //
+        .apply(Create.of(input)) //
+        .apply(InputFileFormat.json.decode()).output() //
+        .apply(GeoCityLookup.of(pipeline.newProvider("GeoLite2-City.mmdb"), null))
+        .apply(OutputFileFormat.json.encode());
 
     PAssert.that(output).containsInAnyOrder(expected);
 
@@ -93,12 +94,12 @@ public class GeoCityLookupTest {
     final List<String> expected = Arrays.asList("{\"attributeMap\":" + "{\"geo_country\":\"US\""
         + ",\"geo_subdivision1\":\"CA\"" + "},\"payload\":\"\"}");
 
-    final PCollection<String> output = pipeline.apply(Create.of(input))
-        .apply("decodeJson", InputFileFormat.json.decode()).output()
-        .apply("geoCityLookup",
-            new GeoCityLookup(pipeline.newProvider("GeoLite2-City.mmdb"),
-                pipeline.newProvider("src/test/resources/cityFilters/milton.txt")))
-        .apply("encodeJson", OutputFileFormat.json.encode());
+    final PCollection<String> output = pipeline //
+        .apply(Create.of(input)) //
+        .apply(InputFileFormat.json.decode()).output() //
+        .apply(GeoCityLookup.of(pipeline.newProvider("GeoLite2-City.mmdb"),
+            pipeline.newProvider("src/test/resources/cityFilters/milton.txt")))
+        .apply(OutputFileFormat.json.encode());
 
     PAssert.that(output).containsInAnyOrder(expected);
 
@@ -113,12 +114,12 @@ public class GeoCityLookupTest {
     final List<String> expected = Arrays.asList("{\"attributeMap\":" + "{\"geo_country\":\"US\""
         + ",\"geo_city\":\"Sacramento\"" + ",\"geo_subdivision1\":\"CA\"" + "},\"payload\":\"\"}");
 
-    final PCollection<String> output = pipeline.apply(Create.of(input))
-        .apply("decodeJson", InputFileFormat.json.decode()).output()
-        .apply("geoCityLookup",
-            new GeoCityLookup(pipeline.newProvider("GeoLite2-City.mmdb"),
-                pipeline.newProvider("src/test/resources/cityFilters/sacramento.txt")))
-        .apply("encodeJson", OutputFileFormat.json.encode());
+    final PCollection<String> output = pipeline //
+        .apply(Create.of(input)) //
+        .apply(InputFileFormat.json.decode()).output() //
+        .apply(GeoCityLookup.of(pipeline.newProvider("GeoLite2-City.mmdb"),
+            pipeline.newProvider("src/test/resources/cityFilters/sacramento.txt")))
+        .apply(OutputFileFormat.json.encode());
 
     PAssert.that(output).containsInAnyOrder(expected);
 
@@ -132,8 +133,10 @@ public class GeoCityLookupTest {
     final List<String> input = Arrays
         .asList("{\"attributeMap\":{\"host\":\"test\"},\"payload\":\"dGVzdA==\"}");
 
-    pipeline.apply(Create.of(input)).apply("decodeJson", InputFileFormat.json.decode()).output()
-        .apply("geoCityLookup", new GeoCityLookup(pipeline.newProvider("missing-file.mmdb"), null));
+    pipeline //
+        .apply(Create.of(input)) //
+        .apply(InputFileFormat.json.decode()).output() //
+        .apply(GeoCityLookup.of(pipeline.newProvider("missing-file.mmdb"), null));
 
     pipeline.run();
   }
@@ -145,8 +148,10 @@ public class GeoCityLookupTest {
     final List<String> input = Arrays
         .asList("{\"attributeMap\":{\"host\":\"test\"},\"payload\":\"dGVzdA==\"}");
 
-    pipeline.apply(Create.of(input)).apply("decodeJson", InputFileFormat.json.decode()).output()
-        .apply("geoCityLookup", new GeoCityLookup(pipeline.newProvider("GeoLite2-City.mmdb"),
+    pipeline //
+        .apply(Create.of(input)) //
+        .apply(InputFileFormat.json.decode()).output() //
+        .apply(GeoCityLookup.of(pipeline.newProvider("GeoLite2-City.mmdb"),
             pipeline.newProvider("missing-file.txt")));
 
     pipeline.run();
@@ -159,8 +164,10 @@ public class GeoCityLookupTest {
     final List<String> input = Arrays
         .asList("{\"attributeMap\":{\"host\":\"test\"},\"payload\":\"dGVzdA==\"}");
 
-    pipeline.apply(Create.of(input)).apply("decodeJson", InputFileFormat.json.decode()).output()
-        .apply("geoCityLookup", new GeoCityLookup(pipeline.newProvider("GeoLite2-City.mmdb"),
+    pipeline //
+        .apply(Create.of(input)) //
+        .apply(InputFileFormat.json.decode()).output() //
+        .apply(GeoCityLookup.of(pipeline.newProvider("GeoLite2-City.mmdb"),
             pipeline.newProvider("src/test/resources/cityFilters/invalid.txt")));
 
     pipeline.run();

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
@@ -56,14 +56,16 @@ public class ParseUriTest {
 
     WithErrors.Result<PCollection<PubsubMessage>> parsed = pipeline
         .apply(Create.of(Iterables.concat(validInput, invalidInput)))
-        .apply(InputFileFormat.json.decode()).output().apply(new ParseUri());
+        .apply("DecodeJsonInput", InputFileFormat.json.decode()).output() //
+        .apply(ParseUri.of());
 
-    PCollection<String> output = parsed.output().apply("encodeJson",
-        OutputFileFormat.json.encode());
+    PCollection<String> output = parsed.output() //
+        .apply("EncodeJsonOutput", OutputFileFormat.json.encode());
     PAssert.that(output).containsInAnyOrder(expected);
 
-    PCollection<String> exceptions = parsed.errors().apply(MapElements
-        .into(TypeDescriptors.strings()).via(message -> message.getAttribute("exception_class")));
+    PCollection<String> exceptions = parsed.errors() //
+        .apply(MapElements.into(TypeDescriptors.strings())
+            .via(message -> message.getAttribute("exception_class")));
     PAssert.that(exceptions)
         .containsInAnyOrder(Arrays.asList("com.mozilla.telemetry.decoder.ParseUri$NullUriException",
             "com.mozilla.telemetry.decoder.ParseUri$InvalidUriException",

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUserAgentTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUserAgentTest.java
@@ -36,10 +36,11 @@ public class ParseUserAgentTest {
             + ",\"user_agent_version\":\"63.0\"" + ",\"user_agent_os\":\"Macintosh\""
             + "},\"payload\":\"\"}");
 
-    final PCollection<String> output = pipeline.apply(Create.of(input))
-        .apply("decodeJson", InputFileFormat.json.decode()).output()
-        .apply("parseUserAgent", new ParseUserAgent())
-        .apply("encodeJson", OutputFileFormat.json.encode());
+    final PCollection<String> output = pipeline //
+        .apply(Create.of(input)) //
+        .apply(InputFileFormat.json.decode()).output() //
+        .apply(ParseUserAgent.of()) //
+        .apply(OutputFileFormat.json.encode());
 
     PAssert.that(output).containsInAnyOrder(expected);
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/DecodePubsubMessagesTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/DecodePubsubMessagesTest.java
@@ -25,11 +25,11 @@ public class DecodePubsubMessagesTest {
   public void testText() {
     List<String> inputLines = Lines.resources("testdata/decode-pubsub-messages/input-*");
 
-    WithErrors.Result<PCollection<PubsubMessage>> decoded = pipeline.apply(Create.of(inputLines))
-        .apply("decodeText", InputFileFormat.text.decode());
+    WithErrors.Result<PCollection<PubsubMessage>> decoded = pipeline //
+        .apply(Create.of(inputLines)) //
+        .apply(InputFileFormat.text.decode());
 
-    PCollection<String> encoded = decoded.output().apply("encodeText",
-        OutputFileFormat.text.encode());
+    PCollection<String> encoded = decoded.output().apply(OutputFileFormat.text.encode());
 
     PAssert.that(encoded).containsInAnyOrder(inputLines);
     PAssert.that(decoded.errors()).empty();
@@ -45,14 +45,15 @@ public class DecodePubsubMessagesTest {
     List<String> invalidLines = Lines
         .resources("testdata/decode-pubsub-messages/input-invalid-json.txt");
 
-    WithErrors.Result<PCollection<PubsubMessage>> decoded = pipeline.apply(Create.of(inputLines))
-        .apply("decodeJson", InputFileFormat.json.decode());
+    WithErrors.Result<PCollection<PubsubMessage>> decoded = pipeline //
+        .apply(Create.of(inputLines)) //
+        .apply(InputFileFormat.json.decode());
 
-    PCollection<String> encoded = decoded.output().apply("encodeJson",
-        OutputFileFormat.json.encode());
+    PCollection<String> encoded = decoded.output() //
+        .apply("EncodeJsonOutput", OutputFileFormat.json.encode());
 
-    PCollection<String> encodedErrors = decoded.errors().apply("encodeText",
-        OutputFileFormat.text.encode());
+    PCollection<String> encodedErrors = decoded.errors() //
+        .apply("EncodeTextError", OutputFileFormat.text.encode());
 
     PAssert.that(encoded).containsInAnyOrder(validLines);
     PAssert.that(encodedErrors).containsInAnyOrder(invalidLines);

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/DecompressPayloadTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/DecompressPayloadTest.java
@@ -33,10 +33,11 @@ public class DecompressPayloadTest {
         "{\"attributeMap\":{\"host\":\"test\"},\"payload\":\"dGVzdA==\"}",
         "{\"attributeMap\":null,\"payload\":\"dGVzdA==\"}");
 
-    final PCollection<String> output = pipeline.apply(Create.of(input))
-        .apply("decodeJson", InputFileFormat.json.decode()).output()
-        .apply("gzipDecompress", DecompressPayload.enabled(pipeline.newProvider(true)))
-        .apply("encodeJson", OutputFileFormat.json.encode());
+    final PCollection<String> output = pipeline //
+        .apply(Create.of(input)) //
+        .apply(InputFileFormat.json.decode()).output() //
+        .apply(DecompressPayload.enabled(pipeline.newProvider(true))) //
+        .apply(OutputFileFormat.json.encode());
 
     PAssert.that(output).containsInAnyOrder(expected);
 


### PR DESCRIPTION
A variety of changes to be more consistent in our style internally and more
consistent with some conventions of Beam.

We give all "user-facing" transforms private constructors and public static
factory methods, returning a Singleton instance in case of transforms that
take no parameters.

Also more consistent in skipping explicit names for transforms when they
simply repeat the class name.