### PR TITLE
Don't insert empty objects into additional_properties

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -228,8 +228,10 @@ public class PubsubMessageToTableRow
           Field valueField = field.getSubFields().get(1);
           if (valueField.getType() == LegacySQLTypeName.RECORD) {
             Map<String, Object> props = new HashMap<>();
-            additionalProperties.put(name, props);
             transformForBqSchema(map, valueField.getSubFields(), props);
+            if (!props.isEmpty()) {
+              additionalProperties.put(name, props);
+            }
           }
           List<Map<String, Object>> unmapped = map.entrySet().stream()
               .map(entry -> ImmutableMap.of("key", entry.getKey(), "value",
@@ -242,8 +244,10 @@ public class PubsubMessageToTableRow
       } else if (field.getType() == LegacySQLTypeName.RECORD && field.getMode() != Mode.REPEATED) {
         value.filter(Map.class::isInstance).map(Map.class::cast).ifPresent(m -> {
           Map<String, Object> props = new HashMap<>();
-          additionalProperties.put(name, props);
           transformForBqSchema(m, field.getSubFields(), props);
+          if (!props.isEmpty()) {
+            additionalProperties.put(name, props);
+          }
         });
 
         // Likewise, we need to recursively call transformForBqSchema on repeated record types.
@@ -252,8 +256,10 @@ public class PubsubMessageToTableRow
             .orElse(ImmutableList.of());
         records.stream().filter(Map.class::isInstance).map(Map.class::cast).forEach(record -> {
           Map<String, Object> props = new HashMap<>();
-          additionalProperties.put(name, props);
           transformForBqSchema(record, field.getSubFields(), props);
+          if (!props.isEmpty()) {
+            additionalProperties.put(name, props);
+          }
         });
       }
     });

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
@@ -122,6 +122,19 @@ public class PubsubMessageToTableRowTest {
   }
 
   @Test
+  public void testAdditionalPropertiesStripsEmpty() throws Exception {
+    Map<String, Object> parent = new HashMap<>();
+    Map<String, Object> additionalProperties = new HashMap<>();
+    parent.put("outer", new HashMap<>(ImmutableMap.of(//
+        "mapfield", new HashMap<>(ImmutableMap.of("foo", 3, "bar", 4)))));
+    List<Field> bqFields = ImmutableList.of(Field.of("outer", LegacySQLTypeName.RECORD, //
+        MAP_FIELD));
+    String expectedAdditional = "{}";
+    PubsubMessageToTableRow.transformForBqSchema(parent, bqFields, additionalProperties);
+    assertEquals(expectedAdditional, Json.asString(additionalProperties));
+  }
+
+  @Test
   public void testPropertyRename() throws Exception {
     Map<String, Object> parent = new HashMap<>();
     Map<String, Object> additionalProperties = new HashMap<>();


### PR DESCRIPTION
Currently, we descend into all records and add a node to additional_properties,
even if it ends up giving us empty output like `{"outer":{}}`. With this change,
a record without any properties absent from the schema will end up with an
empty json record (`{}`) for additional_properties.