### PR TITLE
Forbid use of String.getBytes() via checkstyle regex

### DIFF
--- a/checkstyle/checks.xml
+++ b/checkstyle/checks.xml
@@ -42,6 +42,11 @@
         <module name="SuppressWarningsHolder"/>
         <module name="UnusedImports"/>
         <module name="OuterTypeFilename"/>
+        <module name="RegexpSinglelineJava">
+            <!-- We should always pass in StandardCharsets.UTF_8 when calling String#getBytes() -->
+            <property name="format" value="getBytes\(\)"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
             <property name="format"

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/Deduplicate.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/Deduplicate.java
@@ -15,6 +15,7 @@ import com.mozilla.telemetry.util.Time;
 import java.io.Serializable;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -119,7 +120,8 @@ public class Deduplicate {
             .apply("DropDuplicatePayloads", MapElements //
                 .into(TypeDescriptor.of(PubsubMessage.class))
                 .via(message -> FailureMessage.of("Duplicate",
-                    new PubsubMessage("".getBytes(), message.getAttributeMap()),
+                    new PubsubMessage("".getBytes(StandardCharsets.UTF_8),
+                        message.getAttributeMap()),
                     new DuplicateIdException())));
         PCollection<PubsubMessage> errors = PCollectionList.of(tuple().get(errorTag()))
             .and(duplicateMetadata)

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -14,6 +14,7 @@ import com.mozilla.telemetry.transforms.MapElementsWithErrors;
 import com.mozilla.telemetry.transforms.PubsubConstraints;
 import com.mozilla.telemetry.util.Json;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -212,7 +213,7 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
       crc32 = new CRC32();
     }
     crc32.reset();
-    crc32.update(clientId.getBytes());
+    crc32.update(clientId.getBytes(StandardCharsets.UTF_8));
     return crc32.getValue() % 100;
   }
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableSet;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
 import com.mozilla.telemetry.transforms.MapElementsWithErrors;
 import com.mozilla.telemetry.transforms.PubsubConstraints;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -273,7 +274,7 @@ public class ParseUri extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMe
         }
       }
       // Serialize new payload as json
-      return payload.toString().getBytes();
+      return payload.toString().getBytes(StandardCharsets.UTF_8);
     }
   }
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
@@ -26,6 +26,7 @@ import com.mozilla.telemetry.transforms.PubsubMessageToTableRow.TableRowFormat;
 import com.mozilla.telemetry.transforms.WithErrors;
 import com.mozilla.telemetry.util.DynamicPathTemplate;
 import com.mozilla.telemetry.util.NoColonFileNaming;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -442,7 +443,7 @@ public abstract class Write
                   }
                   TableRow row = bqie.getRow();
                   row.setFactory(JacksonFactory.getDefaultInstance());
-                  byte[] payload = row.toString().getBytes();
+                  byte[] payload = row.toString().getBytes(StandardCharsets.UTF_8);
                   return new PubsubMessage(payload, attributes);
                 })));
       });

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/DecodePubsubMessages.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/DecodePubsubMessages.java
@@ -5,6 +5,7 @@
 package com.mozilla.telemetry.transforms;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 
 /**
@@ -45,7 +46,7 @@ public abstract class DecodePubsubMessages
   public static class Text extends DecodePubsubMessages {
 
     protected PubsubMessage processElement(String element) {
-      return new PubsubMessage(element.getBytes(), null);
+      return new PubsubMessage(element.getBytes(StandardCharsets.UTF_8), null);
     }
   }
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/FailureMessage.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/FailureMessage.java
@@ -5,6 +5,7 @@
 package com.mozilla.telemetry.transforms;
 
 import com.google.common.collect.ImmutableMap;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +35,7 @@ public class FailureMessage {
    * Return a PubsubMessage wrapping a String payload with attributes describing the error.
    */
   public static PubsubMessage of(Object caller, String payload, Throwable e) {
-    return FailureMessage.of(caller, payload.getBytes(), e);
+    return FailureMessage.of(caller, payload.getBytes(StandardCharsets.UTF_8), e);
   }
 
   /**

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubConstraints.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubConstraints.java
@@ -4,12 +4,12 @@
 
 package com.mozilla.telemetry.transforms;
 
-import com.google.common.base.Charsets;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
@@ -111,7 +111,7 @@ public class PubsubConstraints {
     if (s == null) {
       return null;
     }
-    Charset charset = Charsets.UTF_8;
+    Charset charset = StandardCharsets.UTF_8;
     CharsetDecoder decoder = charset.newDecoder();
     byte[] sba = s.getBytes(charset);
     if (sba.length <= maxBytes) {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/FileWindowingTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/FileWindowingTest.java
@@ -15,6 +15,7 @@ import com.mozilla.telemetry.options.SinkOptions;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -108,7 +109,8 @@ public class FileWindowingTest implements Serializable {
   }
 
   private TimestampedValue<PubsubMessage> message(String content, Duration baseTimeOffset) {
-    return TimestampedValue.of(new PubsubMessage(content.getBytes(), new HashMap<>()),
+    return TimestampedValue.of(
+        new PubsubMessage(content.getBytes(StandardCharsets.UTF_8), new HashMap<>()),
         baseTime.plus(baseTimeOffset));
   }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/avro/PubsubMessageRecordFormatterTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/avro/PubsubMessageRecordFormatterTest.java
@@ -6,6 +6,7 @@ package com.mozilla.telemetry.avro;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -23,7 +24,8 @@ public class PubsubMessageRecordFormatterTest {
 
   @Test
   public void testFormatNull() {
-    byte[] data = new JSONObject().put("test_null", JSONObject.NULL).toString().getBytes();
+    byte[] data = new JSONObject().put("test_null", JSONObject.NULL).toString()
+        .getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder.record("root").fields().name("test_null").type().nullType()
@@ -40,7 +42,7 @@ public class PubsubMessageRecordFormatterTest {
     byte[] data = new JSONObject() //
         .put("test_bool", true).put("test_long", -7).put("test_double", 0.99)
         .put("test_string", "hello world") //
-        .toString().getBytes();
+        .toString().getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder.record("root").fields() //
@@ -69,7 +71,7 @@ public class PubsubMessageRecordFormatterTest {
             .put("parallelogram", true) //
             .put("trapezoid", true) //
             .put("kite", true))) //
-        .toString().getBytes();
+        .toString().getBytes(StandardCharsets.UTF_8);
   }
 
   @Test
@@ -124,7 +126,7 @@ public class PubsubMessageRecordFormatterTest {
   public void testFormatArray() {
     byte[] data = new JSONObject() //
         .put("test_array", new JSONArray().put(true).put(false).put(true)) //
-        .toString().getBytes();
+        .toString().getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder //
@@ -144,7 +146,7 @@ public class PubsubMessageRecordFormatterTest {
     byte[] data = new JSONObject() //
         .put("test_none", JSONObject.NULL) //
         .put("test_some", true) //
-        .toString().getBytes();
+        .toString().getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder //
@@ -163,7 +165,8 @@ public class PubsubMessageRecordFormatterTest {
   @Test(expected = AvroTypeException.class)
   public void testFormatMissingRequiredFieldThrowsException() {
     PubsubMessageRecordFormatter formatter = new PubsubMessageRecordFormatter();
-    byte[] data = new JSONObject().put("unused", JSONObject.NULL).toString().getBytes();
+    byte[] data = new JSONObject().put("unused", JSONObject.NULL).toString()
+        .getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder.record("root").fields() //
@@ -175,7 +178,8 @@ public class PubsubMessageRecordFormatterTest {
   @Test(expected = AvroTypeException.class)
   public void testFormatNullAsBooleanWithBooleanDefault() {
     PubsubMessageRecordFormatter formatter = new PubsubMessageRecordFormatter();
-    byte[] data = new JSONObject().put("test", JSONObject.NULL).toString().getBytes();
+    byte[] data = new JSONObject().put("test", JSONObject.NULL).toString()
+        .getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder.record("root").fields() //
@@ -190,7 +194,8 @@ public class PubsubMessageRecordFormatterTest {
   @Test
   public void testFormatMissingAsBooleanWithBooleanDefaultIsNull() {
     PubsubMessageRecordFormatter formatter = new PubsubMessageRecordFormatter();
-    byte[] data = new JSONObject().put("unused", JSONObject.NULL).toString().getBytes();
+    byte[] data = new JSONObject().put("unused", JSONObject.NULL).toString()
+        .getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder.record("root").fields() //
@@ -209,7 +214,8 @@ public class PubsubMessageRecordFormatterTest {
   @Test
   public void testFormatMissingAsBooleanWithNullDefault() {
     PubsubMessageRecordFormatter formatter = new PubsubMessageRecordFormatter();
-    byte[] data = new JSONObject().put("unused", JSONObject.NULL).toString().getBytes();
+    byte[] data = new JSONObject().put("unused", JSONObject.NULL).toString()
+        .getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder.record("root").fields() //
@@ -223,7 +229,8 @@ public class PubsubMessageRecordFormatterTest {
   @Test
   public void testFormatMissingMultipleAsBooleanWithNull() {
     PubsubMessageRecordFormatter formatter = new PubsubMessageRecordFormatter();
-    byte[] data = new JSONObject().put("unused", JSONObject.NULL).toString().getBytes();
+    byte[] data = new JSONObject().put("unused", JSONObject.NULL).toString()
+        .getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder.record("root").fields() //
@@ -239,7 +246,7 @@ public class PubsubMessageRecordFormatterTest {
   @Test
   public void testFormatEmptyObjectAsBooleanWithNull() {
     PubsubMessageRecordFormatter formatter = new PubsubMessageRecordFormatter();
-    byte[] data = new JSONObject().toString().getBytes();
+    byte[] data = new JSONObject().toString().getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder.record("root").fields() //
@@ -257,7 +264,7 @@ public class PubsubMessageRecordFormatterTest {
     byte[] data = new JSONObject() //
         .put("test_none", JSONObject.NULL) //
         .put("test_some", new JSONObject().put("test_field", true)) //
-        .toString().getBytes();
+        .toString().getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema subschema = SchemaBuilder.record("test_object").fields().name("test_field").type()
@@ -284,7 +291,7 @@ public class PubsubMessageRecordFormatterTest {
         .put("test_string", "hello world") //
         .put("test_object", new JSONObject().put("test_field", true)) //
         .put("test_array", new JSONArray().put(1).put(2).put(3)) //
-        .toString().getBytes();
+        .toString().getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder.record("root").fields() //
@@ -316,7 +323,7 @@ public class PubsubMessageRecordFormatterTest {
         .put("-test-prefix-hyphen", true) //
         .put("$test-bad-symbol", true) //
         .put("0-test-prefix-number", true) //
-        .toString().getBytes();
+        .toString().getBytes(StandardCharsets.UTF_8);
     PubsubMessage message = new PubsubMessage(data, Collections.emptyMap());
 
     Schema schema = SchemaBuilder.record("root").fields() //

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
 import com.mozilla.telemetry.util.Json;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONObject;
@@ -31,7 +32,7 @@ public class MessageScrubberTest {
         + "    },\n" //
         + "    \"session_id\": \"ca98fe03-1248-448f-bbdf-59f97dba5a0e\"\n" //
         + "  },\n" //
-        + "  \"client_id\": null\n" + "}").getBytes());
+        + "  \"client_id\": null\n" + "}").getBytes(StandardCharsets.UTF_8));
     assertTrue(MessageScrubber.shouldScrub(attributes, bug1567596AffectedJson));
     assertFalse(MessageScrubber.shouldScrub(new HashMap<>(), bug1567596AffectedJson));
     assertFalse(MessageScrubber.shouldScrub(attributes, new JSONObject()));
@@ -46,7 +47,7 @@ public class MessageScrubberTest {
         + "    },\n" //
         + "    \"session_id\": \"ca98fe03-1248-448f-bbdf-59f97dba5a0e\"\n" //
         + "  },\n" //
-        + "  \"client_id\": null\n" + "}").getBytes());
+        + "  \"client_id\": null\n" + "}").getBytes(StandardCharsets.UTF_8));
 
     Map<String, String> attributes = Maps.newHashMap(ImmutableMap.<String, String>builder()
         .put(Attribute.DOCUMENT_NAMESPACE, "telemetry").put(Attribute.DOCUMENT_TYPE, "crash")
@@ -72,7 +73,7 @@ public class MessageScrubberTest {
         + "    ],\n" //
         + "    \"session_id\": \"ca98fe03-1248-448f-bbdf-59f97dba5a0e\"\n" //
         + "  },\n" //
-        + "  \"client_id\": null\n" + "}").getBytes());
+        + "  \"client_id\": null\n" + "}").getBytes(StandardCharsets.UTF_8));
 
     Map<String, String> attributes = ImmutableMap.<String, String>builder()
         .put(Attribute.DOCUMENT_NAMESPACE, "telemetry").put(Attribute.DOCUMENT_TYPE, "bhr")

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/CompressPayloadTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/CompressPayloadTest.java
@@ -6,6 +6,7 @@ package com.mozilla.telemetry.transforms;
 
 import static org.junit.Assert.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
@@ -20,7 +21,8 @@ public class CompressPayloadTest {
   @Test
   public void testGzipCompress() {
     String text = StringUtils.repeat("Lorem ipsum dolor sit amet ", 100);
-    byte[] compressedBytes = CompressPayload.compress(text.getBytes(), Compression.GZIP);
+    byte[] compressedBytes = CompressPayload.compress(text.getBytes(StandardCharsets.UTF_8),
+        Compression.GZIP);
     assertThat(ArrayUtils.toObject(compressedBytes), Matchers.arrayWithSize(68));
   }
 
@@ -31,7 +33,7 @@ public class CompressPayloadTest {
     CompressPayload transform = CompressPayload.of(StaticValueProvider.of(Compression.GZIP))
         .withMaxCompressedBytes(expectedCompressedSize - 1);
     PubsubMessage truncated = transform
-        .compress(new PubsubMessage(text.getBytes(), new HashMap<>()));
+        .compress(new PubsubMessage(text.getBytes(StandardCharsets.UTF_8), new HashMap<>()));
     assertThat(ArrayUtils.toObject(truncated.getPayload()), Matchers.arrayWithSize(50));
   }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableMap;
 import com.mozilla.telemetry.transforms.PubsubMessageToTableRow.TableRowFormat;
 import com.mozilla.telemetry.util.Json;
 import com.mozilla.telemetry.util.TestWithDeterministicJson;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -88,7 +89,7 @@ public class PubsubMessageToTableRowTest extends TestWithDeterministicJson {
   public void testCoerceMapValueToString() throws Exception {
     String mainPing = "{\"payload\":{\"processes\":{\"parent\":{\"scalars\":"
         + "{\"timestamps.first_paint\":5405}}}}}";
-    Map<String, Object> parent = Json.readTableRow(mainPing.getBytes());
+    Map<String, Object> parent = Json.readTableRow(mainPing.getBytes(StandardCharsets.UTF_8));
     Map<String, Object> additionalProperties = new HashMap<>();
     parent.put("64bit", true);
     parent.put("hi-fi", true);
@@ -211,7 +212,7 @@ public class PubsubMessageToTableRowTest extends TestWithDeterministicJson {
         + "      }\n" //
         + "    }\n" //
         + "  }\n" //
-        + "}\n").getBytes());
+        + "}\n").getBytes(StandardCharsets.UTF_8));
     List<Field> bqFields = ImmutableList.of(Field
         .newBuilder("metrics", LegacySQLTypeName.RECORD, Field.of("key", LegacySQLTypeName.STRING),
             Field.of("value", LegacySQLTypeName.RECORD,
@@ -240,7 +241,7 @@ public class PubsubMessageToTableRowTest extends TestWithDeterministicJson {
 
   @Test
   public void testRawFormat() throws Exception {
-    PubsubMessage message = new PubsubMessage("test".getBytes(),
+    PubsubMessage message = new PubsubMessage("test".getBytes(StandardCharsets.UTF_8),
         // Use example values for all attributes present in the spec:
         // https://github.com/mozilla/gcp-ingestion/blob/master/docs/edge.md#edge-server-pubsub-message-schema
         ImmutableMap.<String, String>builder()
@@ -264,7 +265,7 @@ public class PubsubMessageToTableRowTest extends TestWithDeterministicJson {
   @Test
   public void testDecodedFormat() throws Exception {
 
-    PubsubMessage message = new PubsubMessage("test".getBytes(),
+    PubsubMessage message = new PubsubMessage("test".getBytes(StandardCharsets.UTF_8),
         // Ensure sure we preserve all attributes present in the spec:
         // https://github.com/mozilla/gcp-ingestion/blob/master/docs/decoder.md#decoded-message-metadata-schema
         ImmutableMap.<String, String>builder()

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/util/JsonTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/util/JsonTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Schema;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 
 public class JsonTest {
@@ -20,7 +21,7 @@ public class JsonTest {
 
   @Test
   public void testReadTableRowSuceedsOnEmptyJsonObject() throws Exception {
-    Json.readTableRow("{}".getBytes());
+    Json.readTableRow("{}".getBytes(StandardCharsets.UTF_8));
   }
 
   @Test(expected = IOException.class)
@@ -35,13 +36,14 @@ public class JsonTest {
 
   @Test(expected = IOException.class)
   public void testReadTableRowThrowsOnNullJson() throws Exception {
-    Json.readTableRow("null".getBytes());
+    Json.readTableRow("null".getBytes(StandardCharsets.UTF_8));
   }
 
   @Test
   public void testReadBigQuerySchema() throws Exception {
     Schema schema = Json.readBigQuerySchema(
-        "[{\"mode\":\"NULLABLE\",\"name\":\"document_id\",\"type\": \"STRING\"}]".getBytes());
+        "[{\"mode\":\"NULLABLE\",\"name\":\"document_id\",\"type\": \"STRING\"}]"
+            .getBytes(StandardCharsets.UTF_8));
     assertEquals(LegacySQLTypeName.STRING, schema.getFields().get(0).getType());
   }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/util/TestWithDeterministicJson.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/util/TestWithDeterministicJson.java
@@ -7,6 +7,7 @@ package com.mozilla.telemetry.util;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -30,7 +31,7 @@ public abstract class TestWithDeterministicJson {
   @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
   public static String sortJSON(String data) {
     try {
-      return Json.readJSONObject(data.getBytes()).toString();
+      return Json.readJSONObject(data.getBytes(StandardCharsets.UTF_8)).toString();
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
@@ -16,6 +16,7 @@ import com.mozilla.telemetry.ingestion.sink.util.BatchWrite;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.UUID;
 
@@ -38,7 +39,7 @@ public class Gcs {
 
       @Override
       protected byte[] encodeInput(PubsubMessage input) {
-        return (encoder.apply(input).toString() + "\n").getBytes();
+        return (encoder.apply(input).toString() + "\n").getBytes(StandardCharsets.UTF_8);
       }
     }
 

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/SinkBigQueryIntegrationTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/SinkBigQueryIntegrationTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.mozilla.telemetry.ingestion.sink.util.TestWithSinglePubsubTopic;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -95,8 +96,8 @@ public class SinkBigQueryIntegrationTest extends TestWithSinglePubsubTopic {
       TableId tableId = TableId.of(dataset, table);
       bigquery.create(TableInfo.newBuilder(tableId, tableDef).build());
       PubsubMessage.Builder message = PubsubMessage.newBuilder()
-          .setData(ByteString.copyFrom("test".getBytes())).putAttributes("document_type", "test")
-          .putAttributes("document_version", version)
+          .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8)))
+          .putAttributes("document_type", "test").putAttributes("document_version", version)
           .putAttributes("submission_timestamp", submissionTimestamp);
       if (documentIds.containsKey(version)) {
         message.putAttributes("document_id", documentIds.get(version));

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/SinkGcsIntegrationTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/SinkGcsIntegrationTest.java
@@ -17,6 +17,7 @@ import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.mozilla.telemetry.ingestion.sink.io.Pubsub;
 import com.mozilla.telemetry.ingestion.sink.util.TestWithSinglePubsubTopic;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -66,11 +67,11 @@ public class SinkGcsIntegrationTest extends TestWithSinglePubsubTopic {
     String submissionTimestamp = ZonedDateTime.now(ZoneOffset.UTC)
         .format(DateTimeFormatter.ISO_DATE_TIME);
     List<String> versions = ImmutableList.of("1", "2");
-    versions.forEach(version -> publish(
-        PubsubMessage.newBuilder().setData(ByteString.copyFrom("test".getBytes()))
-            .putAttributes("document_namespace", "namespace").putAttributes("document_type", "type")
-            .putAttributes("document_version", version)
-            .putAttributes("submission_timestamp", submissionTimestamp).build()));
+    versions.forEach(version -> publish(PubsubMessage.newBuilder()
+        .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8)))
+        .putAttributes("document_namespace", "namespace").putAttributes("document_type", "type")
+        .putAttributes("document_version", version)
+        .putAttributes("submission_timestamp", submissionTimestamp).build()));
 
     environmentVariables.set("INPUT_SUBSCRIPTION", getSubscription());
     environmentVariables.set("BATCH_MAX_DELAY", "0.001s");

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/GcsWriteTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/GcsWriteTest.java
@@ -20,6 +20,7 @@ import com.google.pubsub.v1.PubsubMessage;
 import com.mozilla.telemetry.ingestion.sink.transform.PubsubMessageToJSONObject.Format;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.CompletionException;
 import org.junit.Before;
@@ -28,7 +29,7 @@ import org.junit.Test;
 public class GcsWriteTest {
 
   private static final PubsubMessage EMPTY_MESSAGE = PubsubMessage.newBuilder().build();
-  private static final int EMPTY_MESSAGE_SIZE = "{}\n".getBytes().length;
+  private static final int EMPTY_MESSAGE_SIZE = "{}\n".getBytes(StandardCharsets.UTF_8).length;
   private static final String BATCH_KEY = "bucket/prefix/";
   private static final int MAX_BYTES = 10;
   private static final int MAX_MESSAGES = 10;

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/PubsubReadIntegrationTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/PubsubReadIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.mozilla.telemetry.ingestion.sink.util.TestWithSinglePubsubTopic;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -18,7 +19,7 @@ import org.junit.Test;
 public class PubsubReadIntegrationTest extends TestWithSinglePubsubTopic {
 
   private static final PubsubMessage TEST_MESSAGE = PubsubMessage.newBuilder()
-      .setData(ByteString.copyFrom("test".getBytes())).build();
+      .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8))).build();
 
   @Test
   public void canReadOneMessage() {

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/PubsubWriteIntegrationTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/PubsubWriteIntegrationTest.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.mozilla.telemetry.ingestion.sink.util.TestWithSinglePubsubTopic;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.Rule;
@@ -23,9 +24,8 @@ public class PubsubWriteIntegrationTest extends TestWithSinglePubsubTopic {
 
   @Test
   public void canWriteToStaticDestination() {
-    new Pubsub.Write(getTopic(), 1, b -> b)
-        .apply(PubsubMessage.newBuilder().setData(ByteString.copyFrom("test".getBytes())).build())
-        .join();
+    new Pubsub.Write(getTopic(), 1, b -> b).apply(PubsubMessage.newBuilder()
+        .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8))).build()).join();
     assertEquals(ImmutableList.of("test"),
         pull(1, false).stream().map(m -> m.getData().toStringUtf8()).collect(Collectors.toList()));
   }
@@ -33,8 +33,8 @@ public class PubsubWriteIntegrationTest extends TestWithSinglePubsubTopic {
   @Test
   public void canWriteToDynamicDestination() {
     new Pubsub.Write("${topic}", 1, b -> b).apply(PubsubMessage.newBuilder()
-        .setData(ByteString.copyFrom("test".getBytes())).putAttributes("topic", getTopic()).build())
-        .join();
+        .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8)))
+        .putAttributes("topic", getTopic()).build()).join();
     assertEquals(ImmutableList.of("test"),
         pull(1, false).stream().map(m -> m.getData().toStringUtf8()).collect(Collectors.toList()));
   }

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/transform/PubsubMessageToJSONObjectTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/transform/PubsubMessageToJSONObjectTest.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.mozilla.telemetry.ingestion.sink.transform.PubsubMessageToJSONObject.Format;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.junit.Test;
 
@@ -25,7 +26,8 @@ public class PubsubMessageToJSONObjectTest {
   @Test
   public void canFormatAsRaw() {
     final Map<String, Object> actual = RAW_TRANSFORM
-        .apply(PubsubMessage.newBuilder().setData(ByteString.copyFrom("test".getBytes()))
+        .apply(PubsubMessage.newBuilder()
+            .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8)))
             .putAttributes("document_id", "id").putAttributes("document_namespace", "telemetry")
             .putAttributes("document_type", "main").putAttributes("document_version", "4").build())
         .toMap();
@@ -55,32 +57,30 @@ public class PubsubMessageToJSONObjectTest {
 
   @Test
   public void canFormatTelemetryAsDecoded() {
-    final Map<String, Object> actual = DECODED_TRANSFORM
-        .apply(PubsubMessage.newBuilder().setData(ByteString.copyFrom("test".getBytes()))
-            .putAttributes("geo_city", "geo_city").putAttributes("geo_country", "geo_country")
-            .putAttributes("geo_subdivision1", "geo_subdivision1")
-            .putAttributes("geo_subdivision2", "geo_subdivision2")
-            .putAttributes("user_agent_browser", "user_agent_browser")
-            .putAttributes("user_agent_os", "user_agent_os")
-            .putAttributes("user_agent_version", "user_agent_version").putAttributes("date", "date")
-            .putAttributes("dnt", "dnt").putAttributes("x_debug_id", "x_debug_id")
-            .putAttributes("x_pingsender_version", "x_pingsender_version")
-            .putAttributes("uri", "uri").putAttributes("app_build_id", "app_build_id")
-            .putAttributes("app_name", "app_name")
-            .putAttributes("app_update_channel", "app_update_channel")
-            .putAttributes("app_version", "app_version")
-            .putAttributes("document_namespace", "telemetry")
-            .putAttributes("document_type", "document_type")
-            .putAttributes("document_version", "document_version")
-            .putAttributes("submission_timestamp", "submission_timestamp")
-            .putAttributes("document_id", "document_id")
-            .putAttributes("normalized_app_name", "normalized_app_name")
-            .putAttributes("normalized_channel", "normalized_channel")
-            .putAttributes("normalized_country_code", "normalized_country_code")
-            .putAttributes("normalized_os", "normalized_os")
-            .putAttributes("normalized_os_version", "normalized_os_version")
-            .putAttributes("sample_id", "42").putAttributes("client_id", "client_id").build())
-        .toMap();
+    final Map<String, Object> actual = DECODED_TRANSFORM.apply(PubsubMessage.newBuilder()
+        .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8)))
+        .putAttributes("geo_city", "geo_city").putAttributes("geo_country", "geo_country")
+        .putAttributes("geo_subdivision1", "geo_subdivision1")
+        .putAttributes("geo_subdivision2", "geo_subdivision2")
+        .putAttributes("user_agent_browser", "user_agent_browser")
+        .putAttributes("user_agent_os", "user_agent_os")
+        .putAttributes("user_agent_version", "user_agent_version").putAttributes("date", "date")
+        .putAttributes("dnt", "dnt").putAttributes("x_debug_id", "x_debug_id")
+        .putAttributes("x_pingsender_version", "x_pingsender_version").putAttributes("uri", "uri")
+        .putAttributes("app_build_id", "app_build_id").putAttributes("app_name", "app_name")
+        .putAttributes("app_update_channel", "app_update_channel")
+        .putAttributes("app_version", "app_version")
+        .putAttributes("document_namespace", "telemetry")
+        .putAttributes("document_type", "document_type")
+        .putAttributes("document_version", "document_version")
+        .putAttributes("submission_timestamp", "submission_timestamp")
+        .putAttributes("document_id", "document_id")
+        .putAttributes("normalized_app_name", "normalized_app_name")
+        .putAttributes("normalized_channel", "normalized_channel")
+        .putAttributes("normalized_country_code", "normalized_country_code")
+        .putAttributes("normalized_os", "normalized_os")
+        .putAttributes("normalized_os_version", "normalized_os_version")
+        .putAttributes("sample_id", "42").putAttributes("client_id", "client_id").build()).toMap();
 
     assertEquals(
         ImmutableMap.builder()
@@ -114,32 +114,30 @@ public class PubsubMessageToJSONObjectTest {
 
   @Test
   public void canFormatNonTelemetryAsDecoded() {
-    final Map<String, Object> actual = DECODED_TRANSFORM
-        .apply(PubsubMessage.newBuilder().setData(ByteString.copyFrom("test".getBytes()))
-            .putAttributes("geo_city", "geo_city").putAttributes("geo_country", "geo_country")
-            .putAttributes("geo_subdivision1", "geo_subdivision1")
-            .putAttributes("geo_subdivision2", "geo_subdivision2")
-            .putAttributes("user_agent_browser", "user_agent_browser")
-            .putAttributes("user_agent_os", "user_agent_os")
-            .putAttributes("user_agent_version", "user_agent_version").putAttributes("date", "date")
-            .putAttributes("dnt", "dnt").putAttributes("x_debug_id", "x_debug_id")
-            .putAttributes("x_pingsender_version", "x_pingsender_version")
-            .putAttributes("uri", "uri").putAttributes("app_build_id", "app_build_id")
-            .putAttributes("app_name", "app_name")
-            .putAttributes("app_update_channel", "app_update_channel")
-            .putAttributes("app_version", "app_version")
-            .putAttributes("document_namespace", "document_namespace")
-            .putAttributes("document_type", "document_type")
-            .putAttributes("document_version", "document_version")
-            .putAttributes("submission_timestamp", "submission_timestamp")
-            .putAttributes("document_id", "document_id")
-            .putAttributes("normalized_app_name", "normalized_app_name")
-            .putAttributes("normalized_channel", "normalized_channel")
-            .putAttributes("normalized_country_code", "normalized_country_code")
-            .putAttributes("normalized_os", "normalized_os")
-            .putAttributes("normalized_os_version", "normalized_os_version")
-            .putAttributes("sample_id", "42").putAttributes("client_id", "client_id").build())
-        .toMap();
+    final Map<String, Object> actual = DECODED_TRANSFORM.apply(PubsubMessage.newBuilder()
+        .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8)))
+        .putAttributes("geo_city", "geo_city").putAttributes("geo_country", "geo_country")
+        .putAttributes("geo_subdivision1", "geo_subdivision1")
+        .putAttributes("geo_subdivision2", "geo_subdivision2")
+        .putAttributes("user_agent_browser", "user_agent_browser")
+        .putAttributes("user_agent_os", "user_agent_os")
+        .putAttributes("user_agent_version", "user_agent_version").putAttributes("date", "date")
+        .putAttributes("dnt", "dnt").putAttributes("x_debug_id", "x_debug_id")
+        .putAttributes("x_pingsender_version", "x_pingsender_version").putAttributes("uri", "uri")
+        .putAttributes("app_build_id", "app_build_id").putAttributes("app_name", "app_name")
+        .putAttributes("app_update_channel", "app_update_channel")
+        .putAttributes("app_version", "app_version")
+        .putAttributes("document_namespace", "document_namespace")
+        .putAttributes("document_type", "document_type")
+        .putAttributes("document_version", "document_version")
+        .putAttributes("submission_timestamp", "submission_timestamp")
+        .putAttributes("document_id", "document_id")
+        .putAttributes("normalized_app_name", "normalized_app_name")
+        .putAttributes("normalized_channel", "normalized_channel")
+        .putAttributes("normalized_country_code", "normalized_country_code")
+        .putAttributes("normalized_os", "normalized_os")
+        .putAttributes("normalized_os_version", "normalized_os_version")
+        .putAttributes("sample_id", "42").putAttributes("client_id", "client_id").build()).toMap();
 
     assertEquals(
         ImmutableMap.builder()


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/gcp-ingestion/issues/789