### PR TITLE
Add script to flatten schema hierarchy for updating bq datasets and tables

### DIFF
--- a/bin/mvn
+++ b/bin/mvn
@@ -22,11 +22,12 @@ if [ -z "$NONINTERACTIVE" ]; then
     INTERACTIVE_FLAGS="-it"
 fi
 
-if [[ -f ${GOOGLE_APPLICATION_CREDENTIALS} ]]; then
+MOUNT_CREDENTIALS_FLAGS=""
+if [[ -f "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
     # Credentials are detected on the local filesystem via environment. This is
     # mounted into the maven container into an arbitrary location, with the
     # container environment set to point at the mounted volume.
-    echo "Assuming local service account credentials..."
+    echo "Using GOOGLE_APPLICATION_CREDENTIALS..."
     mount_location="/app/.credentials"
     MOUNT_CREDENTIALS_FLAGS="-v ${GOOGLE_APPLICATION_CREDENTIALS}:${mount_location}"
     GOOGLE_APPLICATION_CREDENTIALS=$mount_location
@@ -41,6 +42,6 @@ docker run $INTERACTIVE_FLAGS --rm \
     -v ~/.m2:/var/maven/.m2 \
     -e MAVEN_CONFIG=/var/maven/.m2 \
     -e GOOGLE_APPLICATION_CREDENTIALS \
-    ${MOUNT_CREDENTIALS_FLAGS} \
+    $MOUNT_CREDENTIALS_FLAGS \
     maven:3-jdk-8 \
     mvn -Duser.home=/var/maven "${PROFILE[@]}" "$@"

--- a/bin/mvn
+++ b/bin/mvn
@@ -22,6 +22,16 @@ if [ -z "$NONINTERACTIVE" ]; then
     INTERACTIVE_FLAGS="-it"
 fi
 
+if [[ -f ${GOOGLE_APPLICATION_CREDENTIALS} ]]; then
+    # Credentials are detected on the local filesystem via environment. This is
+    # mounted into the maven container into an arbitrary location, with the
+    # container environment set to point at the mounted volume.
+    echo "Assuming local service account credentials..."
+    mount_location="/app/.credentials"
+    MOUNT_CREDENTIALS_FLAGS="-v ${GOOGLE_APPLICATION_CREDENTIALS}:${mount_location}"
+    GOOGLE_APPLICATION_CREDENTIALS=$mount_location
+fi
+
 # Run mvn with a non-root user id
 # https://docs.docker.com/samples/library/maven/#Running-as-non-root
 docker run $INTERACTIVE_FLAGS --rm \
@@ -31,5 +41,6 @@ docker run $INTERACTIVE_FLAGS --rm \
     -v ~/.m2:/var/maven/.m2 \
     -e MAVEN_CONFIG=/var/maven/.m2 \
     -e GOOGLE_APPLICATION_CREDENTIALS \
+    ${MOUNT_CREDENTIALS_FLAGS} \
     maven:3-jdk-8 \
     mvn -Duser.home=/var/maven "${PROFILE[@]}" "$@"

--- a/docs/ingestion-beam/ingestion_testing_workflow.md
+++ b/docs/ingestion-beam/ingestion_testing_workflow.md
@@ -50,12 +50,16 @@ about the sandbox environment that is provided by data operations.
 Follow the instructions of the project readme. Here is a quick-reference for a running a job from a set of files in GCS.
 
 ```bash
+# this must be an absolute path
 export GOOGLE_APPLICATION_CREDENTIALS=keys.json
 PROJECT=$(gcloud config get-value project)
 BUCKET="gs://$PROJECT"
 
 path="$BUCKET/data/*.ndjson"
-./bin/mvn compile exec:java -Dexec.args="\
+
+# use local maven instead of the docker container in bin/mvn, otherwise make sure to mount
+# credentials into the proper location in the container
+mvn compile exec:java -Dexec.args="\
     --runner=Dataflow \
     --project=$PROJECT \
     --autoscalingAlgorithm=NONE \

--- a/docs/ingestion-beam/ingestion_testing_workflow.md
+++ b/docs/ingestion-beam/ingestion_testing_workflow.md
@@ -42,7 +42,7 @@ about the sandbox environment that is provided by data operations.
     ```
 * Update the BigQuery table in the current project using `bin/update-bq-table`.
     - This may take several minutes. Read the script for usage information.
-    - Each namespace will be given its own dataset and each doctype its own table.
+    - Each namespace will be given its own dataset and each document type its own table.
 * Verify that tables have been updated by viewing the BigQuery console.
 
 ## Building the project
@@ -66,7 +66,7 @@ path="$BUCKET/data/*.ndjson"
     --inputType=file \
     --input=$path\
     --outputType=bigquery \
-    --output=$PROJECT:\${document_namespace}.\${document_type}_v\${document_version} \
+    --output=$PROJECT:test_ingestion.\${document_namespace}__\${document_type}_v\${document_version} \
     --bqWriteMethod=file_loads \
     --tempLocation=$BUCKET/temp/bq-loads \
     --errorOutputType=file \

--- a/docs/ingestion-beam/ingestion_testing_workflow.md
+++ b/docs/ingestion-beam/ingestion_testing_workflow.md
@@ -59,7 +59,7 @@ path="$BUCKET/data/*.ndjson"
 
 # use local maven instead of the docker container in bin/mvn, otherwise make sure to mount
 # credentials into the proper location in the container
-mvn compile exec:java -Dexec.args="\
+./bin/mvn compile exec:java -Dexec.args="\
     --runner=Dataflow \
     --project=$PROJECT \
     --autoscalingAlgorithm=NONE \

--- a/docs/ingestion-beam/ingestion_testing_workflow.md
+++ b/docs/ingestion-beam/ingestion_testing_workflow.md
@@ -29,20 +29,21 @@ about the sandbox environment that is provided by data operations.
 * Download the latest schemas from `mozilla-pipeline-schemas` using `bin/download-schemas`.
     - This script may also inject testing resources into the resulting archive.
     - A `schemas.tar.gz` will appear at the project root.
-* Generate BigQuery schemas using `bin/generate-bq-schemas`.
-    - Schemas will be written to `bq-schemas/`.
+* Copy generated BigQuery schemas using `bin/copy-bq-schemas`.
+    - Schemas will be written to `bq-schemas/` with a `.bq` extension
+    - Schemas can be generated directly from JSON Schema using `bin/generate-bq-schemas`
     ```
     bq-schemas/
-    ├── activity-stream.impression-stats.1.bigquery.json
-    ├── coverage.coverage.1.bigquery.json
-    ├── edge-validator.error-report.1.bigquery.json
-    ├── eng-workflow.bmobugs.1.bigquery.json
+    ├── activity-stream.impression-stats.1.bq
+    ├── coverage.coverage.1.bq
+    ├── edge-validator.error-report.1.bq
+    ├── eng-workflow.bmobugs.1.bq
     ....
     ```
 * Update the BigQuery table in the current project using `bin/update-bq-table`.
     - This may take several minutes. Read the script for usage information.
+    - Each namespace will be given its own dataset and each doctype its own table.
 * Verify that tables have been updated by viewing the BigQuery console.
-
 
 ## Building the project
 

--- a/ingestion-beam/bin/copy-bq-schemas
+++ b/ingestion-beam/bin/copy-bq-schemas
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Copies BigQuery schemas for integration testing and validation from the
-# generated schema # archive fetched by `bin/download-schemas`. This script will
-# write to a flat # directory called `bq-schemas` containing BQ schemas.
+# generated schema archive fetched by `bin/download-schemas`. This script will
+# write to a flat directory called `bq-schemas` containing BQ schemas.
 
 set -e
 

--- a/ingestion-beam/bin/copy-bq-schemas
+++ b/ingestion-beam/bin/copy-bq-schemas
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copies BigQuery schemas for integration testing and validation from the
+# generated schema # archive fetched by `bin/download-schemas`. This script will
+# write to a flat # directory called `bq-schemas` containing BQ schemas.
+
+set -e
+
+cd "$(dirname "$0")/.." || exit
+
+if [[ ! -f schemas.tar.gz ]]; then
+    echo "Run 'bin/download-schemas'"
+    exit 1
+fi
+
+function init_working_directory() {
+    # Create a temporary directory for working. The current directory is stored
+    # into $rootdir and the working directory is stored into $workdir. The
+    # working directory will be removed on exit.
+    rootdir=$(pwd)
+    workdir=$(mktemp -d -t tmp.XXXXXXXXXX)
+    function cleanup {
+        rm -rf "$workdir"
+        echo "Running cleanup!"
+    }
+    trap cleanup EXIT
+    cd "$workdir" || exit
+}
+
+init_working_directory
+
+src="mozilla-pipeline-schemas"
+dst="bq-schemas"
+
+# Find all JSON schemas in the extracted archive. The top-level folder in the
+# archive is consistently named in `bin/download-schemas`
+tar -xf "$rootdir/schemas.tar.gz" -C "$workdir"
+schemas=$(find $src/schemas -type file -name "*.bq")
+
+mkdir $dst
+
+for schema in $schemas; do
+    # replace // with / and get the proper namespace
+    namespace=$(echo "$schema" | sed 's/\/\//\//g' | cut -d/ -f3)
+    mv "$schema" "$dst/$namespace.$(basename $schema)"
+done
+
+# Generate the final archive, overwriting any existing files
+cp -r "$dst" "$rootdir"

--- a/ingestion-beam/bin/download-sampled-landfill
+++ b/ingestion-beam/bin/download-sampled-landfill
@@ -151,7 +151,7 @@ def parse_arguments():
         "--submission-date", default=(datetime.now() - timedelta(1)).strftime("%Y%m%d")
     )
     parser.add_argument("--schema-file", default="schemas.tar.gz")
-    parser.add_argument("--output-file", default="avro-landfill-integration.ndjson")
+    parser.add_argument("--output-file", default="landfill-integration.ndjson")
     args = parser.parse_args()
     return args
 

--- a/ingestion-beam/bin/generate-bq-schemas
+++ b/ingestion-beam/bin/generate-bq-schemas
@@ -53,7 +53,7 @@ function generate_bq_schema() {
     local name
     # replace // with / and get the proper namespace
     namespace=$(echo "$src" | sed 's/\/\//\//g' | cut -d/ -f3)
-    name="$namespace.$(basename "$src" .schema.json).bigquery.json"
+    name="$namespace.$(basename "$src" .schema.json).bq"
     local dst="$root/$name"
     
     # Create the folder if not exists

--- a/ingestion-beam/bin/update-bq-table
+++ b/ingestion-beam/bin/update-bq-table
@@ -5,36 +5,36 @@
 # suitable for ingesting data from decoded messages. Set the following
 # environment variables to modify the behavior of the update.
 #
+#   DATASET=name        - Set the dataset name, defaults to test_ingestion
 #   SKIP_EXISTING=1     - Skip table creation if the table already exists
-#   REPLACE_EXISTING=1  - Drop and create a table whether it exists or not
+#   OVERWRITE=1         - Drop the dataset and create tables from scratch
 #
 # The default behavior is to fail when encountering an existing table.
 
-cd "$(dirname "$0")/.." || exit
+: "${DATASET:=test_ingestion}"
+: "${SKIP_EXISTING:=1}"
+: "${OVERWRITE:=0}"
 
-if [[ ! -d "bq-schemas" ]]; then
-    echo "Run 'bin/generate-bq-schemas' or 'bin/copy-bq-schemas'"
-    exit 1
-fi
-
-echo "Running dataset updates on $(gcloud config get-value project)"
-
+# globals
 total=0
 skip=0
 error=0
+
 function update_table() {
     # Arguments:
-    #   $1 - path to the document in format `{namespace}.{type}.{version}.bq.json`
+    #   $1 - dataset name
+    #   $2 - path to the document in format `{namespace}.{type}.{version}.bq`
     #
     # Options via envvar
     #   $SKIP_EXISTING  - skip if exists
-    #   $REPLACE_EXISTING - remove and create if exists
+    #   $OVERWRITE - remove and create if exists
     #
     # Counters:
     #   $total - the total number of documents seen
     #   $skip  - the number of documents that have been skipped
     #   $error - the number of errors encountered
-    document=$1
+    local dataset=$1
+    local document=$2
     ((total++))
 
     # downcase hyphens to underscores before generating names
@@ -43,12 +43,7 @@ function update_table() {
     doctype=$(echo "${bq_document}" | cut -d. -f2)
     docver=$(echo "${bq_document}" | cut -d. -f3)
 
-    if ! bq ls | grep "${namespace}" >/dev/null ; then
-        echo "creating dataset: ${namespace}"
-        bq mk "${namespace}"
-    fi
-
-    table_exists=$(bq ls "${namespace}" | grep "${doctype}_v${docver}")
+    table_exists=$(bq ls "${dataset}" | grep "${namespace}__${doctype}_v${docver}")
 
     if [[ -n ${SKIP_EXISTING+x} ]] && [[ -n ${table_exists} ]]; then
         echo "skipping bq mk for ${document}"
@@ -56,24 +51,45 @@ function update_table() {
         return
     fi
 
-    if [[ -n ${REPLACE_EXISTING+x} ]] && [[ -n ${table_exists} ]]; then
-        echo "running bq rm for ${document}"
-        bq rm -f "${namespace}.${doctype}_v${docver}"
-    fi
-
     bq mk --table \
         --schema "${document}" \
         --time_partitioning_field submission_timestamp \
-        "${namespace}.${doctype}_v${docver}"
+        --clustering_fields submission_timestamp \
+        "${dataset}.${namespace}__${doctype}_v${docver}"
     if [[ $? ]]; then
         ((error++))
     fi
 }
 
-documents=$(find bq-schemas -type file)
-trap "exit" INT
-for document in ${documents}; do
-    update_table "${document}"
-done
+function main() {
+    cd "$(dirname "$0")/.." || exit
 
-echo "$((total-skip-error))/${total} sucessfully updated, ${skip} skipped, ${error} errors."
+    if [[ ! -d "bq-schemas" ]]; then
+        echo "Run 'bin/generate-bq-schemas' or 'bin/copy-bq-schemas'"
+        exit 1
+    fi
+
+    echo "Running dataset updates on $(gcloud config get-value project)"
+
+    if [[ -n ${OVERWRITE} ]]; then
+        echo "running bq rm for ${DATASET}"
+        bq rm -rf "${DATASET}"
+    fi
+
+    if ! bq ls ${DATASET} > /dev/null; then
+        echo "creating dataset: ${DATASET}"
+        bq mk "${DATASET}"
+    fi
+
+    documents=$(find bq-schemas -type file | sort)
+    trap "exit" INT
+    for document in ${documents}; do
+        update_table "${DATASET}" "${document}"
+    done
+
+    echo "$((total-skip-error))/${total} sucessfully updated, ${skip} skipped, ${error} errors."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/ingestion-beam/bin/update-bq-table
+++ b/ingestion-beam/bin/update-bq-table
@@ -13,9 +13,11 @@
 cd "$(dirname "$0")/.." || exit
 
 if [[ ! -d "bq-schemas" ]]; then
-    echo "Run 'bin/generate-bq-schemas'"
+    echo "Run 'bin/generate-bq-schemas' or 'bin/copy-bq-schemas'"
     exit 1
 fi
+
+echo "Running dataset updates on $(gcloud config get-value project)"
 
 total=0
 skip=0


### PR DESCRIPTION
This PR a duplicate of #827, without modifications to the `ingestion-beam/bin/mvn` script. Instead of modifying the script which is used in production, I've annotated the integration workflow document to note that maven should be run from the host machine.