### PR TITLE
Remove SimpleDateFormat in favor of DateTimeFormatter

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseProxy.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseProxy.java
@@ -6,8 +6,8 @@ package com.mozilla.telemetry.decoder;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.mozilla.telemetry.transforms.PubsubConstraints;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -27,8 +27,6 @@ public class ParseProxy extends PTransform<PCollection<PubsubMessage>, PCollecti
 
   /////////
 
-  private static final SimpleDateFormat TIMESTAMP_FORMAT = new SimpleDateFormat(
-      "yyyy-MM-dd'T'hh:mm:ss.SSSSSS'Z'");
   private static final String PROXY_TIMESTAMP = "proxy_timestamp";
   private static final String SUBMISSION_TIMESTAMP = "submission_timestamp";
   private static final String X_FORWARDED_FOR = "x_forwarded_for";
@@ -55,8 +53,8 @@ public class ParseProxy extends PTransform<PCollection<PubsubMessage>, PCollecti
         // Check if X-Pipeline-Proxy is a timestamp
         boolean proxyIsTimestamp = true;
         try {
-          TIMESTAMP_FORMAT.parse(xpp);
-        } catch (ParseException ignore) {
+          DateTimeFormatter.ISO_INSTANT.parse(xpp);
+        } catch (DateTimeParseException ignore) {
           proxyIsTimestamp = false;
         }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseProxyTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseProxyTest.java
@@ -37,6 +37,9 @@ public class ParseProxyTest {
             + "{\"x_pipeline_proxy\":1" //
             + "},\"payload\":\"proxied+\"}",
         "{\"attributeMap\":" //
+            + "{\"x_pipeline_proxy\":\"\"" //
+            + "},\"payload\":\"emptyXPP\"}",
+        "{\"attributeMap\":" //
             + "{\"submission_timestamp\":\"2000-01-01T00:00:00.000000Z\"" //
             + ",\"x_forwarded_for\":\"3, 2, 1\"" //
             + "},\"payload\":\"notProxied++\"}",
@@ -54,6 +57,7 @@ public class ParseProxyTest {
     final List<String> expected = Arrays.asList(//
         "{\"attributeMap\":{},\"payload\":\"\"}", //
         "{\"attributeMap\":{},\"payload\":\"proxied+\"}", //
+        "{\"attributeMap\":{},\"payload\":\"emptyXPP\"}", //
         "{\"attributeMap\":" //
             + "{\"submission_timestamp\":\"2000-01-01T00:00:00.000000Z\"" //
             + ",\"x_forwarded_for\":\"3, 2, 1\"" //


### PR DESCRIPTION
It appears that SimpleDateFormat's parse method can throw a number
of undocumented exceptions which bubbled up in the Decoder.
I expect the newer java.time library to be more stable and more
thoroughly tested.

Fixes #513