### PR TITLE
Add stream-specific republisher configuration for templates

### DIFF
--- a/ingestion-beam/bin/build-template
+++ b/ingestion-beam/bin/build-template
@@ -54,10 +54,10 @@ elif [[ $JOB_TYPE == "decoder" ]] ; then
   OUTPUT_OPTS="--outputType=pubsub \
 --outputFileFormat=json"
   ERROR_OUTPUT_OPTS="--errorOutputType=pubsub"
-elif [[ $JOB_TYPE == "republisher" ]] ; then
+elif [[ $JOB_TYPE =~ ^republisher_(structured|telemetry)$ ]] ; then
   JOB_CLASS="com.mozilla.telemetry.Republisher"
   OUTPUT_OPTS="--outputType=pubsub \
---outputFileFormat=json"
+--outputFileFormat=json ${SINK_OPTS} ${REPUBLISHER_OPTS:?}"
   ERROR_OUTPUT_OPTS="--errorOutputType=file \
 --errorOutputNumShards=${ERROR_NUM_SHARDS}"
 else


### PR DESCRIPTION
Republisher requires some compile-time options so this needs to be a bit more flexible.