### PR TITLE
Bug 1562011 - Scrub RemoteType annotations from "crash" and "bhr" pings

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -54,7 +54,6 @@ public class MessageScrubber {
       return true;
     } else if ("telemetry".equals(attributes.get(ParseUri.DOCUMENT_NAMESPACE))
         && "bhr".equals(attributes.get(ParseUri.DOCUMENT_TYPE))
-        && "nightly".equals(attributes.get(ParseUri.APP_UPDATE_CHANNEL))
         && (attributes.get(ParseUri.APP_VERSION).startsWith("68")
             || attributes.get(ParseUri.APP_VERSION).startsWith("69"))
         && Optional.of(json) // payload.hangs[].remoteType
@@ -66,6 +65,7 @@ public class MessageScrubber {
                 String s = arr.optJSONObject(i).optString("remoteType");
                 if (s != null && s.startsWith("webIsolated=")) {
                   isPresent = true;
+                  break;
                 }
               }
               return isPresent;

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -8,12 +8,15 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class MessageScrubber {
 
   private static final Counter countScrubbedBug1567596 = Metrics.counter(MessageScrubber.class,
       "bug_1567596");
+  private static final Counter countScrubbedBug1562011 = Metrics.counter(MessageScrubber.class,
+      "bug_1562011");
 
   /**
    * Inspect the contents of the payload and return true if the content matches a known pattern
@@ -33,6 +36,42 @@ public class MessageScrubber {
             .map(j -> j.optString("MozCrashReason"))
             .filter(s -> s.contains("do not use eval with system privileges")).isPresent()) {
       countScrubbedBug1567596.inc();
+      return true;
+    } else if ("telemetry".equals(attributes.get(ParseUri.DOCUMENT_NAMESPACE))
+        && "crash".equals(attributes.get(ParseUri.DOCUMENT_TYPE))
+        && (("nightly".equals(attributes.get(ParseUri.APP_UPDATE_CHANNEL))
+            && (attributes.get(ParseUri.APP_VERSION).startsWith("68")
+                || attributes.get(ParseUri.APP_VERSION).startsWith("69")))
+            || ("beta".equals(attributes.get(ParseUri.APP_UPDATE_CHANNEL))
+                && attributes.get(ParseUri.APP_VERSION).startsWith("68")))
+        && Optional.of(json) // payload.metadata.RemoteType
+            .map(j -> j.optJSONObject("payload")) //
+            .map(j -> j.optJSONObject("metadata")) //
+            .map(j -> j.optString("RemoteType")) //
+            .filter(s -> s.startsWith("webIsolated=")).isPresent()) {
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1562011
+      countScrubbedBug1562011.inc();
+      return true;
+    } else if ("telemetry".equals(attributes.get(ParseUri.DOCUMENT_NAMESPACE))
+        && "bhr".equals(attributes.get(ParseUri.DOCUMENT_TYPE))
+        && "nightly".equals(attributes.get(ParseUri.APP_UPDATE_CHANNEL))
+        && (attributes.get(ParseUri.APP_VERSION).startsWith("68")
+            || attributes.get(ParseUri.APP_VERSION).startsWith("69"))
+        && Optional.of(json) // payload.hangs[].remoteType
+            .map(j -> j.optJSONObject("payload")) //
+            .map(j -> {
+              Boolean isPresent = false;
+              JSONArray arr = j.optJSONArray("hangs");
+              for (int i = 0; i < arr.length(); i++) {
+                String s = arr.optJSONObject(i).optString("remoteType");
+                if (s != null && s.startsWith("webIsolated=")) {
+                  isPresent = true;
+                }
+              }
+              return isPresent;
+            }) //
+            .filter(b -> b).isPresent()) {
+      countScrubbedBug1562011.inc();
       return true;
     } else {
       return false;

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.mozilla.telemetry.util.Json;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,11 +18,11 @@ import org.junit.Test;
 public class MessageScrubberTest {
 
   @Test
-  public void testShouldScrub() throws Exception {
+  public void testShouldScrubBug1567596() throws Exception {
     Map<String, String> attributes = ImmutableMap.<String, String>builder()
         .put(ParseUri.DOCUMENT_NAMESPACE, "telemetry").put(ParseUri.DOCUMENT_TYPE, "crash")
         .put(ParseUri.APP_UPDATE_CHANNEL, "nightly").put(ParseUri.APP_BUILD_ID, "20190719094503")
-        .build();
+        .put(ParseUri.APP_VERSION, "70.0a1").build();
     JSONObject bug1567596AffectedJson = Json.readJSONObject(("{\n" //
         + "  \"payload\": {\n" //
         + "    \"metadata\": {\n" //
@@ -33,6 +34,50 @@ public class MessageScrubberTest {
     assertTrue(MessageScrubber.shouldScrub(attributes, bug1567596AffectedJson));
     assertFalse(MessageScrubber.shouldScrub(new HashMap<>(), bug1567596AffectedJson));
     assertFalse(MessageScrubber.shouldScrub(attributes, new JSONObject()));
+  }
+
+  @Test
+  public void testShouldScrubCrashBug1562011() throws Exception {
+    JSONObject ping = Json.readJSONObject(("{\n" //
+        + "  \"payload\": {\n" //
+        + "    \"metadata\": {\n" //
+        + "      \"RemoteType\": \"webIsolated=foo\"\n" //
+        + "    },\n" //
+        + "    \"session_id\": \"ca98fe03-1248-448f-bbdf-59f97dba5a0e\"\n" //
+        + "  },\n" //
+        + "  \"client_id\": null\n" + "}").getBytes());
+
+    Map<String, String> attributes = Maps.newHashMap(ImmutableMap.<String, String>builder()
+        .put(ParseUri.DOCUMENT_NAMESPACE, "telemetry").put(ParseUri.DOCUMENT_TYPE, "crash")
+        .put(ParseUri.APP_UPDATE_CHANNEL, "nightly").put(ParseUri.APP_VERSION, "68.0").build());
+
+    assertTrue(MessageScrubber.shouldScrub(attributes, ping));
+
+    attributes.put(ParseUri.APP_UPDATE_CHANNEL, "beta");
+    attributes.put(ParseUri.APP_VERSION, "68");
+    assertTrue(MessageScrubber.shouldScrub(attributes, ping));
+
+    attributes.put(ParseUri.APP_VERSION, "69");
+    assertFalse(MessageScrubber.shouldScrub(attributes, ping));
+  }
+
+  @Test
+  public void testShouldScrubBhrBug1562011() throws Exception {
+    JSONObject ping = Json.readJSONObject(("{\n" //
+        + "  \"payload\": {\n" //
+        + "    \"hangs\": [\n" //
+        + "      {\"remoteType\": \"webIsolated=foo\"},\n" //
+        + "      {\"remoteType\": \"web\"}\n" //
+        + "    ],\n" //
+        + "    \"session_id\": \"ca98fe03-1248-448f-bbdf-59f97dba5a0e\"\n" //
+        + "  },\n" //
+        + "  \"client_id\": null\n" + "}").getBytes());
+
+    Map<String, String> attributes = ImmutableMap.<String, String>builder()
+        .put(ParseUri.DOCUMENT_NAMESPACE, "telemetry").put(ParseUri.DOCUMENT_TYPE, "bhr")
+        .put(ParseUri.APP_UPDATE_CHANNEL, "nightly").put(ParseUri.APP_VERSION, "68.0").build();
+
+    assertTrue(MessageScrubber.shouldScrub(attributes, ping));
   }
 
 }


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1562011)

This rejects crash and bhr pings with payloads starting with `webIsolated=` at the decoder.