### PR TITLE
fix ingestion-edge-release

### DIFF
--- a/ingestion-edge/Dockerfile
+++ b/ingestion-edge/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-stretch
 WORKDIR /app
 RUN apt-get update && apt-get install -y wrk
 COPY constraints.txt requirements.txt /app/


### PR DESCRIPTION
debian released `buster` which doesn't have the package `wrk`, but we can still use debian `stretch` for now