### PR TITLE
Metrics per docType

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/Deduplicate.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/Deduplicate.java
@@ -6,6 +6,7 @@ package com.mozilla.telemetry.decoder;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.primitives.Ints;
+import com.mozilla.telemetry.metrics.PerDocTypeCounter;
 import com.mozilla.telemetry.transforms.FailureMessage;
 import com.mozilla.telemetry.transforms.MapElementsWithErrors;
 import com.mozilla.telemetry.transforms.PubsubConstraints;
@@ -150,6 +151,9 @@ public class Deduplicate {
         }
         if (!exceptionWasThrown) {
           if (idExists) {
+            PerDocTypeCounter.inc(element.getAttributeMap(), "duplicate_submission");
+            PerDocTypeCounter.inc(element.getAttributeMap(), "duplicate_submission_bytes",
+                element.getPayload().length);
             out.get(duplicateTag).output(element);
           } else {
             out.get(outputTag).output(element);

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -37,11 +37,11 @@ public class ParseUri extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMe
 
   private static final ParseUri INSTANCE = new ParseUri();
 
-  private static final String TELEMETRY_URI_PREFIX = "/submit/telemetry/";
-  private static final String[] TELEMETRY_URI_SUFFIX_ELEMENTS = new String[] { "document_id",
+  public static final String TELEMETRY_URI_PREFIX = "/submit/telemetry/";
+  public static final String[] TELEMETRY_URI_SUFFIX_ELEMENTS = new String[] { "document_id",
       "document_type", "app_name", "app_version", "app_update_channel", "app_build_id" };
-  private static final String GENERIC_URI_PREFIX = "/submit/";
-  private static final String[] GENERIC_URI_SUFFIX_ELEMENTS = new String[] { "document_namespace",
+  public static final String GENERIC_URI_PREFIX = "/submit/";
+  public static final String[] GENERIC_URI_SUFFIX_ELEMENTS = new String[] { "document_namespace",
       "document_type", "document_version", "document_id" };
 
   private static Map<String, String> zip(String[] keys, String[] values)

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/metrics/PerDocTypeCounter.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/metrics/PerDocTypeCounter.java
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.metrics;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+
+/** Convenience methods for managing sets of counters separated by document_type. */
+public class PerDocTypeCounter {
+
+  private static final Map<String, String> EMPTY_ATTRIBUTES = ImmutableMap.of();
+  private static final Map<String, Counter> counters = new HashMap<>();
+
+  /**
+   * Like {@link #inc(Map, String, long)}, but always increments by 1.
+   */
+  public static void inc(@Nullable Map<String, String> attributes, String name) {
+    inc(attributes, name, 1);
+  }
+
+  /**
+   * Increment a counter segmented by docType.
+   *
+   * <p>Metrics will be named like {@code
+   * ${document_namespace}/${document_type}_v${document_version}/name} based on the passed map of
+   * attributes and the passed metric name. Because we want to keep counters at various points of
+   * message parsing, not all of those attributes may be available. If version is missing, the _v
+   * suffix will be skipped. A null attribute map or missing namespace and docType will be replaced
+   * with unknown_namespace/unknown_doctype.
+   *
+   * <p>Stackdriver allows component "paths" separated by slashes. The Stackdriver UI will show the
+   * name of the metric as the entire user-defined path while the Dataflow UI will the final path
+   * component as the "Counter name", appending the rest of the path to the value it shows as
+   * "Step".
+   *
+   * <p>We change dashes to underscores to match Stackdriver naming restrictions. See
+   * https://cloud.google.com/monitoring/api/v3/metrics-details#label_names
+   *
+   * @param attributes a map of attributes from a PubsubMessage
+   * @param name name to be used as the final component of the path
+   * @param n the number by which to increment the counter
+   */
+  public static void inc(@Nullable Map<String, String> attributes, String name, long n) {
+    getOrCreateCounter(attributes, name).inc(n);
+  }
+
+  @VisibleForTesting
+  static Counter getOrCreateCounter(@Nullable Map<String, String> attributes, String name) {
+    if (attributes == null) {
+      attributes = EMPTY_ATTRIBUTES;
+    }
+    String namespace = attributes.getOrDefault("document_namespace", "unknown_namespace");
+    // Dataflow's UI collapses the metric name, but always shows the penultimate path component
+    // as part of "Step", so we're a bit more verbose with the default doctype value.
+    String docType = attributes.getOrDefault("document_type", "unknown_doctype");
+    String version = attributes.get("document_version");
+    if (version != null) {
+      docType = docType + "_v" + version;
+    }
+    String key = String.format("%s/%s/%s", namespace, docType, name)
+        // We change dashes to underscores to make sure we're following Stackdriver's naming scheme:
+        // https://cloud.google.com/monitoring/api/v3/metrics-details#label_names
+        .replace("-", "_");
+    return counters.computeIfAbsent(key, k -> Metrics.counter(PerDocTypeCounter.class, k));
+  }
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/metrics/PerDocTypeCounterTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/metrics/PerDocTypeCounterTest.java
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.metrics;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.beam.sdk.metrics.Counter;
+import org.junit.Test;
+
+public class PerDocTypeCounterTest {
+
+  @Test
+  public void getCounterTest() {
+    Map<String, String> attributes = ImmutableMap //
+        .of("document_namespace", "telemetry", //
+            "document_type", "core", //
+            "document_version", "10");
+    Counter counter = PerDocTypeCounter.getOrCreateCounter(attributes, "my-name");
+    assertEquals("telemetry/core_v10/my_name", counter.getName().getName());
+  }
+
+  @Test
+  public void getCounterVersionlessTest() {
+    Map<String, String> attributes = ImmutableMap //
+        .of("document_namespace", "telemetry", //
+            "document_type", "core");
+    Counter counter = PerDocTypeCounter.getOrCreateCounter(attributes, "my-name");
+    assertEquals("telemetry/core/my_name", counter.getName().getName());
+  }
+
+  @Test
+  public void getCounterNullTest() {
+    Counter counter = PerDocTypeCounter.getOrCreateCounter(null, "my-name");
+    assertEquals("unknown_namespace/unknown_doctype/my_name", counter.getName().getName());
+  }
+}


### PR DESCRIPTION
Closes #379

This PR defines some machinery for tracking counters per docType and schema
version using Beam's built-in Metrics interface, which Dataflow automatically
visualizes in its UI and sends to Stackdriver.

This explicitly does not match the segmentation of the AWS-based pipeline.
If we segment on appname, channel, etc. then we quickly end up with counters
numbers in tens of thousands, which Dataflow starts to drop. That number of
user-defined counters also clutters the Dataflow UI and causes it to slow down
significantly.

This also doesn't cover all of the metric types of the old pipeline.
In particular, we aren't tracking compressed bytes and invalid gzip errors.
We could do so in a future PR if these Stackdriver-based metrics prove useful
and worth further investment.