### PR TITLE
Support sample_id for activity-stream pings

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -17,7 +17,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 import java.util.zip.CRC32;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
@@ -183,6 +185,11 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
           .filter(v -> !Strings.isNullOrEmpty(v)) //
           .ifPresent(v -> attributes.put(Attribute.OS_VERSION, v));
     } else {
+      // Try to extract "activity-stream"-style values.
+      Optional.ofNullable(json.path("release_channel").textValue()) //
+          .filter(v -> !Strings.isNullOrEmpty(v)) //
+          .ifPresent(v -> attributes.put(Attribute.APP_UPDATE_CHANNEL, v));
+
       // Try to extract "core ping"-style values; see
       // https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/da4a1446efd948399eb9eade22f6fcbc5557f588/schemas/telemetry/core/core.10.schema.json
       Optional.ofNullable(json.path(Attribute.OS).textValue()) //
@@ -195,16 +202,23 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
     }
 
     // Try extracting variants of top-level client id.
-    Optional.ofNullable(json.path(Attribute.CLIENT_ID).textValue()) //
-        .filter(v -> !Strings.isNullOrEmpty(v)) //
-        .ifPresent(v -> attributes.put(Attribute.CLIENT_ID, v));
-    Optional.ofNullable(json.path("clientId").textValue()) //
-        .filter(v -> !Strings.isNullOrEmpty(v)) //
+    Stream
+        .of(attributes.get(Attribute.CLIENT_ID), json.path(Attribute.CLIENT_ID).textValue(),
+            json.path("clientId").textValue())
+        .map(ParsePayload::normalizeUuid) //
+        .filter(Objects::nonNull) //
+        .findFirst() //
         .ifPresent(v -> attributes.put(Attribute.CLIENT_ID, v));
 
-    // Add sample id.
-    Optional.ofNullable(attributes.get(Attribute.CLIENT_ID)) //
-        .filter(v -> !Strings.isNullOrEmpty(v)) //
+    // Add sample id, usually based on hashing clientId, but some other IDs are also supported to
+    // allow sampling on non-telemetry pings.
+    Stream.of(attributes.get(Attribute.CLIENT_ID),
+        // "impression_id" is a client_id-like identifier used in activity-stream ping
+        // that do not contain a client_id.
+        json.path("impression_id").textValue()) //
+        .map(ParsePayload::normalizeUuid) //
+        .filter(Objects::nonNull) //
+        .findFirst() //
         .ifPresent(v -> attributes.put(Attribute.SAMPLE_ID, Long.toString(calculateSampleId(v))));
   }
 
@@ -216,6 +230,21 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
     crc32.reset();
     crc32.update(clientId.getBytes(StandardCharsets.UTF_8));
     return crc32.getValue() % 100;
+  }
+
+  private static String normalizeUuid(String v) {
+    if (v == null) {
+      return null;
+    }
+    // The impression_id in activity-stream pings is a UUID enclosed in curly braces, so we
+    v = v.replaceAll("[{}]", "");
+    try {
+      // Will raise an exception if not a valid UUID.
+      UUID.fromString(v);
+      return v;
+    } catch (IllegalArgumentException ignore) {
+      return null;
+    }
   }
 
   private ObjectNode parseTimed(byte[] bytes) throws IOException {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
@@ -43,7 +43,8 @@ public class ParsePayloadTest {
     ValueProvider<String> schemasLocation = pipeline.newProvider("schemas.tar.gz");
     ValueProvider<String> schemaAliasesLocation = pipeline.newProvider(null);
     final List<String> input = Arrays.asList("{}", "{\"id\":null}", "[]", "{",
-        "{\"clientId\":\"2907648d-711b-4e9f-94b5-52a2b40a44b1\"}");
+        "{\"clientId\":\"2907648d-711b-4e9f-94b5-52a2b40a44b1\"}",
+        "{\"impression_id\":\"{2907648d-711b-4e9f-94b5-52a2b40a44b1}\"}");
     WithErrors.Result<PCollection<PubsubMessage>> output = pipeline.apply(Create.of(input))
         .apply(InputFileFormat.text.decode()).output()
         .apply("AddAttributes",
@@ -54,7 +55,8 @@ public class ParsePayloadTest {
         .apply(ParsePayload.of(schemasLocation, schemaAliasesLocation));
 
     final List<String> expectedMain = Arrays.asList("{}", "{\"id\":null}",
-        "{\"clientId\":\"2907648d-711b-4e9f-94b5-52a2b40a44b1\"}");
+        "{\"clientId\":\"2907648d-711b-4e9f-94b5-52a2b40a44b1\"}",
+        "{\"impression_id\":\"{2907648d-711b-4e9f-94b5-52a2b40a44b1}\"}");
     final PCollection<String> main = output.output().apply("encodeTextMain",
         OutputFileFormat.text.encode());
     PAssert.that(main).containsInAnyOrder(expectedMain);
@@ -64,6 +66,8 @@ public class ParsePayloadTest {
         "{\"document_namespace\":\"test\",\"document_version\":\"1\",\"document_type\":\"test\"}",
         "{\"document_namespace\":\"test\",\"document_version\":\"1\""
             + ",\"client_id\":\"2907648d-711b-4e9f-94b5-52a2b40a44b1\""
+            + ",\"document_type\":\"test\",\"sample_id\":\"67\"}",
+        "{\"document_namespace\":\"test\",\"document_version\":\"1\""
             + ",\"document_type\":\"test\",\"sample_id\":\"67\"}");
     final PCollection<String> attributes = output.output()
         .apply(MapElements.into(TypeDescriptors.strings()).via(m -> {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
@@ -44,7 +44,8 @@ public class ParsePayloadTest {
     ValueProvider<String> schemaAliasesLocation = pipeline.newProvider(null);
     final List<String> input = Arrays.asList("{}", "{\"id\":null}", "[]", "{",
         "{\"clientId\":\"2907648d-711b-4e9f-94b5-52a2b40a44b1\"}",
-        "{\"impression_id\":\"{2907648d-711b-4e9f-94b5-52a2b40a44b1}\"}");
+        "{\"impression_id\":\"{2907648d-711b-4e9f-94b5-52a2b40a44b1}\"}", "{\"client_id\":\"n/a\"}",
+        "{\"client_id\":\"n/a\",\"impression_id\":\"{2907648d-711b-4e9f-94b5-52a2b40a44b1}\"}");
     WithErrors.Result<PCollection<PubsubMessage>> output = pipeline.apply(Create.of(input))
         .apply(InputFileFormat.text.decode()).output()
         .apply("AddAttributes",
@@ -56,7 +57,8 @@ public class ParsePayloadTest {
 
     final List<String> expectedMain = Arrays.asList("{}", "{\"id\":null}",
         "{\"clientId\":\"2907648d-711b-4e9f-94b5-52a2b40a44b1\"}",
-        "{\"impression_id\":\"{2907648d-711b-4e9f-94b5-52a2b40a44b1}\"}");
+        "{\"impression_id\":\"{2907648d-711b-4e9f-94b5-52a2b40a44b1}\"}", "{\"client_id\":\"n/a\"}",
+        "{\"client_id\":\"n/a\",\"impression_id\":\"{2907648d-711b-4e9f-94b5-52a2b40a44b1}\"}");
     final PCollection<String> main = output.output().apply("encodeTextMain",
         OutputFileFormat.text.encode());
     PAssert.that(main).containsInAnyOrder(expectedMain);
@@ -67,6 +69,10 @@ public class ParsePayloadTest {
         "{\"document_namespace\":\"test\",\"document_version\":\"1\""
             + ",\"client_id\":\"2907648d-711b-4e9f-94b5-52a2b40a44b1\""
             + ",\"document_type\":\"test\",\"sample_id\":\"67\"}",
+        "{\"document_namespace\":\"test\",\"document_version\":\"1\""
+            + ",\"document_type\":\"test\",\"sample_id\":\"67\"}",
+        "{\"document_namespace\":\"test\",\"document_version\":\"1\""
+            + ",\"document_type\":\"test\"}",
         "{\"document_namespace\":\"test\",\"document_version\":\"1\""
             + ",\"document_type\":\"test\",\"sample_id\":\"67\"}");
     final PCollection<String> attributes = output.output()


### PR DESCRIPTION
Currently, all activity-stream pings are being assigned `sample_id=51`
because they all contain `"client_id":"n/a"`. The pipeline currently discovers
that value, loads it as an attributes, and happily calculates a sample_id from
it.

The change here involves requiring that we have a valid UUID for clientIds
and then also supporting the `impression_id` field in activity-stream pings
that actually does contain a UUID representing the client.

Closes https://github.com/mozilla/gcp-ingestion/issues/935