### PR TITLE
Include client_id in BQ "decoded" format

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/AddMetadata.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/AddMetadata.java
@@ -41,16 +41,18 @@ public class AddMetadata extends MapElementsWithErrors.ToPubsubMessageFrom<Pubsu
 
   private static final String URI = "uri";
   private static final List<String> URI_ATTRIBUTES = ImmutableList //
-      .of("uri", "app_name", "app_version", "app_update_channel", "app_build_id");
+      .of("uri", ParseUri.APP_NAME, ParseUri.APP_VERSION, ParseUri.APP_UPDATE_CHANNEL,
+          ParseUri.APP_BUILD_ID);
 
   // These are identifying fields that we want to include in the payload so that the payload
   // can be replayed through Beam jobs even if PubSub attributes are lost; this stripping of
-  // attributes occurs for BQ streaming insert errors.
+  // attributes occurs for BQ streaming insert errors. These fields are also useful when emitting
+  // payload bytes to BQ.
   public static final List<String> IDENTIFYING_FIELDS = ImmutableList //
-      .of("document_namespace", "document_type", "document_version");
+      .of(ParseUri.DOCUMENT_NAMESPACE, ParseUri.DOCUMENT_TYPE, ParseUri.DOCUMENT_VERSION);
 
   private static final List<String> TOP_LEVEL_STRING_FIELDS = ImmutableList.of(
-      "submission_timestamp", "document_id", //
+      ParseProxy.SUBMISSION_TIMESTAMP, ParseUri.DOCUMENT_ID, //
       NormalizeAttributes.NORMALIZED_APP_NAME, NormalizeAttributes.NORMALIZED_CHANNEL,
       NormalizeAttributes.NORMALIZED_OS, NormalizeAttributes.NORMALIZED_OS_VERSION,
       NormalizeAttributes.NORMALIZED_COUNTRY_CODE);

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseProxy.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseProxy.java
@@ -29,8 +29,8 @@ public class ParseProxy extends PTransform<PCollection<PubsubMessage>, PCollecti
 
   /////////
 
+  public static final String SUBMISSION_TIMESTAMP = "submission_timestamp";
   private static final String PROXY_TIMESTAMP = "proxy_timestamp";
-  private static final String SUBMISSION_TIMESTAMP = "submission_timestamp";
   private static final String X_FORWARDED_FOR = "x_forwarded_for";
   private static final String X_PIPELINE_PROXY = "x_pipeline_proxy";
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.mozilla.telemetry.decoder.AddMetadata;
+import com.mozilla.telemetry.decoder.ParseProxy;
 import com.mozilla.telemetry.decoder.ParseUri;
 import com.mozilla.telemetry.schemas.BigQuerySchemaStore;
 import com.mozilla.telemetry.schemas.SchemaNotFoundException;
@@ -73,10 +74,9 @@ public class PubsubMessageToTableRow
     raw, decoded, payload
   }
 
-  public static final String SUBMISSION_TIMESTAMP = "submission_timestamp";
   public static final String ADDITIONAL_PROPERTIES = "additional_properties";
   public static final TimePartitioning TIME_PARTITIONING = new TimePartitioning()
-      .setField(SUBMISSION_TIMESTAMP);
+      .setField(ParseProxy.SUBMISSION_TIMESTAMP);
 
   // We have hit rate limiting issues that have sent valid data to error output, so we make the
   // retry settings a bit more generous; see https://github.com/mozilla/gcp-ingestion/issues/651

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.mozilla.telemetry.decoder.AddMetadata;
+import com.mozilla.telemetry.decoder.ParsePayload;
 import com.mozilla.telemetry.decoder.ParseProxy;
 import com.mozilla.telemetry.decoder.ParseUri;
 import com.mozilla.telemetry.schemas.BigQuerySchemaStore;
@@ -74,6 +75,7 @@ public class PubsubMessageToTableRow
     raw, decoded, payload
   }
 
+  public static final String PAYLOAD = "payload";
   public static final String ADDITIONAL_PROPERTIES = "additional_properties";
   public static final TimePartitioning TIME_PARTITIONING = new TimePartitioning()
       .setField(ParseProxy.SUBMISSION_TIMESTAMP);
@@ -206,19 +208,34 @@ public class PubsubMessageToTableRow
     return result;
   }
 
+  /**
+   * Turn the message into a TableRow that contains (likely gzipped) bytes as a "payload" field,
+   * which is the format suitable for the "raw payload" tables in BigQuery that we use for
+   * errors and recovery from pipeline failures.
+   *
+   * <p>We include all attributes as fields. It is up to the configured schema for the destination
+   * table to determine which of those actually appear as fields; some of the attributes will be
+   * thrown away.
+   */
   @VisibleForTesting
   static TableRow rawTableRow(PubsubMessage message) {
     TableRow tableRow = new TableRow();
     message.getAttributeMap().forEach(tableRow::set);
-    tableRow.set("payload", message.getPayload());
+    tableRow.set(PAYLOAD, message.getPayload());
     return tableRow;
   }
 
+  /**
+   * Like {@link #rawTableRow(PubsubMessage)}, but uses the nested metadata format of decoded pings.
+   */
   @VisibleForTesting
   static TableRow decodedTableRow(PubsubMessage message) {
     TableRow tableRow = new TableRow();
     AddMetadata.attributesToMetadataPayload(message.getAttributeMap()).forEach(tableRow::set);
-    tableRow.set("payload", message.getPayload());
+    // Also include client_id if present.
+    Optional.ofNullable(message.getAttribute(ParsePayload.CLIENT_ID))
+        .ifPresent(clientId -> tableRow.set(ParsePayload.CLIENT_ID, clientId));
+    tableRow.set(PAYLOAD, message.getPayload());
     return tableRow;
   }
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/DerivedAttributesMap.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/DerivedAttributesMap.java
@@ -5,6 +5,7 @@
 package com.mozilla.telemetry.util;
 
 import com.google.common.collect.ForwardingMap;
+import com.mozilla.telemetry.decoder.ParseProxy;
 import java.util.Map;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -68,7 +69,8 @@ public class DerivedAttributesMap extends ForwardingMap<String, String> {
   }
 
   private String submissionTimestampSubstring(int beginIndex, int endIndex) {
-    String timestamp = Optional.ofNullable(attributes.get("submission_timestamp")).orElse("");
+    String timestamp = Optional.ofNullable(attributes.get(ParseProxy.SUBMISSION_TIMESTAMP))
+        .orElse("");
     if (timestamp.length() >= endIndex) {
       return timestamp.substring(beginIndex, endIndex);
     } else {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
@@ -267,7 +267,8 @@ public class PubsubMessageToTableRowTest extends TestWithDeterministicJson {
     PubsubMessage message = new PubsubMessage("test".getBytes(),
         // Ensure sure we preserve all attributes present in the spec:
         // https://github.com/mozilla/gcp-ingestion/blob/master/docs/decoder.md#decoded-message-metadata-schema
-        ImmutableMap.<String, String>builder().put("document_version", "4")
+        ImmutableMap.<String, String>builder()
+            .put("client_id", "5c49ec73-4350-45a0-9c8a-6c8f5aded0da").put("document_version", "4")
             .put("document_id", "6c49ec73-4350-45a0-9c8a-6c8f5aded0cf")
             .put("document_namespace", "telemetry").put("document_type", "main")
             .put("app_name", "Firefox").put("app_version", "58.0.2")
@@ -282,14 +283,15 @@ public class PubsubMessageToTableRowTest extends TestWithDeterministicJson {
             .put("normalized_country_code", "US").put("normalized_os", "Windows")
             .put("normalized_os_version", "10").put("sample_id", "42").build());
     String expected = Json.asString(ImmutableMap.<String, Object>builder()
+        .put("client_id", "5c49ec73-4350-45a0-9c8a-6c8f5aded0da")
         .put("document_id", "6c49ec73-4350-45a0-9c8a-6c8f5aded0cf")
         .put("metadata", ImmutableMap.<String, Object>builder()
             .put("document_namespace", "telemetry").put("document_version", "4")
             .put("document_type", "main")
             .put("geo",
-                ImmutableMap
-                    .<String, String>builder().put("country", "US").put("subdivision1", "WA")
-                    .put("subdivision2", "Clark").put("city", "Vancouver").build())
+                ImmutableMap.<String, String>builder().put("country", "US")
+                    .put("subdivision1", "WA").put("subdivision2", "Clark").put("city", "Vancouver")
+                    .build())
             .put("header",
                 ImmutableMap.<String, String>builder().put("date", "Mon, 12 Mar 2018 21:02:18 GMT")
                     .put("dnt", "1").put("x_pingsender_version", "1.0")


### PR DESCRIPTION
Also see https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/376 which ensures client_id is in the payload_bytes schema.

This PR also enforces some string constants that were previously literals.