### PR TITLE
Update instructions to download GeoLite2-City dataset and fix markdown format

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -34,6 +34,7 @@ gcp-ingestion
 GCP
 GCS
 GeoIP
+GeoLite2
 GKE
 GroupByKey
 gzip
@@ -51,6 +52,7 @@ JVM
 Kubernetes
 lookups
 MacOS
+MaxMind
 Memorystore
 metadata
 monorepo

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -12,7 +12,7 @@ This document specifies the architecture for GCP Ingestion as a whole.
   `Cloud Storage`
 - The Dataflow `Decoder` job decodes messages from PubSub `Raw Topics` to
   PubSub `Decoded Topics`
-   - The Dataflow `Decoder` job checks for existence of `document_id`s in
+    - The Dataflow `Decoder` job checks for existence of `document_id`s in
      `Cloud Memorystore` in order to deduplicate messages
 - The Dataflow `Republisher` job reads messages from PubSub `Decoded Topics`,
   marks them as seen in `Cloud Memorystore` and republishes them to various
@@ -32,54 +32,54 @@ This document specifies the architecture for GCP Ingestion as a whole.
    - Must attempt to deliver all new messages to PubSub before storing on disk
    - Must not be scaled down when there are messages on disk
 - Must respond server error if PubSub and disk are both unavailable
-   - Must use a 5XX error error code
+    - Must use a 5XX error error code
 - Must accept configuration mapping `uri` to PubSub Topic
-   - Expected initial topics are Structured Ingestion, Telemetry, and Pioneer
+    - Expected initial topics are Structured Ingestion, Telemetry, and Pioneer
 - Must accept configuration defining HTTP headers to capture
 
 ### Landfill Sink
 
 - Must copy messages from PubSub topics to Cloud Storage
-   - This copy may be for backfill, recovery, or testing
+    - This copy may be for backfill, recovery, or testing
 - Must not ack messages read from PubSub until they are delivered
 - Must accept configuration mapping PubSub topics to Cloud Storage locations
 - Should retry transient Cloud Storage errors indefinitely
-   - Should use exponential back-off to determine retry timing
+    - Should use exponential back-off to determine retry timing
 
 ### Decoder
 
 - Must decode messages from PubSub topics to PubSub topics
 - Must not ack messages read from PubSub until they are delivered
 - Must apply the following transforms in order
-  ([implementations here](../../ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/))
-   1. Parse `uri` attribute into multiple attributes
-   1. Gzip decompress `payload` if gzip compressed
-   1. Validate `payload` using a JSON Schema determined by attributes
-   1. Parse `x_pipeline_proxy` attribute; if present with a valid value in
-      [the edge submission timestamp format](https://github.com/mozilla/gcp-ingestion/blob/master/docs/edge.md#submission-timestamp-format),
-      archive the value of `submission_timestamp` to `proxy_timestamp` and
-      replace with the `x_pipeline_proxy` value
-   1. Resolve GeoIP from `remote_addr` or `x_forwarded_for` attribute into
-      `geo_*` attributes
-   1. Parse `agent` attribute into `user_agent_*` attributes
-   1. Produce `normalized_` variants of select attributes
-   1. Inject `normalized_` attributes at the top level and other select
-      attributes into a nested `metadata` top level key in `payload`
+  ([implementations here](../../ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/)):
+    1. Parse `uri` attribute into multiple attributes
+    1. Gzip decompress `payload` if gzip compressed
+    1. Validate `payload` using a JSON Schema determined by attributes
+    1. Parse `x_pipeline_proxy` attribute; if present with a valid value in
+    [the edge submission timestamp format](https://github.com/mozilla/gcp-ingestion/blob/master/docs/edge.md#submission-timestamp-format),
+    archive the value of `submission_timestamp` to `proxy_timestamp` and
+    replace with the `x_pipeline_proxy` value
+    1. Resolve GeoIP from `remote_addr` or `x_forwarded_for` attribute into
+    `geo_*` attributes
+    1. Parse `agent` attribute into `user_agent_*` attributes
+    1. Produce `normalized_` variants of select attributes
+    1. Inject `normalized_` attributes at the top level and other select
+    attributes into a nested `metadata` top level key in `payload`
 - Should deduplicate messages based on the `document_id` attribute using
   `Cloud MemoryStore`
-  - Must ensure at least once delivery, so deduplication is only "best effort"
-  - Should delay deduplication to the latest possible stage of the pipeline
+    - Must ensure at least once delivery, so deduplication is only "best effort"
+    - Should delay deduplication to the latest possible stage of the pipeline
     to minimize the time window between an ID being marked as seen in
     `Republisher` and it being checked in `Decoder`
 - Must send messages rejected by transforms to a configurable error destination
-   - Must allow error destinations in PubSub and Cloud Storage
+    - Must allow error destinations in PubSub and Cloud Storage
 
 ### Republisher
 
 - Must copy messages from PubSub topics to PubSub topics
 - Must attempt to publish the `document_id` of each consumed message to
   `Cloud MemoryStore`
-  - ID publishing should be "best effort" but must not prevent the message
+    - ID publishing should be "best effort" but must not prevent the message
     proceeding to further steps in case of errors reaching `Cloud MemoryStore`
 - Must ack messages read from PubSub after they are delivered to all
   matching destinations
@@ -87,28 +87,28 @@ This document specifies the architecture for GCP Ingestion as a whole.
   matching destinations
 - Must accept configuration enabling republishing of messages to a debug
   topic if they contain an `x_debug_id` attribute
-  - Must accept a compile-time parameter enabling or disabling debug republishing
-  - Must accept a runtime parameter defining the destination topic
+    - Must accept a compile-time parameter enabling or disabling debug republishing
+    - Must accept a runtime parameter defining the destination topic
 - Must accept configuration enabling republishing of a random sample of the
   input stream
-  - Must accept a compile-time parameter setting the sample ratio
-  - Must accept a runtime parameter defining the destination topic
+    - Must accept a compile-time parameter setting the sample ratio
+    - Must accept a runtime parameter defining the destination topic
 - Must accept configuration mapping `document_type`s to PubSub topics
-  - Must accept a compile-time parameter defining a topic pattern string
+    - Must accept a compile-time parameter defining a topic pattern string
     (may be promoted to runtime if Dataflow adds support for PubSub topic
     names defined via `NestedValueProvider`)
-  - Must accept a compile-time parameter defining which `document_type`s
+    - Must accept a compile-time parameter defining which `document_type`s
     to republish
-  - Must only deliver messages with configured destinations
+    - Must only deliver messages with configured destinations
 - Must accept configuration mapping `document_namespace`s to PubSub topics
-  - Must accept a compile-time parameter defining a map from document
+    - Must accept a compile-time parameter defining a map from document
     namespaces to topics
-  - Must only deliver messages with configured destinations
+    - Must only deliver messages with configured destinations
 - Must accept optional configuration for sampling telemetry data
-  - Must accept a compile-time parameter defining a topic pattern string
+    - Must accept a compile-time parameter defining a topic pattern string
     (may be promoted to runtime if Dataflow adds support for PubSub topic
     names defined via `NestedValueProvider`)
-  - Must accept compile-time parameters defining the sampling ratio for
+    - Must accept compile-time parameters defining the sampling ratio for
     each channel (nightly, beta, and release)
 
 
@@ -124,16 +124,16 @@ This document specifies the architecture for GCP Ingestion as a whole.
 - Must set [`ignoreUnknownValues`](https://beam.apache.org/releases/javadoc/2.7.0/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.Write.html#ignoreUnknownValues--)
   to `true`
 - Should retry transient BigQuery errors indefinitely
-   - Should use exponential back-off to determine retry timing
+    - Should use exponential back-off to determine retry timing
 - Must send messages rejected by BigQuery to a configurable error destination
-   - Must allow error destinations in PubSub and Cloud Storage
+    - Must allow error destinations in PubSub and Cloud Storage
 
 ### Dataset Sink
 
 - Must copy messages from PubSub topics to Cloud Storage
-   - May be used to backfill BigQuery columns previously unspecified in the
+    - May be used to backfill BigQuery columns previously unspecified in the
      table schema
-   - May be used by BigQuery, Spark, and Dataflow to access columns missing
+    - May be used by BigQuery, Spark, and Dataflow to access columns missing
      from BigQuery Tables
 - Must not ack messages read from PubSub until they are delivered
 - Must store messages as newline delimited JSON
@@ -142,7 +142,7 @@ This document specifies the architecture for GCP Ingestion as a whole.
 - Should accept configuration mapping message attributes to Cloud Storage object
   names
 - Should retry transient Cloud Storage errors indefinitely
-   - Should use exponential back-off to determine retry timing
+    - Should use exponential back-off to determine retry timing
 
 ### Notes
 
@@ -214,10 +214,10 @@ view.
 
 ## Known Issues
 
- - Hard limit of 10,000 columns per table in BigQuery
- - Max of 100,000 streaming inserts per second per BigQuery table
- - A PubSub topic without any subscriptions drops all messages until a subscription is created
- - API Rate Limit: 20 req/sec
+- Hard limit of 10,000 columns per table in BigQuery
+- Max of 100,000 streaming inserts per second per BigQuery table
+- A PubSub topic without any subscriptions drops all messages until a subscription is created
+- API Rate Limit: 20 req/sec
 
 ## Further Reading
 

--- a/docs/architecture/test_requirements.md
+++ b/docs/architecture/test_requirements.md
@@ -12,20 +12,20 @@ production must include a document explaining why that decision was made.
 ## Test Phases
 
 1. Continuous Integration
-   - Must run [Unit Tests](#unit-tests) and [Integration Tests](#integration-tests)
-   - Must run against every merge to master and every pull request
-   - Must block merging to master
+    - Must run [Unit Tests](#unit-tests) and [Integration Tests](#integration-tests)
+    - Must run against every merge to master and every pull request
+    - Must block merging to master
 1. Pre-Production
-   - Must run [Unit Tests](#unit-tests) and [Load Tests](#load-tests)
-   - Must run against every version deployed to production
-   - Must mimic production configuration as closely as possible
-   - Should block deployment to production
+    - Must run [Unit Tests](#unit-tests) and [Load Tests](#load-tests)
+    - Must run against every version deployed to production
+    - Must mimic production configuration as closely as possible
+    - Should block deployment to production
 1. Async
-   - Must run [Slow Load Tests](#slow-load-tests)
-   - Must run against every version deployed to production
-   - Must mimic production configuration as closely as possible
-   - Should not block deployment to production
-   - Must notify someone to investigate failures
+    - Must run [Slow Load Tests](#slow-load-tests)
+    - Must run against every version deployed to production
+    - Must mimic production configuration as closely as possible
+    - Should not block deployment to production
+    - Must notify someone to investigate failures
 
 ## Test Categories
 
@@ -33,48 +33,48 @@ Tests must be both thorough and fast enough to not block development. They are
 split into categories with increasing run time and decreasing coverage.
 
 1. [Unit Tests](#unit-tests)
-   - Must cover 100% of code behavior
-   - Should run as fast as possible
+    - Must cover 100% of code behavior
+    - Should run as fast as possible
 1. [Integration Tests](#integration-tests)
-   - Must cover all expected production behavior
-   - Must run fast enough to allow frequent merging to master
+    - Must cover all expected production behavior
+    - Must run fast enough to allow frequent merging to master
 1. [Load Tests](#load-tests)
-   - Must cover performance at scale with and without external services down
-   - Must run fast enough to allow multiple production deployments per day
+    - Must cover performance at scale with and without external services down
+    - Must run fast enough to allow multiple production deployments per day
 1. [Slow Load Tests](#slow-load-tests)
-   - Must cover performance at scale with extended downtime
-   - May take a very long time
+    - Must cover performance at scale with extended downtime
+    - May take a very long time
 
 ### Unit Tests
 
 - Must run in under 5 seconds in CI, not including build time
-   - May use CI parallelism and run each group of tests in under 5 seconds in CI
-   - Should validate code as quickly as possible
+    - May use CI parallelism and run each group of tests in under 5 seconds in CI
+    - Should validate code as quickly as possible
 - Must run completely in memory
-   - Must safely run in parallel
-   - May mock anything that would not run in memory
+    - Must safely run in parallel
+    - May mock anything that would not run in memory
 - Should cover 100% of branches and statements
-   - Should cover all variations of statements having variable behavior without
+    - Should cover all variations of statements having variable behavior without
      branching
-   - Should cover all production configuration variations
-   - Must have [Integration Tests](#integration-tests) to cover exceptions
+    - Should cover all production configuration variations
+    - Must have [Integration Tests](#integration-tests) to cover exceptions
 - Must cover all input and output variations
-   - Must cover all response codes
-   - Must cover all valid URL patterns
-   - Must cover gzipped and not gzipped
-   - Must cover present, absent, and invalid required attributes
-   - Must cover present, absent, and invalid optional attributes
-   - Must cover present, absent, invalid, and wrong type payload JSON
-   - Must cover present, absent, invalid, and wrong type payload fields
-   - Must cover `document_id` duplicates
+    - Must cover all response codes
+    - Must cover all valid URL patterns
+    - Must cover gzipped and not gzipped
+    - Must cover present, absent, and invalid required attributes
+    - Must cover present, absent, and invalid optional attributes
+    - Must cover present, absent, invalid, and wrong type payload JSON
+    - Must cover present, absent, invalid, and wrong type payload fields
+    - Must cover `document_id` duplicates
 - Must cover all error types
-   - Must cover PubSub returning OK but rejecting messages in a batch
-   - Must cover External service returns server error
-   - Must cover External service timeout
-   - Must cover External resource missing
-   - Must cover Insufficient permissions
-   - Must cover behavior when disk becomes full
-   - Must cover behavior with disk already full
+    - Must cover PubSub returning OK but rejecting messages in a batch
+    - Must cover External service returns server error
+    - Must cover External service timeout
+    - Must cover External resource missing
+    - Must cover Insufficient permissions
+    - Must cover behavior when disk becomes full
+    - Must cover behavior with disk already full
 - Must cover behavior when ingestion-edge disk is no longer full
 
 ### Integration Tests
@@ -82,47 +82,47 @@ split into categories with increasing run time and decreasing coverage.
 - Must run in under 5 minutes in CI, not including build time
 - Must be configurable to run locally and in CI
 - Must be configurable to run against a deployment in GCP
-   - May require a proxy to modify cloud service behavior
-   - May require specific configuration
-   - May skip coverage that cannot be forcibly produced in Dataflow
+    - May require a proxy to modify cloud service behavior
+    - May require specific configuration
+    - May skip coverage that cannot be forcibly produced in Dataflow
 - Must clean up created resources when complete
 - Must cover everything unit tests should but do not
 - Must cover a configuration that mimics production as closely as possible
 - Must cover all code with input from or output to external services
-   - The ingestion-edge disk queue is an external service
+    - The ingestion-edge disk queue is an external service
 - Must cover all production configuration options
 - Must cover all API endpoints with invalid traffic
 - Must cover all API endpoints with healthy external services
-   - Must assert disk queue is not used in ingestion-edge
-   - Must assert inputs and outputs preserve schema in ingestion-beam
+    - Must assert disk queue is not used in ingestion-edge
+    - Must assert inputs and outputs preserve schema in ingestion-beam
 - Must cover behavior with errors from external services
-   - Must cover PubSub returning OK but rejecting messages in a batch
-   - Must cover external service DNS does not resolve
-   - Must cover external service cannot TCP connect
-   - Must cover external service hangs after TCP connect
-   - Must cover external service returns 500
-   - Must cover resource does not exist in external service
-   - Must cover insufficient permissions in external service
-   - Must cover behavior when disk becomes full
-   - Must cover behavior with disk already full
-   - Must assert automatic recovery unless manual intervention is required
+    - Must cover PubSub returning OK but rejecting messages in a batch
+    - Must cover external service DNS does not resolve
+    - Must cover external service cannot TCP connect
+    - Must cover external service hangs after TCP connect
+    - Must cover external service returns 500
+    - Must cover resource does not exist in external service
+    - Must cover insufficient permissions in external service
+    - Must cover behavior when disk becomes full
+    - Must cover behavior with disk already full
+    - Must assert automatic recovery unless manual intervention is required
 - Must cover behavior when ingestion-edge disk is no longer full
 
 ### Load Tests
 
 - Must run in parallel in under 1 hour
-   - May require a separate deployment for each test
+    - May require a separate deployment for each test
 - Must record how much it cost to run
 - Must not require manual intervention to evaluate
 - Must check performance against a tunable threshold
 - Must sustain at least 1.5x expected peak production traffic volume
-   - As of 2018-08-01 peak production traffic volume is about 11K req/s
+    - As of 2018-08-01 peak production traffic volume is about 11K req/s
 - Must cover behavior before, during, and after a period of:
-   - Service downtime, except ingestion-edge
-   - 100%, 50%, and 5% invalid traffic
-   - External services cannot TCP connect
-   - 100% and 10% of external service requests time out
-   - 100% and 10% external service requests return 500
+    - Service downtime, except ingestion-edge
+    - 100%, 50%, and 5% invalid traffic
+    - External services cannot TCP connect
+    - 100% and 10% of external service requests time out
+    - 100% and 10% external service requests return 500
 - Must cover ingestion-edge behavior with PubSub returning 500 and auto scaling
   due to disk filling up
 - Must assert ingestion-edge only writes to disk queue when PubSub is unhealthy
@@ -134,11 +134,11 @@ split into categories with increasing run time and decreasing coverage.
 - May run for longer than 1 hour
 - Should not block deployment to production
 - Must cover behavior with sustained load and a backlog equivalent to:
-   - For ingestion-edge: 1.5x the longest PubSub outage in the last year
-      - As of 2018-08-01 the longest PubSub outage was about 4.5 hours
-   - For everything else: 4 days (1 holiday weekend)
-      - Should reach full recovery in under 1 day
+    - For ingestion-edge: 1.5x the longest PubSub outage in the last year
+       - As of 2018-08-01 the longest PubSub outage was about 4.5 hours
+    - For everything else: 4 days (1 holiday weekend)
+       - Should reach full recovery in under 1 day
 - Must cover behavior of ingestion-beam BigQuery output with sustained load and
   BigQuery returning 500 for at least 1.5x the longest BigQuery outage in the
   last year
-   - As of 2018-08-01 the longest BigQuery outage was about 2.3 hours
+    - As of 2018-08-01 the longest BigQuery outage was about 2.3 hours

--- a/docs/ingestion-beam/decoder-job.md
+++ b/docs/ingestion-beam/decoder-job.md
@@ -50,6 +50,11 @@ but with a few extra flags:
  * `--geoCityDatabase=/path/to/GeoIP2-City.mmdb`
  * `--geoCityFilter=/path/to/cities15000.txt` (optional)
 
+To download the [GeoLite2 database](https://dev.maxmind.com/geoip/geoip2/geolite2/),
+you need to [register for a MaxMind account](https://www.maxmind.com/en/geolite2/signup)
+to obtain a license key. After generating a new license key, set `MM_LICENSE_KEY` to 
+your license key.
+
 Example:
 
 ```bash
@@ -59,8 +64,11 @@ echo '{"payload":"dGVzdA==","attributeMap":{"remote_addr":"63.245.208.195"}}' > 
 
 # Download `cities15000.txt`, `GeoLite2-City.mmdb`, and `schemas.tar.gz`
 ./bin/download-cities15000
-./bin/download-geolite2
 ./bin/download-schemas
+
+export MM_LICENSE_KEY="Your MaxMind License Key"
+./bin/download-geolite2
+
 
 # do geo lookup on messages to stdout
 ./bin/mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dexec.args="\

--- a/ingestion-beam/bin/download-geolite2
+++ b/ingestion-beam/bin/download-geolite2
@@ -5,7 +5,7 @@
 # This script downloads and extracts the free GeoLite2 city database
 # from MaxMind for use in development.
 BASE_DIR="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")"
-DOWNLOAD_URL=http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz
+DOWNLOAD_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&date=20200107&license_key=${MM_LICENSE_KEY}&suffix=tar.gz"
 LOCAL_ARCHIVE=/tmp/GeoLite2-City.mmdb.gz
 LOCAL_EXTRACTED=/tmp/GeoLite2-City.mmdb
 


### PR DESCRIPTION
Updated instructions on how to download the GeoLite2-City data set from MaxMind since now an account to get a license key is required.

Also the Markdown formatting of bullet points is currently broken for some pages in the docs. This fixes some of them.