### PR TITLE
Add Java 8 dependency in README

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -47,6 +47,9 @@ IAM
 IPs
 irc.mozilla.org
 Javadoc
+jenv
+JDK
+JDKs
 JSON
 JVM
 Kubernetes

--- a/README.md
+++ b/README.md
@@ -15,4 +15,7 @@ There are currently two components:
 
 For more information, see [the documentation](https://mozilla.github.io/gcp-ingestion).
 
-This project requires Java 8.
+Java 11 support is a work in progress for the Beam Java SDK, so this project requires
+Java 8 and will likely fail to compile using newer versions of the JDK.
+To manage multiple local JDKs, consider [jenv](https://www.jenv.be/) and the 
+`jenv enable-plugin maven` command.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ There are currently two components:
   transformations of ingested messages
 
 For more information, see [the documentation](https://mozilla.github.io/gcp-ingestion).
+
+This project requires Java 8.


### PR DESCRIPTION
I think it would be good to note somewhere that this project requires Java 8 to compile (macOS comes with Java 11 by default and compiling will result in strange errors).