### PR TITLE
Add bqStrictSchemaDocTypes option

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
@@ -388,7 +388,8 @@ public abstract class Write
       streamingInput.ifPresent(messages -> {
         WriteResult writeResult = messages //
             .apply(PubsubMessageToTableRow.of(tableSpecTemplate, strictSchemaDocTypes))
-            .errorsTo(errorCollections).apply(baseWriteTransform //
+            .errorsTo(errorCollections) //
+            .apply(baseWriteTransform //
                 .withMethod(BigQueryWriteMethod.streaming.method)
                 .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors()) //
                 .skipInvalidRows() //
@@ -431,7 +432,8 @@ public abstract class Write
         }
         messages //
             .apply(PubsubMessageToTableRow.of(tableSpecTemplate, strictSchemaDocTypes))
-            .errorsTo(errorCollections).apply(fileLoadsWrite);
+            .errorsTo(errorCollections) //
+            .apply(fileLoadsWrite);
       });
 
       PCollection<PubsubMessage> errorCollection = PCollectionList.of(errorCollections)

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
@@ -369,8 +369,6 @@ public abstract class Write
                   final boolean shouldStream;
                   if (namespace == null || docType == null) {
                     shouldStream = false;
-                  } else if ("telemetry".equals(namespace)) {
-                    shouldStream = streamingDocTypes.get().contains(docType);
                   } else {
                     shouldStream = streamingDocTypes.get().contains(namespace + "/" + docType);
                   }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/OutputType.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/OutputType.java
@@ -66,7 +66,8 @@ public enum OutputType {
     public Write write(SinkOptions.Parsed options) {
       return new BigQueryOutput(options.getOutput(), options.getBqWriteMethod(),
           options.getParsedBqTriggeringFrequency(), options.getInputType(),
-          options.getBqNumFileShards(), options.getBqStreamingDocTypes());
+          options.getBqNumFileShards(), options.getBqStreamingDocTypes(),
+          options.getBqStrictSchemaDocTypes());
     }
   };
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
@@ -87,6 +87,16 @@ public interface SinkOptions extends PipelineOptions {
 
   void setBqStreamingDocTypes(ValueProvider<List<String>> value);
 
+  @Description("A comma-separated list of docTypes for which we will not accumulate an"
+      + " additional_properties field before publishing to BigQuery;"
+      + " this is especially useful for the telemetry main ping where we expect to send the"
+      + " same payload to multiple tables, each with only a subset of the overall schema"
+      + " you may use a slash in each entry to separate namespace from type;"
+      + " the telemetry namespace is assumed for entries that do not contain a slash")
+  ValueProvider<List<String>> getBqStrictSchemaDocTypes();
+
+  void setBqStrictSchemaDocTypes(ValueProvider<List<String>> value);
+
   @Description("File format for --outputType=file|stdout; must be one of"
       + " json (each line contains payload[String] and attributeMap[String,String]) or"
       + " text (each line is payload)")

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
@@ -81,18 +81,16 @@ public interface SinkOptions extends PipelineOptions {
   @Description("A comma-separated list of docTypes that should be published to BigQuery via the"
       + " streaming InsertAll endpoint rather than via file loads;"
       + " only relevant if --bqWriteMethod=mixed;"
-      + " you may use a slash in each entry to separate namespace from type;"
-      + " the telemetry namespace is assumed for entries that do not contain a slash")
+      + " each docType must be qualified with a namespace like 'telemetry/event'")
   ValueProvider<List<String>> getBqStreamingDocTypes();
 
   void setBqStreamingDocTypes(ValueProvider<List<String>> value);
 
   @Description("A comma-separated list of docTypes for which we will not accumulate an"
       + " additional_properties field before publishing to BigQuery;"
-      + " this is especially useful for the telemetry main ping where we expect to send the"
-      + " same payload to multiple tables, each with only a subset of the overall schema"
-      + " you may use a slash in each entry to separate namespace from type;"
-      + " the telemetry namespace is assumed for entries that do not contain a slash")
+      + " this is especially useful for telemetry/main where we expect to send the"
+      + " same payload to multiple tables, each with only a subset of the overall schema;"
+      + " each docType must be qualified with a namespace like 'telemetry/main'")
   ValueProvider<List<String>> getBqStrictSchemaDocTypes();
 
   void setBqStrictSchemaDocTypes(ValueProvider<List<String>> value);

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/republisher/RepublishPerDocType.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/republisher/RepublishPerDocType.java
@@ -65,7 +65,6 @@ public class RepublishPerDocType extends PTransform<PCollection<PubsubMessage>, 
       message = PubsubConstraints.ensureNonNull(message);
       String namespace = message.getAttribute("document_namespace");
       String docType = message.getAttribute("document_type");
-      System.out.println("Partitioning per DocType: " + namespace + docType);
       for (int i = 0; i < destinations.size(); i++) {
         if (destinations.get(i).matches(namespace, docType)) {
           return i;
@@ -88,13 +87,12 @@ public class RepublishPerDocType extends PTransform<PCollection<PubsubMessage>, 
 
     public Destination(String entry) {
       final String[] components = entry.split("/");
-      if (components.length == 1) {
-        this.namespace = "telemetry";
-        this.docType = components[0];
-      } else {
-        this.namespace = components[0];
-        this.docType = components[1];
+      if (components.length != 2) {
+        throw new IllegalArgumentException("Each entry of perDocTypeEnabledList must be in the"
+            + " form namespace/doctype, but found " + entry);
       }
+      this.namespace = components[0];
+      this.docType = components[1];
     }
 
     public boolean matches(String namespaceToMatch, String docTypeToMatch) {

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/republisher/RepublisherOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/republisher/RepublisherOptions.java
@@ -69,8 +69,7 @@ public interface RepublisherOptions extends SinkOptions, PipelineOptions {
   void setPerChannelDestination(String value);
 
   @Description("A comma-separated list of docTypes that should be republished to individual"
-      + " topics; you may use a slash in each entry to separate namespace from type;"
-      + " the telemetry namespace is assumed for entries that do not contain a slash")
+      + " topics; each docType must be qualified with a namespace like 'telemetry/event'")
   List<String> getPerDocTypeEnabledList();
 
   void setPerDocTypeEnabledList(List<String> value);

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -175,8 +175,7 @@ public class PubsubMessageToTableRow
     String namespace = message.getAttribute(ParseUri.DOCUMENT_NAMESPACE);
     String docType = message.getAttribute(ParseUri.DOCUMENT_TYPE);
     final boolean strictSchema = (strictSchemaDocTypes.isAccessible()
-        && (("telemetry".equals(namespace) && strictSchemaDocTypes.get().contains(docType))
-            || (strictSchemaDocTypes.get().contains(String.format("%s/%s", namespace, docType)))));
+        && strictSchemaDocTypes.get().contains(String.format("%s/%s", namespace, docType)));
 
     // Make BQ-specific transformations to the payload structure.
     Map<String, Object> additionalProperties = strictSchema ? null : new HashMap<>();

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/RepublisherMainTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/RepublisherMainTest.java
@@ -54,11 +54,11 @@ public class RepublisherMainTest extends TestWithDeterministicJson {
     String input = inputPath + "/*.ndjson";
     String output = outputPath + "/out_${document_namespace}_${document_type}";
 
-    Republisher
-        .main(new String[] { "--inputFileFormat=json", "--inputType=file", "--input=" + input,
-            "--outputFileFormat=json", "--outputType=file", "--perDocTypeDestination=" + output,
-            "--perDocTypeEnabledList=event,bar/foo", "--outputFileCompression=UNCOMPRESSED",
-            "--redisUri=" + redis.uri, "--errorOutputType=stderr" });
+    Republisher.main(new String[] { "--inputFileFormat=json", "--inputType=file",
+        "--input=" + input, "--outputFileFormat=json", "--outputType=file",
+        "--perDocTypeDestination=" + output, "--perDocTypeEnabledList=telemetry/event,bar/foo",
+        "--outputFileCompression=UNCOMPRESSED", "--redisUri=" + redis.uri,
+        "--errorOutputType=stderr" });
 
     List<String> expectedLines = Lines.files(inputPath + "/per-doctype-*.ndjson");
     List<String> outputLines = Lines.files(outputPath + "/*.ndjson");

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
@@ -124,6 +124,19 @@ public class PubsubMessageToTableRowTest extends TestWithDeterministicJson {
   }
 
   @Test
+  public void testStrictSchema() throws Exception {
+    Map<String, Object> parent = new HashMap<>();
+    parent.put("outer", new HashMap<>(ImmutableMap.of("otherfield", 3, //
+        "mapfield", new HashMap<>(ImmutableMap.of("foo", 3, "bar", 4)))));
+    List<Field> bqFields = ImmutableList.of(Field.of("outer", LegacySQLTypeName.RECORD, //
+        MAP_FIELD));
+    String expected = "{\"outer\":{"
+        + "\"mapfield\":[{\"key\":\"bar\",\"value\":4},{\"key\":\"foo\",\"value\":3}]}}";
+    PubsubMessageToTableRow.transformForBqSchema(parent, bqFields, null);
+    assertEquals(expected, Json.asString(parent));
+  }
+
+  @Test
   public void testAdditionalPropertiesStripsEmpty() throws Exception {
     Map<String, Object> parent = new HashMap<>();
     Map<String, Object> additionalProperties = new HashMap<>();


### PR DESCRIPTION
Closes #644

We should be able to set the following for the bq sink on both telemetry
and structured:

    bqStrictSchemaDocTypes=main