### PR TITLE
Add namespace/docType aliasing

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -58,7 +58,8 @@ public class Decoder extends Sink {
         .apply(options.getInputType().read(options)).errorsTo(errorCollections) //
         .apply(ParseUri.of()).errorsTo(errorCollections) //
         .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())) //
-        .apply(ParsePayload.of(options.getSchemasLocation())).errorsTo(errorCollections) //
+        .apply(ParsePayload.of(options.getSchemasLocation(), options.getSchemaAliasesLocation())) //
+        .errorsTo(errorCollections) //
         .apply(ParseProxy.of()) //
         .apply(GeoCityLookup.of(options.getGeoCityDatabase(), options.getGeoCityFilter())) //
         .apply(ParseUserAgent.of()) //

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/DecoderOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/DecoderOptions.java
@@ -45,6 +45,13 @@ public interface DecoderOptions extends SinkOptions, PipelineOptions {
 
   void setSchemasLocation(ValueProvider<String> value);
 
+  @Description("Path (local or gs://) to a .json file containing list of json schema aliases."
+      + " Example file: schemaAliasing/example-aliasing-config.json"
+      + " If not specified, no schemas will be aliased.")
+  ValueProvider<String> getSchemaAliasesLocation();
+
+  void setSchemaAliasesLocation(ValueProvider<String> value);
+
   @Description("Source of messages to mark as seen for deduplication. Allowed sources are:"
       + " pubsub (mark messages as seen from --deliveredMessagesSubscription),"
       + " immediate (mark messages as seen without waiting for delivery),"

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -31,8 +31,9 @@ import org.json.JSONObject;
  */
 public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMessage> {
 
-  public static ParsePayload of(ValueProvider<String> schemasLocation) {
-    return new ParsePayload(schemasLocation);
+  public static ParsePayload of(ValueProvider<String> schemasLocation,
+      ValueProvider<String> schemaAliasesLocation) {
+    return new ParsePayload(schemasLocation, schemaAliasesLocation);
   }
 
   ////////
@@ -43,12 +44,15 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
       "json_validate_millis");
 
   private final ValueProvider<String> schemasLocation;
+  private final ValueProvider<String> schemaAliasesLocation;
 
   private transient Validator validator;
   private transient JSONSchemaStore schemaStore;
 
-  private ParsePayload(ValueProvider<String> schemasLocation) {
+  private ParsePayload(ValueProvider<String> schemasLocation,
+      ValueProvider<String> schemaAliasesLocation) {
     this.schemasLocation = schemasLocation;
+    this.schemaAliasesLocation = schemaAliasesLocation;
   }
 
   @Override
@@ -58,7 +62,7 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
     Map<String, String> attributes = new HashMap<>(message.getAttributeMap());
 
     if (schemaStore == null) {
-      schemaStore = JSONSchemaStore.of(schemasLocation);
+      schemaStore = JSONSchemaStore.of(schemasLocation, schemaAliasesLocation);
     }
 
     final int submissionBytes = message.getPayload().length;

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/AvroSchemaStore.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/AvroSchemaStore.java
@@ -17,7 +17,7 @@ public class AvroSchemaStore extends SchemaStore<Schema> {
   }
 
   protected AvroSchemaStore(ValueProvider<String> schemasLocation) {
-    super(schemasLocation);
+    super(schemasLocation, null);
   }
 
   @Override

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/JSONSchemaStore.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/JSONSchemaStore.java
@@ -16,13 +16,18 @@ import org.json.JSONObject;
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class JSONSchemaStore extends SchemaStore<Schema> {
 
-  /** Returns a SchemaStore based on the contents of the archive at schemasLocation. */
-  public static JSONSchemaStore of(ValueProvider<String> schemasLocation) {
-    return new JSONSchemaStore(schemasLocation);
+  /**
+   * Returns a SchemaStore based on the contents of the archive at schemasLocation
+   * with additional schemas aliased according to configuration.
+   */
+  public static JSONSchemaStore of(ValueProvider<String> schemasLocation,
+      ValueProvider<String> schemaAliasesLocation) {
+    return new JSONSchemaStore(schemasLocation, schemaAliasesLocation);
   }
 
-  protected JSONSchemaStore(ValueProvider<String> schemasLocation) {
-    super(schemasLocation);
+  protected JSONSchemaStore(ValueProvider<String> schemasLocation,
+      ValueProvider<String> schemaAliasesLocation) {
+    super(schemasLocation, schemaAliasesLocation);
   }
 
   @Override

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/SchemaAlias.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/SchemaAlias.java
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.schemas;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+abstract class SchemaAlias {
+
+  @JsonCreator
+  static SchemaAlias create(@JsonProperty(value = "base", required = true) String base,
+      @JsonProperty(value = "alias", required = true) String alias) {
+    return new AutoValue_SchemaAlias(base, alias);
+  }
+
+  abstract String base();
+
+  abstract String alias();
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/SchemaAliasingConfiguration.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/SchemaAliasingConfiguration.java
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.schemas;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import java.util.List;
+
+@AutoValue
+abstract class SchemaAliasingConfiguration {
+
+  @JsonCreator
+  static SchemaAliasingConfiguration create(
+      @JsonProperty(value = "aliases", required = true) List<SchemaAlias> aliases) {
+    return new AutoValue_SchemaAliasingConfiguration(aliases);
+  }
+
+  abstract List<SchemaAlias> aliases();
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/StorageIntegrationTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/StorageIntegrationTest.java
@@ -125,12 +125,15 @@ public class StorageIntegrationTest {
   public void testCompileDataflowTemplate() throws Exception {
     String gcsPath = "gs://" + bucket;
 
+    String aliases = "src/test/resources/schemaAliasing/example-aliasing-config.json";
+
     Decoder.main(new String[] { "--runner=Dataflow", "--project=" + projectId,
         "--templateLocation=" + gcsPath + "/templates/TestTemplate",
         "--stagingLocation=" + gcsPath + "/temp/staging", "--inputFileFormat=json",
         "--inputType=file", "--outputFileFormat=json", "--outputType=file",
         "--errorOutputType=file", "--geoCityDatabase=GeoLite2-City.mmdb",
-        "--schemasLocation=schemas.tar.gz", "--seenMessagesSource=none" });
+        "--schemasLocation=schemas.tar.gz", "--schemaAliasesLocation=" + aliases,
+        "--seenMessagesSource=none" });
 
   }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/schemas/JSONSchemaStoreTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/schemas/JSONSchemaStoreTest.java
@@ -5,6 +5,7 @@
 package com.mozilla.telemetry.schemas;
 
 import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -12,16 +13,22 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+import org.everit.json.schema.Schema;
 import org.junit.Test;
 
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class JSONSchemaStoreTest {
 
-  private static final ValueProvider<String> LOCATION = StaticValueProvider.of("schemas.tar.gz");
+  private static final ValueProvider<String> SCHEMAS_LOCATION = StaticValueProvider
+      .of("schemas.tar.gz");
+  private static final ValueProvider<String> EMPTY_ALIASING_CONFIG_LOCATION = StaticValueProvider
+      .of(null);
+  private static final ValueProvider<String> ALIASING_CONFIG_LOCATION = StaticValueProvider
+      .of("src/test/resources/schemaAliasing/example-aliasing-config.json");
 
   @Test
   public void testNumSchemas() {
-    JSONSchemaStore store = JSONSchemaStore.of(LOCATION);
+    JSONSchemaStore store = JSONSchemaStore.of(SCHEMAS_LOCATION, EMPTY_ALIASING_CONFIG_LOCATION);
     // At time of writing this test, there were 47 schemas to load, but that number will
     // likely increase over time.
     assertThat(store.numLoadedSchemas(), greaterThan(40));
@@ -29,18 +36,44 @@ public class JSONSchemaStoreTest {
 
   @Test
   public void testDocTypeExists() {
-    JSONSchemaStore store = JSONSchemaStore.of(LOCATION);
+    JSONSchemaStore store = JSONSchemaStore.of(SCHEMAS_LOCATION, EMPTY_ALIASING_CONFIG_LOCATION);
     assertTrue(store.docTypeExists("telemetry", "main"));
     assertTrue(store.docTypeExists("telemetry", "update"));
   }
 
   @Test
   public void testDocTypeExistsViaAttributes() {
-    JSONSchemaStore store = JSONSchemaStore.of(LOCATION);
+    JSONSchemaStore store = JSONSchemaStore.of(SCHEMAS_LOCATION, EMPTY_ALIASING_CONFIG_LOCATION);
     Map<String, String> attributes = new HashMap<>();
     attributes.put("document_namespace", "telemetry");
     attributes.put("document_type", "main");
     assertTrue(store.docTypeExists(attributes));
   }
 
+  @Test
+  public void testAliasedDocTypeExists() {
+    JSONSchemaStore store = JSONSchemaStore.of(SCHEMAS_LOCATION, ALIASING_CONFIG_LOCATION);
+    assertTrue(store.docTypeExists("some-product", "baseline"));
+    assertTrue(store.docTypeExists("glean", "baseline"));
+    assertTrue(store.docTypeExists("some-product", "some-doctype"));
+    assertTrue(store.docTypeExists("glean", "metrics"));
+  }
+
+  @Test
+  public void testAliasedSchemaExistsViaAttributes() throws SchemaNotFoundException {
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("document_namespace", "glean");
+    attributes.put("document_type", "baseline");
+    attributes.put("document_version", "1");
+
+    Map<String, String> aliasedAttributes = new HashMap<>();
+    aliasedAttributes.put("document_namespace", "some-product");
+    aliasedAttributes.put("document_type", "baseline");
+    aliasedAttributes.put("document_version", "1");
+
+    JSONSchemaStore store = JSONSchemaStore.of(SCHEMAS_LOCATION, ALIASING_CONFIG_LOCATION);
+    Schema baseSchema = store.getSchema(attributes);
+    Schema aliasedSchema = store.getSchema(aliasedAttributes);
+    assertEquals(baseSchema, aliasedSchema);
+  }
 }

--- a/ingestion-beam/src/test/resources/schemaAliasing/example-aliasing-config.json
+++ b/ingestion-beam/src/test/resources/schemaAliasing/example-aliasing-config.json
@@ -1,0 +1,12 @@
+{
+  "aliases": [
+    {
+      "alias": "some-product/baseline",
+      "base": "glean/baseline"
+    },
+    {
+      "alias": "some-product/some-doctype",
+      "base": "glean/metrics"
+    }
+  ]
+}


### PR DESCRIPTION
Adds support for namespace/docType aliases (https://github.com/mozilla/gcp-ingestion/issues/424).

Aliasing configuration is stored in json config file, to be loaded from GCS. Decoder should be redeployed on configuration changes, likewise on schema changes.
If configuration file is present, schemas will be aliased in the `SchemaStore`, transparently to the rest of the pipeline.