### PR TITLE
Transform json map fields to arrays before output to BigQuery

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -11,19 +11,31 @@ import com.google.api.services.bigquery.model.TimePartitioning;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Field.Mode;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.Table;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.mozilla.telemetry.util.Json;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers;
 import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
@@ -39,9 +51,8 @@ import org.apache.commons.text.StringSubstitutor;
  * Parses JSON payloads using Google's JSON API model library, emitting a BigQuery-specific
  * TableRow.
  *
- * <p>We also perform some light manipulation of the parsed JSON to match details of our table
- * schemas in BigQuery. In particular, we pull out submission_timestamp to a top level field so we
- * can use it as our partitioning field.
+ * <p>We also perform some manipulation of the parsed JSON to match details of our table
+ * schemas in BigQuery.
  */
 public class PubsubMessageToTableRow
     extends MapElementsWithErrors<PubsubMessage, KV<TableDestination, TableRow>> {
@@ -56,8 +67,9 @@ public class PubsubMessageToTableRow
 
   private final ValueProvider<String> tableSpecTemplate;
 
-  // We'll instantiate this on first use.
+  // We'll instantiate these on first use.
   private transient Cache<DatasetReference, Set<String>> tableListingCache;
+  private transient Cache<TableReference, Schema> tableSchemaCache;
 
   private PubsubMessageToTableRow(ValueProvider<String> tableSpecTemplate) {
     this.tableSpecTemplate = tableSpecTemplate;
@@ -98,7 +110,9 @@ public class PubsubMessageToTableRow
             .getService();
         Dataset dataset = service.getDataset(ref.getDatasetId());
         if (dataset != null) {
-          dataset.list().iterateAll().forEach(t -> tableSet.add(t.getTableId().getTable()));
+          dataset.list().iterateAll().forEach(t -> {
+            tableSet.add(t.getTableId().getTable());
+          });
         }
         return tableSet;
       });
@@ -115,7 +129,30 @@ public class PubsubMessageToTableRow
       throw new IllegalArgumentException("Resolved destination table does not exist: " + tableSpec);
     }
 
+    // Get and cache the BQ schema for this table.
+    Schema schema = null;
+    if (tableSchemaCache == null) {
+      tableSchemaCache = CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(1)).build();
+    }
+    try {
+      schema = tableSchemaCache.get(ref, () -> {
+        BigQuery service = BigQueryOptions.newBuilder().setProjectId(ref.getProjectId()).build()
+            .getService();
+        Table table = service.getTable(ref.getDatasetId(), ref.getTableId());
+        if (table != null) {
+          return table.getDefinition().getSchema();
+        } else {
+          return null;
+        }
+      });
+    } catch (ExecutionException e) {
+      throw new UncheckedExecutionException(e);
+    }
+
     TableRow tableRow = buildTableRow(message.getPayload());
+    Map<String, Object> additionalProperties = new HashMap<>();
+    transformForBqSchema(tableRow, schema.getFields(), additionalProperties);
+    tableRow.put("additional_properties", Json.asString(additionalProperties));
     return KV.of(tableDestination, tableRow);
   }
 
@@ -155,6 +192,113 @@ public class PubsubMessageToTableRow
           // pass
         }
       }
+    }
+  }
+
+  /**
+   * Recursively descend into the fields of the passed map, comparing to the passed BQ schema,
+   * modifying the structure to avoid map types, nested arrays, etc.
+   *
+   * @param parent the map object to inspect and transform
+   * @param bqFields the list of BQ fields expected inside this object
+   * @param additionalProperties a map into which we place any fields absent from the BQ schema
+   */
+  public static void transformForBqSchema(Map<String, Object> parent, List<Field> bqFields,
+      Map<String, Object> additionalProperties) {
+
+    // Clean the key names.
+    ImmutableSet.copyOf(parent.keySet()).forEach(rawKey -> {
+      String key = rawKey;
+      if (key.contains(".") || key.contains("-")) {
+        key = key.replace(".", "_").replace("-", "_");
+      }
+      if (Character.isDigit(key.charAt(0))) {
+        key = "_" + key;
+      }
+      parent.put(key, parent.remove(rawKey));
+    });
+
+    // Populate additionalProperties.
+    Set<String> fieldNames = bqFields.stream().map(Field::getName).collect(Collectors.toSet());
+    ImmutableSet.copyOf(Sets.difference(parent.keySet(), fieldNames))
+        .forEach(k -> additionalProperties.put(k, parent.remove(k)));
+
+    // Special transformations for structures disallowed in BigQuery.
+    bqFields.forEach(field -> {
+      String name = field.getName();
+      Optional<Object> value = Optional.ofNullable(parent.get(name));
+
+      // A repeated string field might need us to JSON-ify a list or map.
+      if (field.getType() == LegacySQLTypeName.STRING && field.getMode() == Mode.REPEATED) {
+
+        value.filter(List.class::isInstance).map(List.class::cast).ifPresent(list -> {
+          List<Object> jsonified = ((List<Object>) list).stream().map(o -> coerceToString(o))
+              .collect(Collectors.toList());
+          parent.put(name, jsonified);
+        });
+
+        // A string field might need us to JSON-ify an object coerce a value to string.
+      } else if (field.getType() == LegacySQLTypeName.STRING && field.getMode() != Mode.REPEATED) {
+        value.ifPresent(o -> parent.put(name, coerceToString(o)));
+
+        // A record of key and value indicates we need to transformForBqSchema a map to an array.
+      } else if (field.getType() == LegacySQLTypeName.RECORD && field.getMode() == Mode.REPEATED //
+          && field.getSubFields().size() == 2 //
+          && field.getSubFields().get(0).getName().equals("key") //
+          && field.getSubFields().get(1).getName().equals("value")) {
+        value.filter(Map.class::isInstance).map(Map.class::cast).ifPresent(m -> {
+          Map<String, Object> map = m;
+          Field valueField = field.getSubFields().get(1);
+          if (valueField.getType() == LegacySQLTypeName.RECORD) {
+            Map<String, Object> props = new HashMap<>();
+            additionalProperties.put(name, props);
+            transformForBqSchema(map, valueField.getSubFields(), props);
+          }
+          List<Map<String, Object>> unmapped = map.entrySet().stream()
+              .map(entry -> ImmutableMap.of("key", entry.getKey(), "value",
+                  coerceIfStringExpected(entry.getValue(), valueField.getType())))
+              .collect(Collectors.toList());
+          parent.put(name, unmapped);
+        });
+
+        // We need to recursively call transformForBqSchema on any normal record type.
+      } else if (field.getType() == LegacySQLTypeName.RECORD && field.getMode() != Mode.REPEATED) {
+        value.filter(Map.class::isInstance).map(Map.class::cast).ifPresent(m -> {
+          Map<String, Object> props = new HashMap<>();
+          additionalProperties.put(name, props);
+          transformForBqSchema(m, field.getSubFields(), props);
+        });
+
+        // Likewise, we need to recursively call transformForBqSchema on repeated record types.
+      } else if (field.getType() == LegacySQLTypeName.RECORD && field.getMode() == Mode.REPEATED) {
+        List<Object> records = value.filter(List.class::isInstance).map(List.class::cast)
+            .orElse(ImmutableList.of());
+        records.stream().filter(Map.class::isInstance).map(Map.class::cast).forEach(record -> {
+          Map<String, Object> props = new HashMap<>();
+          additionalProperties.put(name, props);
+          transformForBqSchema(record, field.getSubFields(), props);
+        });
+      }
+    });
+  }
+
+  private static String coerceToString(Object o) {
+    if (o instanceof String) {
+      return (String) o;
+    } else {
+      try {
+        return Json.asString(o);
+      } catch (IOException ignore) {
+        return o.toString();
+      }
+    }
+  }
+
+  private static Object coerceIfStringExpected(Object o, LegacySQLTypeName typeName) {
+    if (typeName == LegacySQLTypeName.STRING) {
+      return coerceToString(o);
+    } else {
+      return o;
     }
   }
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -196,12 +196,12 @@ public class PubsubMessageToTableRow
   }
 
   /**
-   * Recursively descend into the fields of the passed map, comparing to the passed BQ schema,
-   * modifying the structure to avoid map types, nested arrays, etc.
+   * Recursively descend into the fields of the passed map and compare to the passed BQ schema,
+   * while modifying the structure to accommodate map types, nested arrays, etc.
    *
    * @param parent the map object to inspect and transform
-   * @param bqFields the list of BQ fields expected inside this object
-   * @param additionalProperties a map into which we place any fields absent from the BQ schema
+   * @param bqFields the list of expected BQ fields inside this object
+   * @param additionalProperties a map for storing fields absent in the BQ schema
    */
   public static void transformForBqSchema(Map<String, Object> parent, List<Field> bqFields,
       Map<String, Object> additionalProperties) {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
@@ -6,11 +6,30 @@ package com.mozilla.telemetry.transforms;
 
 import static org.junit.Assert.assertEquals;
 
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Field.Mode;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.mozilla.telemetry.util.Json;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 
 public class PubsubMessageToTableRowTest {
+
+  static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+
+  static final Field MAP_FIELD = Field //
+      .newBuilder("mapfield", LegacySQLTypeName.RECORD, //
+          Field.of("key", LegacySQLTypeName.STRING), //
+          Field.of("value", LegacySQLTypeName.INTEGER)) //
+      .setMode(Mode.REPEATED).build();
 
   @Test
   public void testBuildTableRow() throws Exception {
@@ -21,6 +40,114 @@ public class PubsubMessageToTableRowTest {
     TableRow tableRow = PubsubMessageToTableRow.buildTableRow(input.getBytes());
     tableRow.setFactory(new JacksonFactory());
     assertEquals(expected, tableRow.toString());
+  }
+
+  @Test
+  public void testCoerceNestedArrayToJsonString() throws Exception {
+    Map<String, Object> parent = new HashMap<>();
+    parent.put("events", Arrays.asList(Arrays.asList("hi", "there")));
+    List<Field> bqFields = ImmutableList
+        .of(Field.newBuilder("events", LegacySQLTypeName.STRING).setMode(Mode.REPEATED).build());
+    String expected = "{\"events\":[\"[\\\"hi\\\",\\\"there\\\"]\"]}";
+    PubsubMessageToTableRow.transformForBqSchema(parent, bqFields, null);
+    assertEquals(expected, Json.asString(parent));
+  }
+
+  @Test
+  public void testCoerceEmptyObjectToJsonString() throws Exception {
+    Map<String, Object> parent = new HashMap<>();
+    parent.put("payload", new HashMap<>());
+    List<Field> bqFields = ImmutableList.of(Field.of("payload", LegacySQLTypeName.STRING));
+    String expected = "{\"payload\":\"{}\"}";
+    PubsubMessageToTableRow.transformForBqSchema(parent, bqFields, null);
+    assertEquals(expected, Json.asString(parent));
+  }
+
+  @Test
+  public void testCoerceIntToString() throws Exception {
+    Map<String, Object> parent = new HashMap<>();
+    parent.put("payload", 3);
+    List<Field> bqFields = ImmutableList.of(Field.of("payload", LegacySQLTypeName.STRING));
+    String expected = "{\"payload\":\"3\"}";
+    PubsubMessageToTableRow.transformForBqSchema(parent, bqFields, null);
+    assertEquals(expected, Json.asString(parent));
+  }
+
+  @Test
+  public void testCoerceMapValueToString() throws Exception {
+    String mainPing = "{\"payload\":{\"processes\":{\"parent\":{\"scalars\":"
+        + "{\"timestamps.first_paint\":5405}}}}}";
+    Map<String, Object> parent = JSON_FACTORY.fromString(mainPing, Map.class);
+    Map<String, Object> additionalProperties = new HashMap<>();
+    parent.put("64bit", true);
+    parent.put("hi-fi", true);
+    List<Field> bqFields = ImmutableList.of(Field.of("payload", LegacySQLTypeName.RECORD,
+        Field.of("processes", LegacySQLTypeName.RECORD,
+            Field.of("parent", LegacySQLTypeName.RECORD,
+                Field.newBuilder("scalars", LegacySQLTypeName.RECORD, //
+                    Field.of("key", LegacySQLTypeName.STRING), //
+                    Field.of("value", LegacySQLTypeName.STRING)) //
+                    .setMode(Mode.REPEATED).build()))));
+    String expected = "{\"payload\":{\"processes\":{\"parent\":{\"scalars\":"
+        + "[{\"key\":\"timestamps.first_paint\",\"value\":\"5405\"}]}}}}";
+    PubsubMessageToTableRow.transformForBqSchema(parent, bqFields, additionalProperties);
+    assertEquals(expected, Json.asString(parent));
+  }
+
+  @Test
+  public void testUnmap() throws Exception {
+    Map<String, Object> parent = new HashMap<>();
+    Map<String, Object> additionalProperties = new HashMap<>();
+    parent.put("mapfield", new HashMap<>(ImmutableMap.of("foo", 3, "bar", 4)));
+    List<Field> bqFields = ImmutableList.of(MAP_FIELD);
+    String expected = "{\"mapfield\":"
+        + "[{\"key\":\"bar\",\"value\":4},{\"key\":\"foo\",\"value\":3}]}";
+    PubsubMessageToTableRow.transformForBqSchema(parent, bqFields, additionalProperties);
+    assertEquals(expected, Json.asString(parent));
+  }
+
+  @Test
+  public void testNestedUnmap() throws Exception {
+    Map<String, Object> parent = new HashMap<>();
+    Map<String, Object> additionalProperties = new HashMap<>();
+    parent.put("outer", new HashMap<>(ImmutableMap.of("otherfield", 3, //
+        "mapfield", new HashMap<>(ImmutableMap.of("foo", 3, "bar", 4)))));
+    List<Field> bqFields = ImmutableList.of(Field.of("outer", LegacySQLTypeName.RECORD, //
+        Field.of("otherfield", LegacySQLTypeName.INTEGER), //
+        MAP_FIELD));
+    String expected = "{\"outer\":{\"otherfield\":3"
+        + ",\"mapfield\":[{\"key\":\"bar\",\"value\":4},{\"key\":\"foo\",\"value\":3}]}}";
+    PubsubMessageToTableRow.transformForBqSchema(parent, bqFields, additionalProperties);
+    assertEquals(expected, Json.asString(parent));
+  }
+
+  @Test
+  public void testAdditionalProperties() throws Exception {
+    Map<String, Object> parent = new HashMap<>();
+    Map<String, Object> additionalProperties = new HashMap<>();
+    parent.put("outer", new HashMap<>(ImmutableMap.of("otherfield", 3, //
+        "mapfield", new HashMap<>(ImmutableMap.of("foo", 3, "bar", 4)))));
+    List<Field> bqFields = ImmutableList.of(Field.of("outer", LegacySQLTypeName.RECORD, //
+        MAP_FIELD));
+    String expected = "{\"outer\":{"
+        + "\"mapfield\":[{\"key\":\"bar\",\"value\":4},{\"key\":\"foo\",\"value\":3}]}}";
+    String expectedAdditional = "{\"outer\":{\"otherfield\":3}}";
+    PubsubMessageToTableRow.transformForBqSchema(parent, bqFields, additionalProperties);
+    assertEquals(expected, Json.asString(parent));
+    assertEquals(expectedAdditional, Json.asString(additionalProperties));
+  }
+
+  @Test
+  public void testPropertyRename() throws Exception {
+    Map<String, Object> parent = new HashMap<>();
+    Map<String, Object> additionalProperties = new HashMap<>();
+    parent.put("64bit", true);
+    parent.put("hi-fi", true);
+    List<Field> bqFields = ImmutableList.of(Field.of("_64bit", LegacySQLTypeName.BOOLEAN), //
+        Field.of("hi_fi", LegacySQLTypeName.BOOLEAN));
+    String expected = "{\"hi_fi\":true,\"_64bit\":true}";
+    PubsubMessageToTableRow.transformForBqSchema(parent, bqFields, additionalProperties);
+    assertEquals(expected, Json.asString(parent));
   }
 
 }


### PR DESCRIPTION
In parallel to the work on Avro loading, we want to be able to test stability and performance of a JSON-based solution.

In this PR, we support a variety of transformations to account for limitations of BigQuery schemas. In particular, we support transforming maps into arrays of key/value pairs, serializing structures to json strings where a string is expected, and sanitizing field names that BQ cannot support.

We additionally build up a JSON string of items for which we have no JSON fields in the destination BigQuery table (#450).