### PR TITLE
Prevent mutation of Pubsubmessage attributes when reading from Pubsub

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Read.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Read.java
@@ -50,8 +50,9 @@ public abstract class Read
       return input //
           .apply(PubsubIO.readMessagesWithAttributesAndMessageId().fromSubscription(subscription))
           .apply(MapElements.into(TypeDescriptor.of(PubsubMessage.class)).via(message -> {
-            message.getAttributeMap().put(Attribute.MESSAGE_ID, message.getMessageId());
-            return message;
+            Map<String, String> attributesWithMessageId = new HashMap<>(message.getAttributeMap());
+            attributesWithMessageId.put(Attribute.MESSAGE_ID, message.getMessageId());
+            return new PubsubMessage(message.getPayload(), attributesWithMessageId);
           })).apply(ToPubsubMessageFrom.identity());
     }
   }


### PR DESCRIPTION
Fixes https://circleci.com/gh/mozilla/gcp-ingestion/18849?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification

Uses approach as discussed in https://github.com/mozilla/gcp-ingestion/pull/1074#discussion_r369589007