### PR TITLE
Add ensureNonNull pubsub util for simplifying error checking

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/AddMetadata.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/AddMetadata.java
@@ -5,6 +5,7 @@
 package com.mozilla.telemetry.decoder;
 
 import com.mozilla.telemetry.transforms.MapElementsWithErrors;
+import com.mozilla.telemetry.transforms.PubsubConstraints;
 import com.mozilla.telemetry.util.Json;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -25,11 +26,12 @@ public class AddMetadata extends MapElementsWithErrors.ToPubsubMessageFrom<Pubsu
   }
 
   @Override
-  protected PubsubMessage processElement(PubsubMessage element) throws IOException {
+  protected PubsubMessage processElement(PubsubMessage message) throws IOException {
+    message = PubsubConstraints.ensureNonNull(message);
     // Get payload
-    final byte[] payload = element.getPayload();
+    final byte[] payload = message.getPayload();
     // Get attributes as bytes, throws IOException
-    final byte[] metadata = Json.asBytes(element.getAttributeMap());
+    final byte[] metadata = Json.asBytes(message.getAttributeMap());
     // Ensure that we have a json object with no leading whitespace
     if (payload.length < 2 || payload[0] != '{') {
       throw new IOException("invalid json object: must start with {");
@@ -48,7 +50,7 @@ public class AddMetadata extends MapElementsWithErrors.ToPubsubMessageFrom<Pubsu
     }
     // Write payload without leading `{`
     payloadWithMetadata.write(payload, 1, payload.length - 1);
-    return new PubsubMessage(payloadWithMetadata.toByteArray(), element.getAttributeMap());
+    return new PubsubMessage(payloadWithMetadata.toByteArray(), message.getAttributeMap());
   }
 
   ////////

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -7,6 +7,7 @@ package com.mozilla.telemetry.decoder;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Resources;
 import com.mozilla.telemetry.transforms.MapElementsWithErrors;
+import com.mozilla.telemetry.transforms.PubsubConstraints;
 import com.mozilla.telemetry.util.Json;
 import java.io.IOException;
 import java.net.URL;
@@ -119,17 +120,14 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
   }
 
   @Override
-  protected PubsubMessage processElement(PubsubMessage element)
+  protected PubsubMessage processElement(PubsubMessage message)
       throws SchemaNotFoundException, IOException {
-    // Throws IOException if not a valid json object
-    final JSONObject json = parseTimed(element.getPayload());
+    message = PubsubConstraints.ensureNonNull(message);
 
-    Map<String, String> attributes;
-    if (element.getAttributeMap() == null) {
-      attributes = new HashMap<>();
-    } else {
-      attributes = new HashMap<>(element.getAttributeMap());
-    }
+    // Throws IOException if not a valid json object
+    final JSONObject json = parseTimed(message.getPayload());
+
+    Map<String, String> attributes = new HashMap<>(message.getAttributeMap());
 
     // Remove any top-level "metadata" field if it exists, and attempt to parse it as a
     // key-value map of strings, adding all entries as attributes.

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -5,6 +5,7 @@
 package com.mozilla.telemetry.decoder;
 
 import com.mozilla.telemetry.transforms.MapElementsWithErrors;
+import com.mozilla.telemetry.transforms.PubsubConstraints;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
@@ -58,9 +59,10 @@ public class ParseUri extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMe
   }
 
   @Override
-  protected PubsubMessage processElement(PubsubMessage element) throws InvalidUriException {
+  protected PubsubMessage processElement(PubsubMessage message) throws InvalidUriException {
+    message = PubsubConstraints.ensureNonNull(message);
     // Copy attributes
-    final Map<String, String> attributes = new HashMap<>(element.getAttributeMap());
+    final Map<String, String> attributes = new HashMap<>(message.getAttributeMap());
 
     // parse uri based on prefix
     final String uri = attributes.get("uri");
@@ -78,6 +80,6 @@ public class ParseUri extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMe
     } else {
       throw new InvalidUriException("Unknown URI prefix");
     }
-    return new PubsubMessage(element.getPayload(), attributes);
+    return new PubsubMessage(message.getPayload(), attributes);
   }
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUserAgent.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUserAgent.java
@@ -5,6 +5,7 @@
 package com.mozilla.telemetry.decoder;
 
 import com.google.common.collect.Sets;
+import com.mozilla.telemetry.transforms.PubsubConstraints;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,9 +64,11 @@ public class ParseUserAgent
         .dropDefaultResources().addResources("UserAgents/*.yaml").build();
 
     @Override
-    public PubsubMessage apply(PubsubMessage value) {
+    public PubsubMessage apply(PubsubMessage message) {
+      message = PubsubConstraints.ensureNonNull(message);
+
       // Copy attributes
-      Map<String, String> attributes = new HashMap<String, String>(value.getAttributeMap());
+      Map<String, String> attributes = new HashMap<String, String>(message.getAttributeMap());
 
       if (attributes.containsKey(USER_AGENT)) {
         // Extract user agent fields
@@ -83,7 +86,7 @@ public class ParseUserAgent
         attributes.remove(USER_AGENT);
       }
       // Return new message
-      return new PubsubMessage(value.getPayload(), attributes);
+      return new PubsubMessage(message.getPayload(), attributes);
     }
   }
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/LimitPayloadSize.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/LimitPayloadSize.java
@@ -30,7 +30,8 @@ public class LimitPayloadSize extends MapElementsWithErrors.ToPubsubMessageFrom<
 
   @Override
   protected PubsubMessage processElement(PubsubMessage message) throws Exception {
-    int numBytes = message.getPayload() == null ? 0 : message.getPayload().length;
+    message = PubsubConstraints.ensureNonNull(message);
+    int numBytes = message.getPayload().length;
     if (numBytes > maxBytes) {
       countPayloadTooLarge.inc();
       throw new PayloadTooLargeException("Message payload is " + numBytes + "bytes, larger than the"

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubConstraints.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubConstraints.java
@@ -39,6 +39,19 @@ public class PubsubConstraints {
     return truncateToFitUtf8ByteLength(value, MAX_ATTRIBUTE_VALUE_BYTES);
   }
 
+  /** Fills out empty payload and attributes if the message itself or components are null. */
+  public static PubsubMessage ensureNonNull(PubsubMessage message) {
+    if (message == null) {
+      return new PubsubMessage(new byte[] {}, new HashMap<>());
+    } else if (message.getPayload() == null) {
+      return ensureNonNull(new PubsubMessage(new byte[] {}, message.getAttributeMap()));
+    } else if (message.getAttributeMap() == null) {
+      return ensureNonNull(new PubsubMessage(message.getPayload(), new HashMap<>()));
+    } else {
+      return message;
+    }
+  }
+
   /**
    * Return a {@link PTransform} that truncates attribute keys and values as needed to satisfy size
    * constraints.


### PR DESCRIPTION
We had some complicated duplicated logic spread around transforms simply
for ensuring that messages, payloads, and attributes were non-null.
This consolidates that logic to a method that we apply across the codebase
and allows us to remove some distracting null-checking code.