### PR TITLE
Remove duplicate delete of X-Pipeline-Proxy

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/GeoCityLookup.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/GeoCityLookup.java
@@ -152,7 +152,6 @@ public class GeoCityLookup
 
         // remove client ip from attributes
         attributes.remove("x_forwarded_for");
-        attributes.remove("x_pipeline_proxy");
         attributes.remove("remote_addr");
 
         // remove null attributes because the coder can't handle them


### PR DESCRIPTION
this header is already removed in [ParseProxy.java](https://github.com/mozilla/gcp-ingestion/blob/edc9eaa/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseProxy.java#L80)