### PR TITLE
Fix build-template script to mount full git repo

### DIFF
--- a/ingestion-beam/bin/build-template
+++ b/ingestion-beam/bin/build-template
@@ -84,10 +84,14 @@ cd "$(dirname "$0")/.."
 # Create dir to cache maven dependencies if it doesn't already exist.
 mkdir -p ~/.m2
 
+# Get current path and git root path
+GIT_TOPLEVEL="$(git rev-parse --show-toplevel)"
+GIT_PREFIX="$(git rev-parse --show-prefix)"
+
 # Run mvn with a non-root user id
 # https://docs.docker.com/samples/library/maven/#Running-as-non-root
 docker run -v ~/.m2:/var/maven/.m2 --rm -u $UID \
-  -v $PWD:/var/maven/project -w /var/maven/project \
+  -v "$GIT_TOPLEVEL":/var/maven/project -w /var/maven/project/"$GIT_PREFIX" \
   -e MAVEN_CONFIG=/var/maven/.m2 maven mvn \
   -Duser.home=/var/maven \
   compile exec:java -Dexec.mainClass=$JOB_CLASS -Dexec.args="$COMPILE_OPTIONS"


### PR DESCRIPTION
full git repo needs to be made available to maven inside docker, so that the parent-module `pom.xml` is present.