### PR TITLE
Add scripts for testing bigquery table updates with schemas generated from mps

### DIFF
--- a/ingestion-beam/.gitignore
+++ b/ingestion-beam/.gitignore
@@ -8,3 +8,5 @@ derby.log
 tmp/
 GeoLite2-City.mmdb
 schemas.tar.gz
+avro-schema.tar.gz
+bq-schemas/

--- a/ingestion-beam/bin/generate-bq-schemas
+++ b/ingestion-beam/bin/generate-bq-schemas
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/.." || exit
+
+if [ ! -x  "$(command -v jsonschema-transpiler)" ]; then
+    echo "jsonschema-transpiler is not installed"
+    echo "Run 'cargo install --git https://github.com/acmiyaguchi/jsonschema-transpiler.git --branch dev'"
+    exit 1
+fi
+
+if [[ ! -f schemas.tar.gz ]]; then
+    echo "Run 'bin/download-schemas'"
+    exit 1
+fi
+
+function init_working_directory() {
+    # Create a temporary directory for working. The current directory is stored
+    # into $rootdir and the working directory is stored into $workdir. The
+    # working directory will be removed on exit.
+    rootdir=$(pwd)
+    workdir=$(mktemp -d -t tmp.XXXXXXXXXX)
+    function cleanup {
+        rm -rf "$workdir"
+        echo "Running cleanup!"
+    }
+    trap cleanup EXIT
+    cd "$workdir" || exit
+}
+
+total=0
+failed=0
+function generate_avro_schema() {
+    # From a relative path to a jsonschema, transpile an bigquery schema in a
+    # flat directory. This function requires the following global variables:
+    # $total, $failed
+    local src=$1
+    local root=$2
+    
+    local namespace
+    local name
+    # replace // with / and get the proper namespace
+    namespace=$(echo $src | sed 's/\/\//\//g' | cut -d/ -f3)
+    name="$namespace.$(basename "$src" .schema.json).bigquery.json"
+    local dst="$root/$name"
+    
+    # Create the folder to the new schema
+    mkdir -p "$root/$relpath"
+
+    if ! jsonschema-transpiler --type bigquery "$src" > "$dst" 2> /dev/null; then
+        echo "Unable to convert $(basename "$src")"
+        rm "$dst"
+        ((failed++))
+    fi
+    tmp="$dst.tmp"
+    
+    # remove top-level record and insert metadata and timestamp
+    submission='{"name": "submission_timestamp", "type": "TIMESTAMP", "mode": "REQUIRED"}'
+    metadata=$(cat << EOM
+{
+    "name": "metadata", 
+    "type": "RECORD", 
+    "fields": [
+        {"name": "key", "type": "STRING", "mode": "REQUIRED"},
+        {"name": "value", "type": "STRING", "mode": "REQUIRED"}
+    ]
+}
+EOM
+)
+    # ignore metadata for now
+    jq ".fields | . += [$submission]" $dst > $tmp
+    mv $tmp $dst
+
+    ((total++))
+    return 0
+}
+
+init_working_directory
+
+src="mozilla-pipeline-schemas"
+dst="bq-schemas"
+
+# Find all JSON schemas in the extracted archive. The top-level folder in the
+# archive is consistently named in `bin/download-schemas`
+tar -xf "$rootdir/schemas.tar.gz" -C "$workdir"
+schemas=$(find $src/schemas -type file -name "*.schema.json")
+
+# Transpile avro schema into a destination directory
+for schema in $schemas; do
+    generate_avro_schema "$schema" $dst
+done
+echo "$((total-failed))/$total sucessfully converted"
+
+# Generate the final archive
+cp -r "$dst" "$rootdir"

--- a/ingestion-beam/bin/generate-bq-schemas
+++ b/ingestion-beam/bin/generate-bq-schemas
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Generate BigQuery schemas from a schema archive fetched by
-# `bin/download=schemas`. This script will write to a flat directory called
-# `bq-schemas` containing BQ schemas that have been injected with partitioning
-# and metadata schemas.
+# Generate BigQuery schemas for integration testing and validation from a schema
+# archive fetched by `bin/download=schemas`. This script will write to a flat
+# directory called `bq-schemas` containing BQ schemas that have been injected
+# with partitioning and metadata schemas.
 
 
 set -e

--- a/ingestion-beam/bin/generate-bq-schemas
+++ b/ingestion-beam/bin/generate-bq-schemas
@@ -43,7 +43,7 @@ function init_working_directory() {
 total=0
 failed=0
 function generate_bq_schema() {
-    # From a relative path to a jsonschema, transpile an bigquery schema in a
+    # From a relative path to a jsonschema, transpile a bigquery schema in a
     # flat directory. This function requires the following global variables:
     # $total, $failed
     local src=$1
@@ -98,7 +98,7 @@ dst="bq-schemas"
 tar -xf "$rootdir/schemas.tar.gz" -C "$workdir"
 schemas=$(find $src/schemas -type file -name "*.schema.json")
 
-# Transpile avro schema into a destination directory
+# Transpile BigQuery schema into a destination directory
 for schema in $schemas; do
     generate_bq_schema "$schema" $dst
 done

--- a/ingestion-beam/bin/generate-bq-schemas
+++ b/ingestion-beam/bin/generate-bq-schemas
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Generate BigQuery schemas from a schema archive fetched by
+# `bin/download=schemas`. This script will write to a flat directory called
+# `bq-schemas` containing BQ schemas that have been injected with partitioning
+# and metadata schemas.
+
+
 set -e
 
 cd "$(dirname "$0")/.." || exit
@@ -7,6 +13,11 @@ cd "$(dirname "$0")/.." || exit
 if [ ! -x  "$(command -v jsonschema-transpiler)" ]; then
     echo "jsonschema-transpiler is not installed"
     echo "Run 'cargo install --git https://github.com/acmiyaguchi/jsonschema-transpiler.git --branch dev'"
+    exit 1
+fi
+
+if [ ! -x  "$(command -v jq)" ]; then
+    echo "jq is not installed"
     exit 1
 fi
 
@@ -31,7 +42,7 @@ function init_working_directory() {
 
 total=0
 failed=0
-function generate_avro_schema() {
+function generate_bq_schema() {
     # From a relative path to a jsonschema, transpile an bigquery schema in a
     # flat directory. This function requires the following global variables:
     # $total, $failed
@@ -45,8 +56,8 @@ function generate_avro_schema() {
     name="$namespace.$(basename "$src" .schema.json).bigquery.json"
     local dst="$root/$name"
     
-    # Create the folder to the new schema
-    mkdir -p "$root/$relpath"
+    # Create the folder if not exists
+    mkdir -p "$root"
 
     if ! jsonschema-transpiler --type bigquery "$src" > "$dst" 2> /dev/null; then
         echo "Unable to convert $(basename "$src")"
@@ -60,16 +71,17 @@ function generate_avro_schema() {
     metadata=$(cat << EOM
 {
     "name": "metadata", 
-    "type": "RECORD", 
+    "type": "RECORD",
     "fields": [
         {"name": "key", "type": "STRING", "mode": "REQUIRED"},
         {"name": "value", "type": "STRING", "mode": "REQUIRED"}
-    ]
+    ],
+    "mode": "REPEATED"
 }
 EOM
 )
-    # ignore metadata for now
-    jq ".fields | . += [$submission]" $dst > $tmp
+    # Extract the top-level columns from the record and insert metadata
+    jq ".fields | . += [$submission, $metadata]" $dst > $tmp
     mv $tmp $dst
 
     ((total++))
@@ -88,7 +100,7 @@ schemas=$(find $src/schemas -type file -name "*.schema.json")
 
 # Transpile avro schema into a destination directory
 for schema in $schemas; do
-    generate_avro_schema "$schema" $dst
+    generate_bq_schema "$schema" $dst
 done
 echo "$((total-failed))/$total sucessfully converted"
 

--- a/ingestion-beam/bin/generate-bq-schemas
+++ b/ingestion-beam/bin/generate-bq-schemas
@@ -52,7 +52,7 @@ function generate_bq_schema() {
     local namespace
     local name
     # replace // with / and get the proper namespace
-    namespace=$(echo $src | sed 's/\/\//\//g' | cut -d/ -f3)
+    namespace=$(echo "$src" | sed 's/\/\//\//g' | cut -d/ -f3)
     name="$namespace.$(basename "$src" .schema.json).bigquery.json"
     local dst="$root/$name"
     
@@ -81,8 +81,8 @@ function generate_bq_schema() {
 EOM
 )
     # Extract the top-level columns from the record and insert metadata
-    jq ".fields | . += [$submission, $metadata]" $dst > $tmp
-    mv $tmp $dst
+    jq ".fields | . += [$submission, $metadata]" "$dst" > "$tmp"
+    mv "$tmp" "$dst"
 
     ((total++))
     return 0

--- a/ingestion-beam/bin/update-bq-table
+++ b/ingestion-beam/bin/update-bq-table
@@ -17,6 +17,7 @@ fi
 
 total=0
 skip=0
+error=0
 function update_table() {
     # Arguments:
     #   $1 - path to the document in format `{namespace}.{type}.{version}.bq.json`
@@ -28,7 +29,9 @@ function update_table() {
     # Counters:
     #   $total - the total number of documents seen
     #   $skip  - the number of documents that have been skipped
+    #   $error - the number of errors encountered
     document=$1
+    ((total++))
 
     # downcase hyphens to underscores before generating names
     bq_document=$(basename "${document}" | sed 's/-/_/g')
@@ -58,6 +61,9 @@ function update_table() {
         --schema "${document}" \
         --time_partitioning_field submission_timestamp \
         "${namespace}.${doctype}_v${docver}"
+    if [[ $? ]]; then
+        ((error++))
+    fi
 }
 
 documents=$(find bq-schemas -type file)
@@ -65,4 +71,5 @@ trap "exit" INT
 for document in ${documents}; do
     update_table "${document}"
 done
-echo "$((total-skip))/${total} sucessfully updated, ${skip} skipped."
+
+echo "$((total-skip-error))/${total} sucessfully updated, ${skip} skipped, ${error} errors."

--- a/ingestion-beam/bin/update-bq-table
+++ b/ingestion-beam/bin/update-bq-table
@@ -1,20 +1,35 @@
 #!/bin/bash
 
+# Update the BigQuery table schemas in the current project. Set the following
+# environment variables to modify the behavior of the update.
+#
+#   SKIP_EXISTING=1     - Skip table creation if the table already exists
+#   REPLACE_EXISTING=1  - Drop and create a table whether it exists or not
+#
+# The default behavior is to fail when encountering an existing table.
+
 cd "$(dirname "$0")/.." || exit
 
-if [[ ! -d bq-schemas ]]; then
+if [[ ! -d "bq-schemas" ]]; then
     echo "Run 'bin/generate-bq-schemas'"
     exit 1
 fi
 
-documents=$(find bq-schemas -type file)
-
 total=0
-error=0
 skip=0
+function update_table() {
+    # Arguments:
+    #   $1 - path to the document in format `{namespace}.{type}.{version}.bq.json`
+    #
+    # Options via envvar
+    #   $SKIP_EXISTING  - skip if exists
+    #   $REPLACE_EXISTING - remove and create if exists
+    #
+    # Counters:
+    #   $total - the total number of documents seen
+    #   $skip  - the number of documents that have been skipped
+    document=$1
 
-trap "exit" INT
-for document in ${documents}; do
     # downcase hyphens to underscores before generating names
     bq_document=$(echo $(basename $document) | sed 's/-/_/g')
     namespace=$(echo $bq_document | cut -d. -f1)
@@ -31,7 +46,7 @@ for document in ${documents}; do
     if [[ ! -z ${SKIP_EXISTING+x} ]] && [[ ! -z ${table_exists} ]]; then
         echo "skipping bq mk for ${document}"
         ((skip++))
-        continue
+        return
     fi
 
     if [[ ! -z ${REPLACE_EXISTING+x} ]] && [[ ! -z ${table_exists} ]]; then
@@ -43,4 +58,11 @@ for document in ${documents}; do
         --schema $document \
         --time_partitioning_field submission_timestamp \
         ${namespace}.${doctype}_v${docver}
+}
+
+documents=$(find bq-schemas -type file)
+trap "exit" INT
+for document in ${documents}; do
+    update_table $document
 done
+echo "$((total-skip))/$total sucessfully updated, ${skip} skipped."

--- a/ingestion-beam/bin/update-bq-table
+++ b/ingestion-beam/bin/update-bq-table
@@ -31,38 +31,38 @@ function update_table() {
     document=$1
 
     # downcase hyphens to underscores before generating names
-    bq_document=$(echo $(basename $document) | sed 's/-/_/g')
-    namespace=$(echo $bq_document | cut -d. -f1)
-    doctype=$(echo $bq_document | cut -d. -f2)
-    docver=$(echo $bq_document | cut -d. -f3)
+    bq_document=$(basename "${document}" | sed 's/-/_/g')
+    namespace=$(echo "${bq_document}" | cut -d. -f1)
+    doctype=$(echo "${bq_document}" | cut -d. -f2)
+    docver=$(echo "${bq_document}" | cut -d. -f3)
 
-    if ! bq ls | grep ${namespace} >/dev/null ; then
+    if ! bq ls | grep "${namespace}" >/dev/null ; then
         echo "creating dataset: ${namespace}"
-        bq mk ${namespace}
+        bq mk "${namespace}"
     fi
 
-    table_exists=$(bq ls ${namespace} | grep ${doctype}_v${docver})
+    table_exists=$(bq ls "${namespace}" | grep "${doctype}_v${docver}")
 
-    if [[ ! -z ${SKIP_EXISTING+x} ]] && [[ ! -z ${table_exists} ]]; then
+    if [[ -n ${SKIP_EXISTING+x} ]] && [[ -n ${table_exists} ]]; then
         echo "skipping bq mk for ${document}"
         ((skip++))
         return
     fi
 
-    if [[ ! -z ${REPLACE_EXISTING+x} ]] && [[ ! -z ${table_exists} ]]; then
+    if [[ -n ${REPLACE_EXISTING+x} ]] && [[ -n ${table_exists} ]]; then
         echo "running bq rm for ${document}"
-        bq rm -f ${namespace}.${doctype}_v${docver}
+        bq rm -f "${namespace}.${doctype}_v${docver}"
     fi
 
     bq mk --table \
-        --schema $document \
+        --schema "${document}" \
         --time_partitioning_field submission_timestamp \
-        ${namespace}.${doctype}_v${docver}
+        "${namespace}.${doctype}_v${docver}"
 }
 
 documents=$(find bq-schemas -type file)
 trap "exit" INT
 for document in ${documents}; do
-    update_table $document
+    update_table "${document}"
 done
-echo "$((total-skip))/$total sucessfully updated, ${skip} skipped."
+echo "$((total-skip))/${total} sucessfully updated, ${skip} skipped."

--- a/ingestion-beam/bin/update-bq-table
+++ b/ingestion-beam/bin/update-bq-table
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-# Update the BigQuery table schemas in the current project. Set the following
+# Update the BigQuery table schemas in the current project for integration
+# testing and validation. This script generates the empty tables that are
+# suitable for ingesting data from decoded messages. Set the following
 # environment variables to modify the behavior of the update.
 #
 #   SKIP_EXISTING=1     - Skip table creation if the table already exists

--- a/ingestion-beam/bin/update-bq-table
+++ b/ingestion-beam/bin/update-bq-table
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+cd "$(dirname "$0")/.." || exit
+
+if [[ ! -d bq-schemas ]]; then
+    echo "Run 'bin/generate-bq-schemas'"
+    exit 1
+fi
+
+documents=$(find bq-schemas -type file)
+
+total=0
+error=0
+skip=0
+
+trap "exit" INT
+for document in ${documents}; do
+    # downcase hyphens to underscores before generating names
+    bq_document=$(echo $(basename $document) | sed 's/-/_/g')
+    namespace=$(echo $bq_document | cut -d. -f1)
+    doctype=$(echo $bq_document | cut -d. -f2)
+    docver=$(echo $bq_document | cut -d. -f3)
+
+    if ! bq ls | grep ${namespace} >/dev/null ; then
+        echo "creating dataset: ${namespace}"
+        bq mk ${namespace}
+    fi
+
+    table_exists=$(bq ls ${namespace} | grep ${doctype}_v${docver})
+
+    if [[ ! -z ${SKIP_EXISTING+x} ]] && [[ ! -z ${table_exists} ]]; then
+        echo "skipping bq mk for ${document}"
+        ((skip++))
+        continue
+    fi
+
+    if [[ ! -z ${REPLACE_EXISTING+x} ]] && [[ ! -z ${table_exists} ]]; then
+        echo "running bq rm for ${document}"
+        bq rm -f ${namespace}.${doctype}_v${docver}
+    fi
+
+    bq mk --table \
+        --schema $document \
+        --time_partitioning_field submission_timestamp \
+        ${namespace}.${doctype}_v${docver}
+done


### PR DESCRIPTION
This adds two scripts that were used for reducing testing overhead in #536. 

`generate-bq-schemas` will generate BigQuery schemas from mps and insert the partitioning column and metadata. It also includes a fix for extracting the columns from the root record to conform to the `bq` cli tool.

`update-bq-table` will update the current project's BigQuery tables using schemas in the `bq-schemas` folder. This will create the datasets from the namespaces, the tables from the types and version, and the partitioning columns.


```bash
# install jsonschema-transpiler, jq, gcloud cli tools

# generates `schema.tar.gz`
$ ./bin/download-schemas

# generates `bq-schemas/`
$ ./bin/generate-bq-schemas

# updates BigQuery in current project `gcloud config get-value project` 
$ ./bin/update-bq-table
```

I ran the following command to update the tables with data:

```bash
export GOOGLE_APPLICATION_CREDENTIALS=bq-sink-key.json
PROJECT=$(gcloud config get-value project)
BUCKET="gs://$PROJECT"
path="$BUCKET/telemetry-decoded-2019-04-15-00/*-00000-*"
mvn compile exec:java -Dexec.args="\
    --runner=Dataflow \
    --project=$(gcloud config get-value project) \
    --autoscalingAlgorithm=NONE \
    --workerMachineType=n1-standard-1 \
    --numWorkers=3 \
    --gcpTempLocation=$BUCKET/tmp \
    --inputFileFormat=json \
    --inputType=file \
    --input=$path\
    --outputType=bigquery \
    --output=$PROJECT:\${document_namespace}.\${document_type}_v\${document_version} \
    --bqWriteMethod=file_loads \
    --tempLocation=$BUCKET/temp/bq-loads \
    --errorOutputType=file \
    --errorOutput=$BUCKET/error/ \
"
```

Finally, I wrote a small query using the populated `telemetry.events_v4` table.

```sql
SELECT
  submission_timestamp,
  payload.events.parent,
  metadata
FROM
  telemetry.event_v4
```
[source](https://console.cloud.google.com/bigquery?project=amiyaguchi-unmap-json-bq-sink&j=bq:US:bquxjob_5ab6cad9_16a5af05c7e&page=queryresults)
