### PR TITLE
Use the correct schema suffix when retrieving avro schemas

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/AvroSchemaStore.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/AvroSchemaStore.java
@@ -12,12 +12,14 @@ import org.apache.commons.compress.archivers.ArchiveInputStream;
 public class AvroSchemaStore extends SchemaStore<Schema> {
 
   /** Returns a SchemaStore based on the contents of the archive at schemasLocation. */
-  public static AvroSchemaStore of(ValueProvider<String> schemasLocation) {
-    return new AvroSchemaStore(schemasLocation);
+  public static AvroSchemaStore of(ValueProvider<String> schemasLocation,
+      ValueProvider<String> schemaAliasesLocation) {
+    return new AvroSchemaStore(schemasLocation, schemaAliasesLocation);
   }
 
-  protected AvroSchemaStore(ValueProvider<String> schemasLocation) {
-    super(schemasLocation, null);
+  protected AvroSchemaStore(ValueProvider<String> schemasLocation,
+      ValueProvider<String> schemaAliasesLocation) {
+    super(schemasLocation, schemaAliasesLocation);
   }
 
   @Override

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/AvroSchemaStore.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/AvroSchemaStore.java
@@ -21,8 +21,8 @@ public class AvroSchemaStore extends SchemaStore<Schema> {
   }
 
   @Override
-  protected boolean containsSchemaSuffix(String name) {
-    return name.endsWith(".avro.json");
+  protected String schemaSuffix() {
+    return ".avro.json";
   }
 
   @Override

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/JSONSchemaStore.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/JSONSchemaStore.java
@@ -31,8 +31,8 @@ public class JSONSchemaStore extends SchemaStore<Schema> {
   }
 
   @Override
-  protected boolean containsSchemaSuffix(String name) {
-    return name.endsWith(".schema.json");
+  protected String schemaSuffix() {
+    return ".schema.json";
   }
 
   @Override

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/SchemaStore.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/SchemaStore.java
@@ -52,8 +52,8 @@ public abstract class SchemaStore<T> implements Serializable {
     }
     // This is the path provided by mozilla-pipeline-schemas
     final String path = StringSubstitutor.replace(
-        "${document_namespace}/${document_type}/" + "${document_type}.${document_version}",
-        attributes) + schemaSuffix();
+        "${document_namespace}/${document_type}/${document_type}.${document_version}", attributes)
+        + schemaSuffix();
     return getSchema(path);
   }
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/SchemaStore.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/SchemaStore.java
@@ -51,8 +51,9 @@ public abstract class SchemaStore<T> implements Serializable {
       throw new SchemaNotFoundException("No schema for message with null attributeMap");
     }
     // This is the path provided by mozilla-pipeline-schemas
-    final String path = StringSubstitutor.replace("${document_namespace}/${document_type}/"
-        + "${document_type}.${document_version}.schema.json", attributes);
+    final String path = StringSubstitutor.replace(
+        "${document_namespace}/${document_type}/" + "${document_type}.${document_version}",
+        attributes) + schemaSuffix();
     return getSchema(path);
   }
 
@@ -81,8 +82,8 @@ public abstract class SchemaStore<T> implements Serializable {
     this.schemaAliasesLocation = schemaAliasesLocation;
   }
 
-  /* Returns true on a valid schema name e.g. `document.schema.json` */
-  protected abstract boolean containsSchemaSuffix(String name);
+  /* Returns the expected suffix for a particular schema type e.g. `.schema.json` */
+  protected abstract String schemaSuffix();
 
   /* Returns a parsed schema from an archive input stream. */
   protected abstract T loadSchemaFromArchive(ArchiveInputStream archive) throws IOException;
@@ -130,7 +131,7 @@ public abstract class SchemaStore<T> implements Serializable {
             tempDirs.add(name);
             continue;
           }
-          if (containsSchemaSuffix(name)) {
+          if (name.endsWith(schemaSuffix())) {
             tempSchemas.put(name, loadSchemaFromArchive(i));
           }
         }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/schemas/AvroSchemaStoreTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/schemas/AvroSchemaStoreTest.java
@@ -35,16 +35,18 @@ public class AvroSchemaStoreTest {
   */
   private static final ValueProvider<String> LOCATION = StaticValueProvider
       .of(Resources.getResource("avro/test-schema.tar.gz").getPath());
+  private static final ValueProvider<String> EMPTY_ALIASING_CONFIG_LOCATION = StaticValueProvider
+      .of(null);
 
   @Test
   public void testNumSchemas() {
-    AvroSchemaStore store = AvroSchemaStore.of(LOCATION);
+    AvroSchemaStore store = AvroSchemaStore.of(LOCATION, EMPTY_ALIASING_CONFIG_LOCATION);
     assertEquals(store.numLoadedSchemas(), 3);
   }
 
   @Test
   public void testDocTypeExists() {
-    AvroSchemaStore store = AvroSchemaStore.of(LOCATION);
+    AvroSchemaStore store = AvroSchemaStore.of(LOCATION, EMPTY_ALIASING_CONFIG_LOCATION);
     assertTrue(store.docTypeExists("namespace_0", "foo"));
     assertTrue(store.docTypeExists("namespace_0", "bar"));
     assertTrue(store.docTypeExists("namespace_1", "baz"));
@@ -52,7 +54,7 @@ public class AvroSchemaStoreTest {
 
   @Test
   public void testDocTypeExistsViaAttributes() {
-    AvroSchemaStore store = AvroSchemaStore.of(LOCATION);
+    AvroSchemaStore store = AvroSchemaStore.of(LOCATION, EMPTY_ALIASING_CONFIG_LOCATION);
     Map<String, String> attributes = new HashMap<>();
     attributes.put("document_namespace", "namespace_0");
     attributes.put("document_type", "foo");
@@ -61,7 +63,7 @@ public class AvroSchemaStoreTest {
 
   @Test
   public void testGetSchemaViaAttributes() throws SchemaNotFoundException {
-    AvroSchemaStore store = AvroSchemaStore.of(LOCATION);
+    AvroSchemaStore store = AvroSchemaStore.of(LOCATION, EMPTY_ALIASING_CONFIG_LOCATION);
     Map<String, String> attributes = new HashMap<>();
     attributes.put("document_namespace", "namespace_0");
     attributes.put("document_type", "foo");
@@ -73,7 +75,7 @@ public class AvroSchemaStoreTest {
 
   @Test
   public void testGetSchemaViaPath() throws SchemaNotFoundException {
-    AvroSchemaStore store = AvroSchemaStore.of(LOCATION);
+    AvroSchemaStore store = AvroSchemaStore.of(LOCATION, EMPTY_ALIASING_CONFIG_LOCATION);
     Schema schema = store.getSchema("namespace_0/foo/foo.1.avro.json");
     assertEquals(schema.getField("test_int").schema().getType(), Schema.Type.INT);
   }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/schemas/AvroSchemaStoreTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/schemas/AvroSchemaStoreTest.java
@@ -8,8 +8,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.io.Resources;
+import com.mozilla.telemetry.schemas.SchemaNotFoundException;
+
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.avro.Schema;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.junit.Test;
@@ -54,6 +57,25 @@ public class AvroSchemaStoreTest {
     attributes.put("document_namespace", "namespace_0");
     attributes.put("document_type", "foo");
     assertTrue(store.docTypeExists(attributes));
+  }
+
+  @Test
+  public void testGetSchemaViaAttributes() throws SchemaNotFoundException {
+    AvroSchemaStore store = AvroSchemaStore.of(LOCATION);
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("document_namespace", "namespace_0");
+    attributes.put("document_type", "foo");
+    attributes.put("document_version", "1");
+    Schema schema = store.getSchema(attributes);
+    assertEquals(schema.getField("test_int").schema().getType(), Schema.Type.INT);
+
+  }
+
+  @Test
+  public void testGetSchemaViaPath() throws SchemaNotFoundException {
+    AvroSchemaStore store = AvroSchemaStore.of(LOCATION);
+    Schema schema = store.getSchema("namespace_0/foo/foo.1.avro.json");
+    assertEquals(schema.getField("test_int").schema().getType(), Schema.Type.INT);
   }
 
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/schemas/JSONSchemaStoreTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/schemas/JSONSchemaStoreTest.java
@@ -76,4 +76,23 @@ public class JSONSchemaStoreTest {
     Schema aliasedSchema = store.getSchema(aliasedAttributes);
     assertEquals(baseSchema, aliasedSchema);
   }
+
+  @Test
+  public void testGetSchemaViaAttributes() throws SchemaNotFoundException {
+    JSONSchemaStore store = JSONSchemaStore.of(SCHEMAS_LOCATION, ALIASING_CONFIG_LOCATION);
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("document_namespace", "telemetry");
+    attributes.put("document_type", "main");
+    attributes.put("document_version", "4");
+    Schema schema = store.getSchema(attributes);
+    assertTrue(schema.definesProperty("clientId"));
+
+  }
+
+  @Test
+  public void testGetSchemaViaPath() throws SchemaNotFoundException {
+    JSONSchemaStore store = JSONSchemaStore.of(SCHEMAS_LOCATION, ALIASING_CONFIG_LOCATION);
+    Schema schema = store.getSchema("telemetry/main/main.4.schema.json");
+    assertTrue(schema.definesProperty("clientId"));
+  }
 }


### PR DESCRIPTION
This fixes a bug with the SchemaStore where the wrong path is provided when fetching a schema. This adds failing tests and a patch for fixing the tests.

Additionally, this updates the AvroSchemaStore to take advantage of schema aliasing.