### PR TITLE
Normalize paths in SchemaStore to support casing variants

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -251,12 +251,7 @@ public class PubsubMessageToTableRow
     Schema schema;
     if (schemaStore != null) {
       try {
-        // The untrustedModules docType is translated to untrusted_modules in attributes,
-        // but the schema store supports hyphens rather than underscores, so it appears as
-        // untrusted-modules there and we have to translate.
-        Map<String, String> hyphenatedAttributes = Maps.transformValues(attributes,
-            v -> v.replaceAll("_", "-"));
-        schema = schemaStore.getSchema(hyphenatedAttributes);
+        schema = schemaStore.getSchema(attributes);
       } catch (SchemaNotFoundException e) {
         throw new IllegalArgumentException(
             "The schema store does not contain a BigQuery schema for this table: " + tableSpec, e);
@@ -459,7 +454,7 @@ public class PubsubMessageToTableRow
    * <p>The format must match exactly with the transformations made by jsonschema-transpiler
    * and mozilla-pipeline-schemas. In general, this format requires converting camelCase to
    * snake_case, replacing incompatible characters like '-' with underscores, and prepending
-   * and underscore to names that begin with a digit.
+   * an underscore to names that begin with a digit.
    */
   @VisibleForTesting
   static String convertNameForBq(String name) {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/schemas/JSONSchemaStoreTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/schemas/JSONSchemaStoreTest.java
@@ -39,6 +39,8 @@ public class JSONSchemaStoreTest {
     JSONSchemaStore store = JSONSchemaStore.of(SCHEMAS_LOCATION, EMPTY_ALIASING_CONFIG_LOCATION);
     assertTrue(store.docTypeExists("telemetry", "main"));
     assertTrue(store.docTypeExists("telemetry", "update"));
+    assertTrue(store.docTypeExists("telemetry", "untrustedModules"));
+    assertTrue(store.docTypeExists("telemetry", "untrusted_modules"));
   }
 
   @Test


### PR DESCRIPTION
Closes #744

Also see https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/387 for discussion of longer-term solutions to avoid this complexity.