### PR TITLE
Calculate sample_id in the Decoder

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/republisher/RandomSampler.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/republisher/RandomSampler.java
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.republisher;
+
+import java.util.concurrent.ThreadLocalRandom;
+import javax.annotation.Nullable;
+
+public class RandomSampler {
+
+  /**
+   * If the given sampleIdString is convertible to an integer between 0 and 99,
+   * return whether the integer is less than {@code int(100 * ratio)}.
+   * Otherwise, generate a random number between 0 and 1 and return whether the generated number
+   * is less then the passed ratio.
+   */
+  public static boolean filterBySampleIdOrRandomNumber(@Nullable String sampleIdString,
+      Double ratio) {
+    Long sampleId = null;
+    if (sampleIdString != null) {
+      try {
+        sampleId = Long.valueOf(sampleIdString);
+      } catch (NumberFormatException ignore) {
+        // pass
+      }
+    }
+    return filterBySampleIdOrRandomNumber(sampleId, ratio);
+  }
+
+  /**
+   * If the given sampleId is between 0 and 99,
+   * return whether the integer is less than {@code int(100 * ratio)}.
+   * Otherwise, generate a random number between 0 and 1 and return whether the generated number
+   * is less then the passed ratio.
+   */
+  public static boolean filterBySampleIdOrRandomNumber(@Nullable Long sampleId, Double ratio) {
+    if (sampleId != null && sampleId >= 0 && sampleId < 100) {
+      long maxPercentile = Math.round(ratio * 100);
+      return sampleId < maxPercentile;
+    } else {
+      return ThreadLocalRandom.current().nextDouble() < ratio;
+    }
+  }
+
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/RepublisherMainTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/RepublisherMainTest.java
@@ -118,10 +118,10 @@ public class RepublisherMainTest {
     assertThat(outputLinesNightly, Matchers.hasSize(0));
 
     List<String> outputLinesRelease = Lines.files(outputPath + "/out-release*.ndjson");
-    assertThat("50% random sample of 20 should be greater than 5", outputLinesRelease.size(),
-        Matchers.greaterThan(5));
-    assertThat("50% random sample of 20 should be less than 15", outputLinesRelease.size(),
-        Matchers.lessThan(15));
+    assertThat("50% random sample of 20 elements should produce at least 2",
+        outputLinesRelease.size(), Matchers.greaterThanOrEqualTo(2));
+    assertThat("50% random sample of 20 elements should produce at most 18",
+        outputLinesRelease.size(), Matchers.lessThanOrEqualTo(18));
   }
 
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
@@ -4,6 +4,8 @@
 
 package com.mozilla.telemetry.decoder;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableMap;
 import com.mozilla.telemetry.options.InputFileFormat;
 import com.mozilla.telemetry.options.OutputFileFormat;
@@ -26,6 +28,16 @@ public class ParsePayloadTest {
 
   @Rule
   public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testSampleId() {
+    ValueProvider<String> schemasLocation = pipeline.newProvider("schemas.tar.gz");
+    ValueProvider<String> schemaAliasesLocation = pipeline.newProvider(null);
+    ParsePayload transform = ParsePayload.of(schemasLocation, schemaAliasesLocation);
+    assertEquals(67L, transform.calculateSampleId("2907648d-711b-4e9f-94b5-52a2b40a44b1"));
+    assertEquals(17L, transform.calculateSampleId("90210716-99f8-0a4f-8119-9bfc16cd68a3"));
+    assertEquals(0L, transform.calculateSampleId(""));
+  }
 
   @Test
   public void testOutput() {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/republisher/RandomSamplerTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/republisher/RandomSamplerTest.java
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.republisher;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class RandomSamplerTest {
+
+  @Test
+  public void filterBySampleIdOrRandomNumber() {
+    assertTrue(RandomSampler.filterBySampleIdOrRandomNumber(0L, 0.01));
+    assertFalse(RandomSampler.filterBySampleIdOrRandomNumber(1L, 0.01));
+    assertFalse(RandomSampler.filterBySampleIdOrRandomNumber(99L, 0.01));
+
+    assertTrue(RandomSampler.filterBySampleIdOrRandomNumber(0L, 0.05));
+    assertTrue(RandomSampler.filterBySampleIdOrRandomNumber(4L, 0.05));
+    assertFalse(RandomSampler.filterBySampleIdOrRandomNumber(5L, 0.05));
+    assertFalse(RandomSampler.filterBySampleIdOrRandomNumber(99L, 0.05));
+
+    assertTrue(RandomSampler.filterBySampleIdOrRandomNumber(99L, 1.0));
+
+    assertTrue(RandomSampler.filterBySampleIdOrRandomNumber("0", 0.01));
+    assertFalse(RandomSampler.filterBySampleIdOrRandomNumber("1", 0.01));
+    assertFalse(RandomSampler.filterBySampleIdOrRandomNumber("99", 0.01));
+
+    assertFalse(RandomSampler.filterBySampleIdOrRandomNumber(-3L, 0.00));
+    assertFalse(RandomSampler.filterBySampleIdOrRandomNumber(400L, 0.00));
+    assertFalse(RandomSampler.filterBySampleIdOrRandomNumber("foo", 0.00));
+    assertFalse(RandomSampler.filterBySampleIdOrRandomNumber((String) null, 0.00));
+  }
+}


### PR DESCRIPTION
This calculates sample_id, adds to metadata, and pulls it out as a top-level field for BQ tables. It also leverages sample_id for stably sampling topics in Republisher.

The approach to top-level fields may change as the discussion evolves in the [ping metadata proposal](https://docs.google.com/document/d/1AsshL_QS1qRVXcHW5lz0jZeM-UKIWFl1oV3XJz7Xewo/edit#), but for now I'm sticking to the method that exists.