### PR TITLE
Replace maven inter-module deps with copying src

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,8 @@ jobs:
               echo "Run tests because .circleci/ was modified since branching off master"
           elif test -f pom.xml && ! git diff --quiet origin/master -- "$(git rev-parse --show-toplevel)"/pom.xml; then
               echo "Run tests because pom.xml was modified since branching off master"
+          elif test -f pom.xml && ! git diff --quiet origin/master -- "$(git rev-parse --show-toplevel)"/ingestion-core/src; then
+              echo "Run tests because ingestion-core/src was modified since branching off master"
           elif ! git diff --quiet origin/master... -- .; then
               echo "Run tests because $(git rev-parse --show-prefix) was modified since branching off master"
           else
@@ -149,9 +151,7 @@ jobs:
       run:
         name: Maven Test
         command: |
-          PROFILE="$(basename "$PWD")"
-          cd ..
-          mvn -P "$PROFILE" clean test
+          mvn clean test
     - *report_code_coverage
     - save_cache:
         paths:
@@ -184,9 +184,7 @@ jobs:
         command: |
           export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
           echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-          PROFILE="$(basename "$PWD")"
-          cd ..
-          mvn -P "$PROFILE" clean test -Dtest=*IntegrationTest -DfailIfNoTests=false
+          mvn clean test -Dtest=*IntegrationTest -DfailIfNoTests=false
     - *report_code_coverage
     # We don't save_cache here; we let the ingestion-beam job cover that.
 

--- a/.spelling
+++ b/.spelling
@@ -59,6 +59,7 @@ namespaces
 natively
 nginx
 ok
+osx
 pre-production
 protobuf
 PubSub

--- a/.spelling
+++ b/.spelling
@@ -50,6 +50,7 @@ JSON
 JVM
 Kubernetes
 lookups
+MacOS
 Memorystore
 metadata
 monorepo
@@ -59,7 +60,6 @@ namespaces
 natively
 nginx
 ok
-osx
 pre-production
 protobuf
 PubSub

--- a/bin/mvn
+++ b/bin/mvn
@@ -7,15 +7,11 @@
 set -eo pipefail
 
 cd "$(dirname "$0")/.."
+GIT_TOPLEVEL="$(git rev-parse --show-toplevel)"
+GIT_PREFIX="$(git rev-parse --show-prefix)"
 
 # Create dir to cache maven dependencies if it doesn't already exist.
 mkdir -p ~/.m2
-
-if [ "$(git rev-parse --show-toplevel)" != "$PWD" ]; then
-    PROFILE=( -P "$(basename "$PWD")" )
-else
-    PROFILE=()
-fi
 
 INTERACTIVE_FLAGS=""
 if [ -z "$NONINTERACTIVE" ]; then
@@ -37,11 +33,11 @@ fi
 # https://docs.docker.com/samples/library/maven/#Running-as-non-root
 docker run $INTERACTIVE_FLAGS --rm \
     -u $UID \
-    -v "$(git rev-parse --show-toplevel)":/var/maven/project \
-    -w /var/maven/project \
+    -v "$GIT_TOPLEVEL":/var/maven/project \
+    -w /var/maven/project/"$GIT_PREFIX" \
     -v ~/.m2:/var/maven/.m2 \
     -e MAVEN_CONFIG=/var/maven/.m2 \
     -e GOOGLE_APPLICATION_CREDENTIALS \
     $MOUNT_CREDENTIALS_FLAGS \
     maven:3-jdk-8 \
-    mvn -Duser.home=/var/maven "${PROFILE[@]}" "$@"
+    mvn -Duser.home=/var/maven "$@"

--- a/docs/ingestion-beam/index.md
+++ b/docs/ingestion-beam/index.md
@@ -51,14 +51,11 @@ If you wish to just run a single test class or a single test case, try something
 
 ```bash
 # Run all tests in a single class
-./bin/mvn test -Dtest=com.mozilla.telemetry.util.SnakeCaseTest -DfailIfNoTests=false
+./bin/mvn test -Dtest=com.mozilla.telemetry.util.SnakeCaseTest
 
 # Run only a single test case
-./bin/mvn test -Dtest='com.mozilla.telemetry.util.SnakeCaseTest#testSnakeCaseFormat -DfailIfNoTests=false'
+./bin/mvn test -Dtest='com.mozilla.telemetry.util.SnakeCaseTest#testSnakeCaseFormat'
 ```
-
-The `-DfailIfNoTests=false` is necessary, otherwise it will fail because the `ingestion-core` module
-(on which we depend) will not match any of the above tests.
 
 To run the project in a sandbox against production data, see this document on
 [configuring an integration testing workflow](./ingestion_testing_workflow.md).

--- a/docs/ingestion-beam/sink-job.md
+++ b/docs/ingestion-beam/sink-job.md
@@ -174,14 +174,15 @@ Note: `-Dexec.args` does not handle newlines gracefully, but bash will remove
 
 ### Locally
 
-If you install Java and maven, you can invoke `mvn -P ingestion-beam` from the
-git root in the following commands instead of using `./bin/mvn` from the
-`ingestion-beam/` directory; be aware, though, that Java 8 is the target JVM
+If you install Java and maven, you can invoke `mvn` in the following commands
+instead of using `./bin/mvn`; be aware, though, that Java 8 is the target JVM
 and some reflection warnings may be thrown on newer versions, though these are
 generally harmless.
 
-The provided `bin/mvn` script downloads and runs maven with the correct profile
-via docker so that less setup is needed on the local machine.
+The provided `bin/mvn` script downloads and runs maven via docker so that less
+setup is needed on the local machine. For prolonged development performance is
+likely to be significantly better, especially in osx, if `mvn` is installed and
+run natively without docker.
 
 ```bash
 # create a test input file

--- a/docs/ingestion-beam/sink-job.md
+++ b/docs/ingestion-beam/sink-job.md
@@ -181,7 +181,7 @@ generally harmless.
 
 The provided `bin/mvn` script downloads and runs maven via docker so that less
 setup is needed on the local machine. For prolonged development performance is
-likely to be significantly better, especially in osx, if `mvn` is installed and
+likely to be significantly better, especially in MacOS, if `mvn` is installed and
 run natively without docker.
 
 ```bash

--- a/ingestion-beam/checkstyle
+++ b/ingestion-beam/checkstyle
@@ -1,0 +1,1 @@
+../checkstyle/

--- a/ingestion-beam/pom.xml
+++ b/ingestion-beam/pom.xml
@@ -26,11 +26,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>ingestion-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-runners-direct-java</artifactId>
             <version>${beam.version}</version>

--- a/ingestion-core/checkstyle
+++ b/ingestion-core/checkstyle
@@ -1,0 +1,1 @@
+../checkstyle/

--- a/ingestion-core/pom.xml
+++ b/ingestion-core/pom.xml
@@ -13,16 +13,5 @@
     <artifactId>ingestion-core</artifactId>
     <packaging>jar</packaging>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>28.1-jre</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-    </dependencies>
+    <!-- dependencies must go in the parent pom.xml -->
 </project>

--- a/ingestion-sink/Dockerfile
+++ b/ingestion-sink/Dockerfile
@@ -1,14 +1,14 @@
-FROM maven:3-jdk-8 AS BASE
-WORKDIR /app
+FROM maven:3-jdk-8 AS base
+WORKDIR /app/ingestion-sink
 COPY pom.xml /app/pom.xml
-COPY ingestion-core/pom.xml /app/ingestion-core/pom.xml
 COPY ingestion-sink/pom.xml /app/ingestion-sink/pom.xml
 COPY checkstyle /app/checkstyle
+COPY ingestion-sink/checkstyle /app/ingestion-sink/checkstyle
 COPY ingestion-core/src /app/ingestion-core/src
 COPY ingestion-sink/src /app/ingestion-sink/src
 
 FROM base AS build
-RUN mvn --activate-profiles ingestion-sink package
+RUN mvn package
 
 FROM base
 COPY --from=build /app/ingestion-sink/target/*.jar /app/ingestion-sink/target/

--- a/ingestion-sink/checkstyle
+++ b/ingestion-sink/checkstyle
@@ -1,0 +1,1 @@
+../checkstyle/

--- a/ingestion-sink/pom.xml
+++ b/ingestion-sink/pom.xml
@@ -19,11 +19,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>ingestion-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-pubsub</artifactId>
             <version>${google-cloud.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,14 +24,12 @@
         <profile>
             <id>ingestion-beam</id>
             <modules>
-                <module>ingestion-core</module>
                 <module>ingestion-beam</module>
             </modules>
         </profile>
         <profile>
             <id>ingestion-sink</id>
             <modules>
-                <module>ingestion-core</module>
                 <module>ingestion-sink</module>
             </modules>
         </profile>
@@ -67,6 +65,17 @@
     </repositories>
 
     <dependencies>
+        <!-- dependencies for ingestion-core must be specified here -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>28.1-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -193,7 +202,7 @@
                         </excludes>
                         <licenseHeader>
                             <!-- end license header with extra trailing newline to separate from package statement -->
-                            <file>${maven.multiModuleProjectDirectory}/checkstyle/java.header</file>
+                            <file>checkstyle/java.header</file>
                         </licenseHeader>
                         <eclipse>
                             <file>https://raw.githubusercontent.com/apache/beam/v${beam.version}/sdks/java/build-tools/src/main/resources/beam/beam-codestyle.xml</file>
@@ -232,6 +241,66 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <!-- add ingestion-core/src to all modules -->
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.parent.basedir}/ingestion-core/src/main/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.parent.basedir}/ingestion-core/src/test/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-resource</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.parent.basedir}/ingestion-core/src/main/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-resource</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.parent.basedir}/ingestion-core/src/test/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This allows running maven in module directories and removes the need for running maven with `-P {module}` and `-DfailIfNoTests=false`, while avoiding duplication of maven plugin configuration, shared code, and shared dependencies.