### PR TITLE
Fix some shaded guava imports

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/SchemaStore.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schemas/SchemaStore.java
@@ -1,7 +1,7 @@
 package com.mozilla.telemetry.schemas;
 
-import avro.shaded.com.google.common.annotations.VisibleForTesting;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/AddMetadataTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/AddMetadataTest.java
@@ -2,8 +2,8 @@ package com.mozilla.telemetry.decoder;
 
 import static org.junit.Assert.assertEquals;
 
-import avro.shaded.com.google.common.collect.ImmutableList;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.mozilla.telemetry.options.InputFileFormat;
 import com.mozilla.telemetry.options.OutputFileFormat;


### PR DESCRIPTION
Looks like these snuck in accidentally. We should avoid use of shaded packages pulled in from dependencies.