### PR TITLE
Ensure we use Jackson for serializing to JSON

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -140,7 +140,11 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
 
     addAttributesFromPayload(attributes, json);
 
-    byte[] normalizedPayload = json.toString().getBytes();
+    // https://github.com/mozilla/gcp-ingestion/issues/780
+    // We need to be careful to consistently use our util methods (which use Jackson) for
+    // serializing and deserializing JSON to reduce the possibility of introducing encoding
+    // issues. We previously called json.toString().getBytes() here without specifying a charset.
+    byte[] normalizedPayload = Json.asBytes(json);
 
     PerDocTypeCounter.inc(attributes, "valid_submission");
     PerDocTypeCounter.inc(attributes, "valid_submission_bytes", submissionBytes);


### PR DESCRIPTION
Closes #780

I wasn't able to reproduce encoding problems on my Mac using the Java local runner, but I _was_ able to reproduce issues by submitting a job to Dataflow. The change in this PR led to correct output without corrupted characters replaced by `?`.

I don't see a way to write a regression test for this, since I still don't understand what exactly about the Dataflow execution environment differs from local testing.