### PR TITLE
Add template build script

### DIFF
--- a/ingestion-beam/bin/build-template
+++ b/ingestion-beam/bin/build-template
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Build dataflow template with output to
+# gs://$TEMPLATE_BUCKET/$JOB_TYPE/templates/$BUILD_ID/template
+# and staging/temporary assets at
+# gs://$TEMP_BUCKET/$JOB_TYPE/$BUILD_ID/{stage,tmp}
+set -e
+
+PROJECT="${PROJECT:?}"
+JOB_TYPE="${JOB_TYPE:?}"
+TEMPLATE_BUCKET="${TEMPLATE_BUCKET:?}"
+TEMP_BUCKET="${TEMP_BUCKET:?}"
+BUILD_ID="${BUILD_ID:?}"
+
+OUTPUT_OPTS=""
+ERROR_OUTPUT_OPTS=""
+
+# See https://github.com/mozilla/gcp-ingestion/issues/376 for some
+# discussion about the default values of these parameters
+# Note: sharding and worker pool settings are generally superseded by runtime
+# configuration, where possible
+ERROR_NUM_SHARDS="${ERROR_NUM_SHARDS:=60}"
+NUM_SHARDS="${NUM_SHARDS:=200}"
+MAX_NUM_WORKERS="${MAX_NUM_WORKERS:=60}"
+SINK_DISK_SIZE="${SINK_DISK_SIZE:=500}"
+SINK_WORKER_MACHINE_TYPE="${SINK_WORKER_MACHINE_TYPE:=n1-standard-8}"
+
+WORKER_OPTS="--numWorkers=1 \
+--maxNumWorkers=${MAX_NUM_WORKERS} \
+--autoscalingAlgorithm=THROUGHPUT_BASED"
+
+SINK_OPTS="--workerMachineType=${SINK_WORKER_MACHINE_TYPE} \
+--workerDiskType='compute.googleapis.com/projects//zones//diskTypes/pd-ssd' \
+--diskSizeGb=${SINK_DISK_SIZE} \
+--outputNumShards=${NUM_SHARDS}"
+
+INPUT_OPTS="--inputFileFormat=json \
+--inputType=pubsub"
+
+if [[ $JOB_TYPE == "bqsink" ]]; then
+  JOB_CLASS="com.mozilla.telemetry.Sink"
+  OUTPUT_OPTS="--outputType=bigquery ${SINK_OPTS}"
+  ERROR_OUTPUT_OPTS="--errorOutputType=file \
+--errorOutputNumShards=${ERROR_NUM_SHARDS}"
+elif [[ $JOB_TYPE == "gcssink" ]] ; then
+  JOB_CLASS="com.mozilla.telemetry.Sink"
+  OUTPUT_OPTS="--outputType=file \
+--outputFileFormat=json \
+${SINK_OPTS}"
+  ERROR_OUTPUT_OPTS="--errorOutputType=file \
+--errorOutputNumShards=${ERROR_NUM_SHARDS}"
+elif [[ $JOB_TYPE == "decoder" ]] ; then
+  JOB_CLASS="com.mozilla.telemetry.Decoder"
+  OUTPUT_OPTS="--outputType=pubsub \
+--outputFileFormat=json"
+  ERROR_OUTPUT_OPTS="--errorOutputType=pubsub"
+else
+  echo "unknown job type ${JOB_TYPE}"
+  exit 1
+fi
+
+TEMPLATE_LOCATION=gs://$TEMPLATE_BUCKET/$JOB_TYPE/templates/$BUILD_ID/template
+STAGE_LOCATION=gs://$TEMP_BUCKET/$JOB_TYPE/$BUILD_ID/stage
+TEMP_LOCATION=gs://$TEMP_BUCKET/$JOB_TYPE/$BUILD_ID/tmp
+
+COMPILE_OPTIONS="--runner=Dataflow \
+--project=${PROJECT} \
+${INPUT_OPTS} \
+${OUTPUT_OPTS} \
+${ERROR_OUTPUT_OPTS} \
+${WORKER_OPTS} \
+--templateLocation=${TEMPLATE_LOCATION} \
+--stagingLocation=${STAGE_LOCATION} \
+--tempLocation=${TEMP_LOCATION}"
+
+cd "$(dirname "$0")/.."
+
+# Create dir to cache maven dependencies if it doesn't already exist.
+mkdir -p ~/.m2
+
+# Run mvn with a non-root user id
+# https://docs.docker.com/samples/library/maven/#Running-as-non-root
+docker run -v ~/.m2:/var/maven/.m2 --rm -u $UID \
+  -v $PWD:/var/maven/project -w /var/maven/project \
+  -e MAVEN_CONFIG=/var/maven/.m2 maven mvn \
+  -Duser.home=/var/maven \
+  compile exec:java -Dexec.mainClass=$JOB_CLASS -Dexec.args="$COMPILE_OPTIONS"


### PR DESCRIPTION
This script is used by jenkins to build templates, though it should also work when run locally. Having the script live in this repo is slightly more convenient than the cloudops-infra repo, as it avoids a copy.