### PR TITLE
Support outputNumShards and errorNumShards as runtime params

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/ErrorOutputType.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/ErrorOutputType.java
@@ -44,7 +44,8 @@ public enum ErrorOutputType {
     /** Return a PTransform that writes errors to local or remote files. */
     public Write writeFailures(SinkOptions.Parsed options) {
       return new FileOutput(options.getErrorOutput(), FORMAT, options.getParsedWindowDuration(),
-          options.getErrorOutputNumShards(), options.getErrorOutputFileCompression());
+          options.getErrorOutputNumShards(), options.getErrorOutputFileCompression(),
+          options.getInputType());
     }
   },
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/OutputType.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/OutputType.java
@@ -37,7 +37,7 @@ public enum OutputType {
     public Write write(SinkOptions.Parsed options) {
       return new FileOutput(options.getOutput(), options.getOutputFileFormat(),
           options.getParsedWindowDuration(), options.getOutputNumShards(),
-          options.getOutputFileCompression());
+          options.getOutputFileCompression(), options.getInputType());
     }
   },
 
@@ -55,7 +55,7 @@ public enum OutputType {
     public Write write(SinkOptions.Parsed options) {
       return new BigQueryOutput(options.getOutput(), options.getBqWriteMethod(),
           options.getParsedBqTriggeringFrequency(), options.getInputType(),
-          options.getOutputNumShards());
+          options.getBqNumFileShards());
     }
   };
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/FileWindowingTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/FileWindowingTest.java
@@ -65,7 +65,7 @@ public class FileWindowingTest implements Serializable {
     options.setOutputType(OutputType.file);
     options.setOutputFileFormat(OutputFileFormat.text);
     options.setOutputFileCompression(Compression.UNCOMPRESSED);
-    options.setOutputNumShards(1);
+    options.setOutputNumShards(pipeline.newProvider(1));
     options.setWindowDuration("10 minutes");
     options.setOutput(pipeline.newProvider(output));
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/SinkMainTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/SinkMainTest.java
@@ -159,20 +159,6 @@ public class SinkMainTest {
   }
 
   @Test
-  public void testThrowsOnMissingNumShards() {
-    thrown.expectMessage(Matchers.startsWith("Configuration errors found"));
-    Sink.main(new String[] { "--inputType=pubsub", "--input=foo", "--outputType=file",
-        "--output=foo", "--errorOutputType=pubsub", "--errorOutput=bar" });
-  }
-
-  @Test
-  public void testThrowsOnMissingErrorNumShards() {
-    thrown.expectMessage(Matchers.startsWith("Configuration errors found"));
-    Sink.main(new String[] { "--inputType=pubsub", "--input=foo", "--outputType=pubsub",
-        "--output=foo", "--errorOutputType=file", "--errorOutput=bar" });
-  }
-
-  @Test
   public void testParseTimestamp() throws Exception {
     String inputPath = Resources.getResource("testdata").getPath();
     String input = inputPath + "/basic-messages-valid-*.ndjson";

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DeduplicateTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DeduplicateTest.java
@@ -31,8 +31,8 @@ public class DeduplicateTest {
   @Test
   public void testOutput() {
     DecoderOptions decoderOptions = pipeline.getOptions().as(DecoderOptions.class);
-    decoderOptions.setOutputNumShards(1);
-    decoderOptions.setErrorOutputNumShards(1);
+    decoderOptions.setOutputNumShards(pipeline.newProvider(1));
+    decoderOptions.setErrorOutputNumShards(pipeline.newProvider(1));
     decoderOptions.setDeduplicateExpireDuration(pipeline.newProvider("24h"));
     decoderOptions.setRedisUri(pipeline.newProvider(redis.uri));
     DecoderOptions.Parsed options = DecoderOptions.parseDecoderOptions(decoderOptions);


### PR DESCRIPTION
Closes #435

BQ doesn't accept a ValueProvider for its sharding, so we break that out to
a separate compile-time param that we don't expect we'll need to mess with.

We lose some validation capability with this route, but we are now able to
provide a non-zero default for sharding, since we check whether we're streaming
and ignore sharding params for batch mode.