### PR TITLE
Bug: Cannot serialize PipelineOptions

### DIFF
--- a/ingestion-beam/src/test/resources/testdata/pubsub-integration/error-input.ndjson
+++ b/ingestion-beam/src/test/resources/testdata/pubsub-integration/error-input.ndjson
@@ -1,0 +1,1 @@
+{"attributeMap":{"host":"test"},"payload":"dGVzdA=="}

--- a/ingestion-beam/src/test/resources/testdata/pubsub-integration/error-output.ndjson
+++ b/ingestion-beam/src/test/resources/testdata/pubsub-integration/error-output.ndjson
@@ -1,0 +1,1 @@
+{"attributeMap":{"host":"test","input":"test input","input_type":"pubsub","job_name":"test job name"},"payload":"dGVzdA=="}


### PR DESCRIPTION
Fixup for #759 where we accessed a PipelineOptions instance from
a function body that has to execute on workers, thus it tried to
serialize the options object and failed.

This change fixes the bug and adds an integration test case to make
sure we exercise pubsub error output.