### PR TITLE
Add Normalize.countryCode

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/GeoCityLookup.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/GeoCityLookup.java
@@ -13,6 +13,7 @@ import com.maxmind.geoip2.model.CityResponse;
 import com.maxmind.geoip2.record.City;
 import com.maxmind.geoip2.record.Subdivision;
 import com.mozilla.telemetry.transforms.PubsubConstraints;
+import com.mozilla.telemetry.util.Normalize;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -123,7 +124,8 @@ public class GeoCityLookup
           CityResponse response = geoIP2City.city(ipAddress);
           foundCity.inc();
 
-          attributes.put("geo_country", response.getCountry().getIsoCode());
+          String countryCode = response.getCountry().getIsoCode();
+          attributes.put("geo_country", Normalize.countryCode(countryCode));
 
           City city = response.getCity();
           if (cityAllowed(city.getGeoNameId())) {

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/Normalize.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/Normalize.java
@@ -40,6 +40,7 @@ public class Normalize {
       "Firefox");
 
   private static final Pattern OS_VERSION_RE = Pattern.compile("([0-9]+(?:\\.[0-9]+){0,2}).*");
+  private static final Pattern COUNTRY_CODE_RE = Pattern.compile("[A-Z][A-Z]");
 
   /**
    * Normalize a channel string to one of the five canonical release channels or "Other".
@@ -122,6 +123,29 @@ public class Normalize {
       }
     }
     return OTHER;
+  }
+
+  /**
+   * Normalize a 2-letter country code value to uppercase, otherwise return "Other".
+   *
+   * <p>This function is intended to be used to normalize ISO 3166-1 alpha-2 codes, but we do not
+   * check that the code actually corresponds to an officially assigned country so that we don't
+   * need to worry about our list of codes drifting out of date. The space of two-letter codes
+   * (26 * 26 = 676) is sufficiently small that the impact of invalid codes would likely be small.
+   *
+   * <p>See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+   *
+   * <p>Previous implementation with a fixed list of allowable codes:
+   * https://github.com/mozilla-services/lua_sandbox_extensions/blob/607b3c7b9def600ddbd373a14f67a55e1c69f7a1/moz_telemetry/modules/moz_telemetry/normalize.lua#L233-L268
+   */
+  public static String countryCode(String code) {
+    code = Strings.nullToEmpty(code).toUpperCase();
+    Matcher matcher = COUNTRY_CODE_RE.matcher(code);
+    if (matcher.matches()) {
+      return code;
+    } else {
+      return OTHER;
+    }
   }
 
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/util/NormalizeTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/util/NormalizeTest.java
@@ -114,4 +114,13 @@ public class NormalizeTest {
     assertEquals("Other", Normalize.appName(null));
   }
 
+  @Test
+  public void countryCode() {
+    assertEquals("FI", Normalize.countryCode("FI"));
+    assertEquals("FI", Normalize.countryCode("fi"));
+    assertEquals("Other", Normalize.countryCode("FII"));
+    assertEquals("Other", Normalize.countryCode("asdf"));
+    assertEquals("Other", Normalize.countryCode(null));
+  }
+
 }


### PR DESCRIPTION
Follow-up to #478

We will likely add a top-level "normalized_country_code" attribute next
week as part of a cohesive strategy for building a nested metadata struct
and top-level metadata fields. For now, we're immediately normalizing the value
we get from geo lookup.