### PR TITLE
Fix maven dependency cache in docker

### DIFF
--- a/bin/mvn
+++ b/bin/mvn
@@ -32,4 +32,4 @@ docker run $INTERACTIVE_FLAGS --rm \
     -e MAVEN_CONFIG=/var/maven/.m2 \
     -e GOOGLE_APPLICATION_CREDENTIALS \
     maven:3-jdk-8 \
-    mvn "${PROFILE[@]}" "$@"
+    mvn -Duser.home=/var/maven "${PROFILE[@]}" "$@"


### PR DESCRIPTION
as seen in the sample for using maven as non-root in docker from https://docs.docker.com/samples/library/maven/#Running-as-non-root