### PR TITLE
Fix some formatting in documentation

### DIFF
--- a/docs/ingestion-beam/index.md
+++ b/docs/ingestion-beam/index.md
@@ -264,7 +264,7 @@ gsutil cat $BUCKET/output/*
 Dataflow templates make a distinction between
 [runtime parameters that implement the `ValueProvider` interface](https://cloud.google.com/dataflow/docs/guides/templates/creating-templates#runtime-parameters-and-the-valueprovider-interface)
 and compile-time parameters which do not.
-All option can be specified at template compile time by passing command line flags,
+All options can be specified at template compile time by passing command line flags,
 but runtime parameters can also be overridden when
 [executing the template](https://cloud.google.com/dataflow/docs/guides/templates/executing-templates#using-gcloud)
 via the `--parameters` flag.
@@ -349,12 +349,12 @@ unmodified.
 #### GeoIP Lookup
 
 1. Extract `ip` from the `x_forwarded_for` attribute
-   * when the `x_pipeline_proxy` attribute is not present, use the
+    * when the `x_pipeline_proxy` attribute is not present, use the
      second-to-last value (since the last value is a forwarding rule IP
      added by Google load balancer)
-   * when the `x_pipeline_proxy` attribute is present, use the third-to-last
+    * when the `x_pipeline_proxy` attribute is present, use the third-to-last
      value (since the tee introduces an additional proxy IP)
-   * fall back to the `remote_addr` attribute, then to an empty string
+    * fall back to the `remote_addr` attribute, then to an empty string
 1. Execute the following steps until one fails and ignore the exception
     1. Parse `ip` using `InetAddress.getByName`
     1. Lookup `ip` in the configured `GeoIP2City.mmdb`

--- a/docs/ingestion-edge/index.md
+++ b/docs/ingestion-edge/index.md
@@ -2,7 +2,7 @@
 
 A simple service for delivering HTTP messages to Google Cloud PubSub
 
-The source code lives in the [ingestion-edge](https://github.com/mozilla/gcp-ingestion/tree/master/ingestion-beam)
+The source code lives in the [ingestion-edge](https://github.com/mozilla/gcp-ingestion/tree/master/ingestion-edge)
 subdirectory of the gcp-ingestion repository.
 
 ## Building
@@ -173,7 +173,7 @@ docker-compose run --rm test bin/pytest tests/load
 
 Load test options (from `./bin/test -h`)
 
-```
+```plain
   --min-success-rate=MIN_SUCCESS_RATE
                         Minimum 200 responses per non-200 response to require
                         during --test-period, default is 1000 (0.1% errors)


### PR DESCRIPTION
I was reading through the docs and found some broken links and formatting. Thought it might be nice to fix them.