### PR TITLE
Use underscores for metric names

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/GeoCityLookup.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/GeoCityLookup.java
@@ -67,14 +67,14 @@ public class GeoCityLookup
     private transient DatabaseReader geoIP2City;
     private transient Set<Integer> allowedCities;
 
-    private final Counter countIpForwarded = Metrics.counter(Fn.class, "ip-from-x-forwarded-for");
-    private final Counter countIpRemoteAddr = Metrics.counter(Fn.class, "ip-from-remote-addr");
-    private final Counter countPipelineProxy = Metrics.counter(Fn.class, "count-pipeline-proxy");
-    private final Counter foundIp = Metrics.counter(Fn.class, "found-ip");
-    private final Counter foundCity = Metrics.counter(Fn.class, "found-city");
-    private final Counter foundCityAllowed = Metrics.counter(Fn.class, "found-city-allowed");
-    private final Counter foundGeo1 = Metrics.counter(Fn.class, "found-geo-subdivision-1");
-    private final Counter foundGeo2 = Metrics.counter(Fn.class, "found-geo-subdivision-2");
+    private final Counter countIpForwarded = Metrics.counter(Fn.class, "ip_from_x_forwarded_for");
+    private final Counter countIpRemoteAddr = Metrics.counter(Fn.class, "ip_from_remote_addr");
+    private final Counter countPipelineProxy = Metrics.counter(Fn.class, "count_pipeline_proxy");
+    private final Counter foundIp = Metrics.counter(Fn.class, "found_ip");
+    private final Counter foundCity = Metrics.counter(Fn.class, "found_city");
+    private final Counter foundCityAllowed = Metrics.counter(Fn.class, "found_city_allowed");
+    private final Counter foundGeo1 = Metrics.counter(Fn.class, "found_geo_subdivision_1");
+    private final Counter foundGeo2 = Metrics.counter(Fn.class, "found_geo_subdivision_2");
 
     @Override
     public PubsubMessage apply(PubsubMessage value) {

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -39,9 +39,9 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
   ////////
 
   private final Distribution parseTimer = Metrics.distribution(ParsePayload.class,
-      "json-parse-millis");
+      "json_parse_millis");
   private final Distribution validateTimer = Metrics.distribution(ParsePayload.class,
-      "json-validate-millis");
+      "json_validate_millis");
 
   private transient Validator validator;
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/DecompressPayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/DecompressPayload.java
@@ -48,8 +48,8 @@ public class DecompressPayload
 
     private static final byte ZERO_BYTE = 0x00;
 
-    private final Counter compressedInput = Metrics.counter(Fn.class, "compressed-input");
-    private final Counter uncompressedInput = Metrics.counter(Fn.class, "uncompressed-input");
+    private final Counter compressedInput = Metrics.counter(Fn.class, "compressed_input");
+    private final Counter uncompressedInput = Metrics.counter(Fn.class, "uncompressed_input");
 
     @Override
     public PubsubMessage apply(PubsubMessage message) {

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/LimitPayloadSize.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/LimitPayloadSize.java
@@ -44,7 +44,7 @@ public class LimitPayloadSize extends MapElementsWithErrors.ToPubsubMessageFrom<
   private final int maxBytes;
 
   private final Counter countPayloadTooLarge = Metrics.counter(LimitPayloadSize.class,
-      "payload-too-large");
+      "payload_too_large");
 
   private LimitPayloadSize(int maxBytes) {
     this.maxBytes = maxBytes;

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubConstraints.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubConstraints.java
@@ -59,8 +59,8 @@ public class PubsubConstraints {
 
     private static class Fn extends DoFn<PubsubMessage, PubsubMessage> {
 
-      private final Counter countTruncatedKey = Metrics.counter(Fn.class, "truncated-key");
-      private final Counter countTruncatedValue = Metrics.counter(Fn.class, "truncated-value");
+      private final Counter countTruncatedKey = Metrics.counter(Fn.class, "truncated_key");
+      private final Counter countTruncatedValue = Metrics.counter(Fn.class, "truncated_value");
 
       @ProcessElement
       public void processElement(@Element PubsubMessage message,


### PR DESCRIPTION
This matches the convention for all built-in Dataflow metrics.