### PR TITLE
Fix an omission re: running ingestion-beam tests

### DIFF
--- a/ingestion-beam/README.md
+++ b/ingestion-beam/README.md
@@ -553,6 +553,14 @@ echo '{"payload":"dGVzdA==","attributeMap":{"x_debug_id":"mysession"}}' > tmp/in
 
 # Testing
 
+Before anything else, be sure to download the test data:
+
+```bash
+./bin/download-cities15000
+./bin/download-geolite2
+./bin/download-schemas
+```
+
 Run tests locally with [CircleCI Local CLI](https://circleci.com/docs/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros)
 
 ```bash

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/heka/File.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/heka/File.java
@@ -1,0 +1,4 @@
+package com.mozilla.telemetry.heka;
+
+public class File {
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/heka/File.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/heka/File.java
@@ -1,4 +1,0 @@
-package com.mozilla.telemetry.heka;
-
-public class File {
-}


### PR DESCRIPTION
Add a note about downloading test data before running ingestion-beam
tests, see https://github.com/mozilla/gcp-ingestion/issues/729#issuecomment-519557808