### PR TITLE
Fix template build

### DIFF
--- a/bin/mvn
+++ b/bin/mvn
@@ -2,7 +2,7 @@
 
 # Wrapper script for executing maven via docker, but interacting with
 # the local filesystem. Useful for local development without installing
-# Java and mvn.
+# Java and mvn and also used by Jenkins.
 
 set -eo pipefail
 
@@ -17,9 +17,14 @@ else
     PROFILE=()
 fi
 
+INTERACTIVE_FLAGS=""
+if [ -z "$NONINTERACTIVE" ]; then
+    INTERACTIVE_FLAGS="-it"
+fi
+
 # Run mvn with a non-root user id
 # https://docs.docker.com/samples/library/maven/#Running-as-non-root
-docker run -it --rm \
+docker run $INTERACTIVE_FLAGS --rm \
     -u $UID \
     -v "$(git rev-parse --show-toplevel)":/var/maven/project \
     -w /var/maven/project \

--- a/bin/mvn
+++ b/bin/mvn
@@ -17,10 +17,14 @@ else
     PROFILE=()
 fi
 
+# Run mvn with a non-root user id
+# https://docs.docker.com/samples/library/maven/#Running-as-non-root
 docker run -it --rm \
-    -v ~/.m2:/root/.m2 \
-    -v "$(git rev-parse --show-toplevel)":/root/project \
-    -w /root/project \
+    -u $UID \
+    -v "$(git rev-parse --show-toplevel)":/var/maven/project \
+    -w /var/maven/project \
+    -v ~/.m2:/var/maven/.m2 \
+    -e MAVEN_CONFIG=/var/maven/.m2 \
     -e GOOGLE_APPLICATION_CREDENTIALS \
     maven \
     mvn "${PROFILE[@]}" "$@"

--- a/bin/mvn
+++ b/bin/mvn
@@ -31,5 +31,5 @@ docker run $INTERACTIVE_FLAGS --rm \
     -v ~/.m2:/var/maven/.m2 \
     -e MAVEN_CONFIG=/var/maven/.m2 \
     -e GOOGLE_APPLICATION_CREDENTIALS \
-     maven:3-jdk-8 \
+    maven:3-jdk-8 \
     mvn "${PROFILE[@]}" "$@"

--- a/bin/mvn
+++ b/bin/mvn
@@ -26,5 +26,5 @@ docker run -it --rm \
     -v ~/.m2:/var/maven/.m2 \
     -e MAVEN_CONFIG=/var/maven/.m2 \
     -e GOOGLE_APPLICATION_CREDENTIALS \
-    maven \
+     maven:3-jdk-8 \
     mvn "${PROFILE[@]}" "$@"

--- a/ingestion-beam/bin/build-template
+++ b/ingestion-beam/bin/build-template
@@ -84,14 +84,4 @@ cd "$(dirname "$0")/.."
 # Create dir to cache maven dependencies if it doesn't already exist.
 mkdir -p ~/.m2
 
-# Get current path and git root path
-GIT_TOPLEVEL="$(git rev-parse --show-toplevel)"
-GIT_PREFIX="$(git rev-parse --show-prefix)"
-
-# Run mvn with a non-root user id
-# https://docs.docker.com/samples/library/maven/#Running-as-non-root
-docker run -v ~/.m2:/var/maven/.m2 --rm -u $UID \
-  -v "$GIT_TOPLEVEL":/var/maven/project -w /var/maven/project/"$GIT_PREFIX" \
-  -e MAVEN_CONFIG=/var/maven/.m2 maven mvn \
-  -Duser.home=/var/maven \
-  compile exec:java -Dexec.mainClass=$JOB_CLASS -Dexec.args="$COMPILE_OPTIONS"
+./bin/mvn compile exec:java -Dexec.mainClass=$JOB_CLASS -Dexec.args="$COMPILE_OPTIONS"

--- a/ingestion-beam/bin/build-template
+++ b/ingestion-beam/bin/build-template
@@ -84,4 +84,7 @@ cd "$(dirname "$0")/.."
 # Create dir to cache maven dependencies if it doesn't already exist.
 mkdir -p ~/.m2
 
+# Jenkins doesn't want a tty, so we set a variable to let ./bin/mvn know not to allocate one.
+export NONINTERACTIVE=true
+
 ./bin/mvn compile exec:java -Dexec.mainClass=$JOB_CLASS -Dexec.args="$COMPILE_OPTIONS"


### PR DESCRIPTION
@whd reported that the template builds were failing, and it looks like that's due to the script not being updated to run maven at the top level.

I take this opportunity to make `bin/mvn` usable within the template build script.