### PR TITLE
Add DeduplicateByDocumentId transform

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -13,10 +13,12 @@ import com.mozilla.telemetry.decoder.ParseProxy;
 import com.mozilla.telemetry.decoder.ParseUri;
 import com.mozilla.telemetry.decoder.ParseUserAgent;
 import com.mozilla.telemetry.transforms.DecompressPayload;
+import com.mozilla.telemetry.transforms.DeduplicateByDocumentId;
 import com.mozilla.telemetry.transforms.LimitPayloadSize;
 import com.mozilla.telemetry.transforms.NormalizeAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
@@ -55,22 +57,26 @@ public class Decoder extends Sink {
     final Pipeline pipeline = Pipeline.create(options);
     final List<PCollection<PubsubMessage>> errorCollections = new ArrayList<>();
 
-    // Trailing comments are used below to prevent rewrapping by google-java-format.
-    pipeline //
-        .apply(options.getInputType().read(options)).errorsTo(errorCollections) //
-        .apply(ParseUri.of()).errorsTo(errorCollections) //
-        .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())) //
-        .apply(LimitPayloadSize.toMB(10)).errorsTo(errorCollections) //
-        .apply(ParsePayload.of(options.getSchemasLocation(), options.getSchemaAliasesLocation())) //
-        .errorsTo(errorCollections) //
-        .apply(ParseProxy.of()) //
-        .apply(GeoCityLookup.of(options.getGeoCityDatabase(), options.getGeoCityFilter())) //
-        .apply(ParseUserAgent.of()) //
-        .apply(NormalizeAttributes.of()) //
-        .apply(AddMetadata.of()).errorsTo(errorCollections) //
-        .apply(Deduplicate.removeDuplicates(options.getParsedRedisUri()))
-        .sendDuplicateMetadataToErrors().errorsTo(errorCollections) //
-        .apply(options.getOutputType().write(options)).errorsTo(errorCollections);
+    // We wrap pipeline in Optional for more convenience in chaining together transforms.
+    Optional.of(pipeline) //
+        .map(p -> p //
+            .apply(options.getInputType().read(options)).errorsTo(errorCollections) //
+            .apply(ParseUri.of()).errorsTo(errorCollections) //
+            .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())) //
+            .apply(LimitPayloadSize.toMB(10)).errorsTo(errorCollections) //
+            .apply(
+                ParsePayload.of(options.getSchemasLocation(), options.getSchemaAliasesLocation()))
+            .errorsTo(errorCollections) //
+            .apply(ParseProxy.of()) //
+            .apply(GeoCityLookup.of(options.getGeoCityDatabase(), options.getGeoCityFilter())) //
+            .apply(ParseUserAgent.of()) //
+            .apply(NormalizeAttributes.of()) //
+            .apply(AddMetadata.of()).errorsTo(errorCollections) //
+            .apply(Deduplicate.removeDuplicates(options.getParsedRedisUri()))
+            .sendDuplicateMetadataToErrors().errorsTo(errorCollections)) //
+        .map(p -> options.getDeduplicateByDocumentId() ? p.apply(DeduplicateByDocumentId.of()) : p)
+        .map(p -> p //
+            .apply(options.getOutputType().write(options)).errorsTo(errorCollections));
 
     // Write error output collections.
     PCollectionList.of(errorCollections) //

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Sink.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Sink.java
@@ -7,9 +7,11 @@ package com.mozilla.telemetry;
 import com.mozilla.telemetry.decoder.DecoderOptions;
 import com.mozilla.telemetry.options.SinkOptions;
 import com.mozilla.telemetry.transforms.DecompressPayload;
+import com.mozilla.telemetry.transforms.DeduplicateByDocumentId;
 import com.mozilla.telemetry.transforms.PublishBundleMetrics;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
@@ -49,12 +51,15 @@ public class Sink {
     final Pipeline pipeline = Pipeline.create(options);
     final List<PCollection<PubsubMessage>> errorCollections = new ArrayList<>();
 
-    // Trailing comments are used below to prevent rewrapping by google-java-format.
-    pipeline //
-        .apply(options.getInputType().read(options)).errorsTo(errorCollections) //
-        .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())) //
-        .apply(PublishBundleMetrics.of()) //
-        .apply(options.getOutputType().write(options)).errorsTo(errorCollections);
+    // We wrap pipeline in Optional for more convenience in chaining together transforms.
+    Optional.of(pipeline) //
+        .map(p -> p //
+            .apply(options.getInputType().read(options)).errorsTo(errorCollections)
+            .apply(DecompressPayload.enabled(options.getDecompressInputPayloads()))
+            .apply(PublishBundleMetrics.of())) //
+        .map(p -> options.getDeduplicateByDocumentId() ? p.apply(DeduplicateByDocumentId.of()) : p)
+        .map(p -> p //
+            .apply(options.getOutputType().write(options)).errorsTo(errorCollections));
 
     PCollectionList.of(errorCollections) //
         .apply("FlattenErrorCollections", Flatten.pCollections()) //

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseProxy.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseProxy.java
@@ -7,9 +7,8 @@ package com.mozilla.telemetry.decoder;
 import com.google.common.annotations.VisibleForTesting;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
 import com.mozilla.telemetry.transforms.PubsubConstraints;
+import com.mozilla.telemetry.util.Time;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -52,11 +51,11 @@ public class ParseProxy extends PTransform<PCollection<PubsubMessage>, PCollecti
       if (xpp != null) {
 
         // Check if X-Pipeline-Proxy is a timestamp
-        final Instant proxyInstant = parseAsInstantOrNull(xpp);
+        final Instant proxyInstant = Time.parseAsInstantOrNull(xpp);
         if (proxyInstant != null) {
           // Record the difference between submission and proxy times as tee latency.
           final String submissionTimestamp = attributes.get(Attribute.SUBMISSION_TIMESTAMP);
-          final Instant submissionInstant = parseAsInstantOrNull(submissionTimestamp);
+          final Instant submissionInstant = Time.parseAsInstantOrNull(submissionTimestamp);
           if (submissionInstant != null) {
             teeLatencyTimer.update(submissionInstant.toEpochMilli() - proxyInstant.toEpochMilli());
           }
@@ -96,11 +95,4 @@ public class ParseProxy extends PTransform<PCollection<PubsubMessage>, PCollecti
   private ParseProxy() {
   }
 
-  private static Instant parseAsInstantOrNull(String timestamp) {
-    try {
-      return Instant.from(DateTimeFormatter.ISO_INSTANT.parse(timestamp));
-    } catch (DateTimeParseException | NullPointerException ignore) {
-      return null;
-    }
-  }
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
@@ -190,6 +190,14 @@ public interface SinkOptions extends PipelineOptions {
 
   void setWindowDuration(String value);
 
+  @Description("Deduplicate globally by document_id attribute; this is an experimental option that"
+      + " may have terrible performance; it assumes that the job is running in batch mode over a"
+      + " single day of input (submission_timestamp values are all on the same date)")
+  @Default.Boolean(false)
+  Boolean getDeduplicateByDocumentId();
+
+  void setDeduplicateByDocumentId(Boolean value);
+
   /*
    * Note: Dataflow templates accept ValueProvider options at runtime, and other options at creation
    * time. When running without templates specify all options at once.

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/DeduplicateByDocumentId.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/DeduplicateByDocumentId.java
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.transforms;
+
+import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import com.mozilla.telemetry.util.Time;
+import java.time.Instant;
+import java.util.stream.StreamSupport;
+import org.apache.beam.sdk.io.Compression;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.Partition;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeDescriptors;
+
+/**
+ * Transform that introduces a GroupByKey operation to group together all duplicate messages in
+ * the batch, based on document_id.
+ *
+ * <p>The intention is that the logic here should exactly match the daily copy_deduplicate
+ * queries that we run to copy from _live tables to _stable tables. See
+ * https://github.com/mozilla/bigquery-etl/blob/master/script/copy_deduplicate
+ *
+ * <p>Records without a document_id attribute bypass the GroupByKey and are not deduplicated.
+ *
+ * <p>We apply no windowing, so the GroupByKey will be global. This assumes the pipeline is in
+ * batch mode and that the pipeline is processing a single day of data.
+ */
+public class DeduplicateByDocumentId
+    extends PTransform<PCollection<PubsubMessage>, PCollection<PubsubMessage>> {
+
+  public static DeduplicateByDocumentId of() {
+    return INSTANCE;
+  }
+
+  @Override
+  public PCollection<PubsubMessage> expand(PCollection<PubsubMessage> input) {
+    PCollectionList<PubsubMessage> partitioned = input.apply("PartitionByDocumentIdPresence",
+        Partition.of(2,
+            (message, numPartitions) -> message.getAttributeMap().containsKey(Attribute.DOCUMENT_ID)
+                ? 0
+                : 1));
+    PCollection<PubsubMessage> messagesWithDocId = partitioned.get(0);
+    PCollection<PubsubMessage> messagesWithoutDocId = partitioned.get(1);
+
+    PCollection<PubsubMessage> deduplicated = messagesWithDocId //
+        // We compress payloads before grouping by key to reduce I/O impact of the GroupByKey,
+        // which forces the pipeline to checkpoint state to disk.
+        .apply(CompressPayload.of(StaticValueProvider.of(Compression.GZIP)))
+        .apply("KeyByDocumentId",
+            MapElements
+                .into(TypeDescriptors.kvs(TypeDescriptors.strings(),
+                    TypeDescriptor.of(PubsubMessage.class)))
+                .via(message -> KV.of(message.getAttribute(Attribute.DOCUMENT_ID), message)))
+        .apply("GroupByDocumentId", GroupByKey.create()) //
+        .apply("TakeEarliestRecordPerDocumentId",
+            MapElements.into(TypeDescriptor.of(PubsubMessage.class)).via(
+                kv -> StreamSupport.stream(kv.getValue().spliterator(), false).min((m1, m2) -> {
+                  Instant i1 = Time
+                      .parseAsInstantOrNull(m1.getAttribute(Attribute.SUBMISSION_TIMESTAMP));
+                  Instant i2 = Time
+                      .parseAsInstantOrNull(m2.getAttribute(Attribute.SUBMISSION_TIMESTAMP));
+                  if (i2 == null) {
+                    // If i2 has an unparseable timestamp, we consider i1 the earlier record.
+                    return -1;
+                  } else if (i1 == null) {
+                    return 1;
+                  } else {
+                    return Math.toIntExact(i1.toEpochMilli() - i2.toEpochMilli());
+                  }
+                }).get()))
+        .apply(DecompressPayload.enabled(StaticValueProvider.of(true)));
+
+    return PCollectionList.of(messagesWithoutDocId).and(deduplicated) //
+        .apply(Flatten.pCollections());
+  }
+
+  ////
+
+  private static DeduplicateByDocumentId INSTANCE = new DeduplicateByDocumentId();
+
+  private DeduplicateByDocumentId() {
+  }
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/Time.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/Time.java
@@ -6,6 +6,9 @@ package com.mozilla.telemetry.util;
 
 import static com.mozilla.telemetry.ingestion.core.util.Time.parseJavaDuration;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.NestedValueProvider;
 
@@ -63,6 +66,17 @@ public class Time {
    */
   public static ValueProvider<Long> parseSeconds(ValueProvider<String> value) {
     return NestedValueProvider.of(value, Time::parseSeconds);
+  }
+
+  /**
+   * Attempts to parse a string in format '2011-12-03T10:15:30Z', returning null in case of error.
+   */
+  public static Instant parseAsInstantOrNull(String timestamp) {
+    try {
+      return Instant.from(DateTimeFormatter.ISO_INSTANT.parse(timestamp));
+    } catch (DateTimeParseException | NullPointerException ignore) {
+      return null;
+    }
   }
 
   /*

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/DeduplicateByDocumentIdTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/DeduplicateByDocumentIdTest.java
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.telemetry.transforms;
+
+import com.mozilla.telemetry.options.InputFileFormat;
+import com.mozilla.telemetry.options.OutputFileFormat;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DeduplicateByDocumentIdTest {
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testOutput() {
+    final List<String> input = Arrays.asList(
+        // Non-duplicated record
+        "{\"attributeMap\":{\"document_id\":\"not duplicated\""
+            + ",\"submission_timestamp\":\"2020-01-12T21:03:18.234567Z\"}"
+            + ",\"payload\":\"dGVzdA==\"}",
+        // No document_id
+        "{\"attributeMap\":{}" + ",\"payload\":\"dGVzdA==\"}",
+        "{\"attributeMap\":{}" + ",\"payload\":\"dGVzdA==\"}",
+        // Missing and invalid timestamps
+        "{\"attributeMap\":{\"document_id\":\"strange timestamps\""
+            + ",\"submission_timestamp\":\"2020-01-12F\"}" + ",\"payload\":\"dGVzdA==\"}",
+        "{\"attributeMap\":{\"document_id\":\"strange timestamps\""
+            + ",\"submission_timestamp\":\"2020-01-12T21:03:18.234567Z\"}"
+            + ",\"payload\":\"dGVzdA==\"}",
+        "{\"attributeMap\":{\"document_id\":\"strange timestamps\"}" + ",\"payload\":\"dGVzdA==\"}",
+        // Record that appears three times with different timestamps.
+        "{\"attributeMap\":{\"document_id\":\"foo\""
+            + ",\"submission_timestamp\":\"2020-01-12T21:03:18.234567Z\"}"
+            + ",\"payload\":\"dGVzdA==\"}",
+        "{\"attributeMap\":{\"document_id\":\"foo\""
+            + ",\"submission_timestamp\":\"2020-01-12T21:03:18.123456Z\"}"
+            + ",\"payload\":\"dGVzdA==\"}",
+        "{\"attributeMap\":{\"document_id\":\"foo\""
+            + ",\"submission_timestamp\":\"2020-01-12T21:02:18.123456Z\"}"
+            + ",\"payload\":\"dGVzdA==\"}");
+
+    final List<String> expected = Arrays.asList(
+        "{\"attributeMap\":{\"document_id\":\"not duplicated\""
+            + ",\"submission_timestamp\":\"2020-01-12T21:03:18.234567Z\"}"
+            + ",\"payload\":\"dGVzdA==\"}",
+        "{\"attributeMap\":{}" + ",\"payload\":\"dGVzdA==\"}",
+        "{\"attributeMap\":{}" + ",\"payload\":\"dGVzdA==\"}",
+        "{\"attributeMap\":{\"document_id\":\"strange timestamps\""
+            + ",\"submission_timestamp\":\"2020-01-12T21:03:18.234567Z\"}"
+            + ",\"payload\":\"dGVzdA==\"}",
+        "{\"attributeMap\":{\"document_id\":\"foo\""
+            + ",\"submission_timestamp\":\"2020-01-12T21:02:18.123456Z\"}"
+            + ",\"payload\":\"dGVzdA==\"}");
+
+    final PCollection<String> output = pipeline //
+        .apply(Create.of(input)) //
+        .apply(InputFileFormat.json.decode()).output() //
+        .apply(DeduplicateByDocumentId.of()) //
+        .apply(OutputFileFormat.json.encode());
+
+    PAssert.that(output).containsInAnyOrder(expected);
+
+    pipeline.run();
+  }
+
+}


### PR DESCRIPTION
Closes #821

cc @whd 

This would be enabled for heka backfills so that we could load directly into stable tables rather than live tables. I don't know how this is going to perform in practice.