### PR TITLE
Don't set insert id when writing to BigQuery in ingestion-sink

### DIFF
--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/BigQuery.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/BigQuery.java
@@ -6,7 +6,6 @@ import com.google.cloud.bigquery.InsertAllResponse;
 import com.google.cloud.bigquery.TableId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.pubsub.v1.PubsubMessage;
-import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
 import com.mozilla.telemetry.ingestion.core.util.Json;
 import com.mozilla.telemetry.ingestion.sink.transform.PubsubMessageToObjectNode;
 import com.mozilla.telemetry.ingestion.sink.transform.PubsubMessageToObjectNode.Format;
@@ -96,8 +95,7 @@ public class BigQuery {
       @Override
       protected synchronized void write(PubsubMessage input) {
         Map<String, Object> content = Json.asMap(encoder.apply(input));
-        Optional.ofNullable(input.getAttributesOrDefault(Attribute.DOCUMENT_ID, null))
-            .map(id -> builder.addRow(id, content)).orElseGet(() -> builder.addRow(content));
+        builder.addRow(content);
       }
 
       @Override

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/BigQueryTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/BigQueryTest.java
@@ -3,6 +3,7 @@ package com.mozilla.telemetry.ingestion.sink.io;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
@@ -119,7 +120,7 @@ public class BigQueryTest {
     List<InsertAllRequest.RowToInsert> rows = ((BigQuery.Write.Batch) output.batches
         .get(BATCH_KEY)).builder.build().getRows();
 
-    assertEquals("id", rows.get(0).getId());
+    assertNull(rows.get(0).getId());
     assertEquals(ImmutableMap.of("document_id", "id"), rows.get(0).getContent());
     assertEquals(20, output.batches.get(BATCH_KEY).byteSize);
   }


### PR DESCRIPTION
so that we hit the high-volume streaming insert backend, and the decoded sink will stop throwing api rate limit errors