### PR TITLE
Refactoring to use MapElements.WithFailure

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -59,7 +59,7 @@ public class Decoder extends Sink {
             .apply(options.getInputType().read(options)).errorsTo(errorCollections) //
             .apply(ParseUri.of()).errorsTo(errorCollections) //
             .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())) //
-            .apply(LimitPayloadSize.toMB(10)).failuresTo(errorCollections) //
+            .apply("LimitPayloadSize", LimitPayloadSize.toMB(10)).failuresTo(errorCollections) //
             .apply(
                 ParsePayload.of(options.getSchemasLocation(), options.getSchemaAliasesLocation()))
             .errorsTo(errorCollections) //

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -59,7 +59,7 @@ public class Decoder extends Sink {
             .apply(options.getInputType().read(options)).errorsTo(errorCollections) //
             .apply(ParseUri.of()).errorsTo(errorCollections) //
             .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())) //
-            .apply(LimitPayloadSize.toMB(10)).errorsTo(errorCollections) //
+            .apply(LimitPayloadSize.toMB(10)).failuresTo(errorCollections) //
             .apply(
                 ParsePayload.of(options.getSchemasLocation(), options.getSchemaAliasesLocation()))
             .errorsTo(errorCollections) //

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
@@ -371,7 +371,8 @@ public abstract class Write
           .of(tableSpecTemplate, partitioningField, clusteringFields);
 
       input = input //
-          .apply(LimitPayloadSize.toBytes(writeMethod.maxPayloadBytes)).errorsTo(errorCollections);
+          .apply(LimitPayloadSize.toBytes(writeMethod.maxPayloadBytes))
+          .failuresTo(errorCollections);
 
       // When writing to live tables, we expect the input is uncompressed and we partition to
       // streaming vs. file loads based on uncompressed size, but we then want to compress again

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
@@ -371,7 +371,7 @@ public abstract class Write
           .of(tableSpecTemplate, partitioningField, clusteringFields);
 
       input = input //
-          .apply(LimitPayloadSize.toBytes(writeMethod.maxPayloadBytes))
+          .apply("LimitPayloadSize", LimitPayloadSize.toBytes(writeMethod.maxPayloadBytes))
           .failuresTo(errorCollections);
 
       // When writing to live tables, we expect the input is uncompressed and we partition to

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/LimitPayloadSize.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/LimitPayloadSize.java
@@ -46,7 +46,8 @@ public class LimitPayloadSize {
           try {
             throw ee.exception();
           } catch (PayloadTooLargeException e) {
-            return FailureMessage.of("LimitPayloadSize", ee.element(), ee.exception());
+            return FailureMessage.of(LimitPayloadSize.class.getSimpleName(), ee.element(),
+                ee.exception());
           }
         });
   }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/LimitPayloadSize.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/LimitPayloadSize.java
@@ -4,14 +4,11 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.MapElements;
-import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.MapElements.MapWithFailures;
 import org.apache.beam.sdk.transforms.WithFailures.ExceptionElement;
-import org.apache.beam.sdk.transforms.WithFailures.Result;
-import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptor;
 
-public class LimitPayloadSize extends
-    PTransform<PCollection<PubsubMessage>, Result<PCollection<PubsubMessage>, PubsubMessage>> {
+public class LimitPayloadSize {
 
   /** Exception to throw for messages whose payloads exceed the configured size limit. */
   public static class PayloadTooLargeException extends RuntimeException {
@@ -22,46 +19,35 @@ public class LimitPayloadSize extends
   }
 
   /** Return a transform that will send messages to error output if payload exceeds maxBytes. */
-  public static LimitPayloadSize toBytes(int maxBytes) {
-    return new LimitPayloadSize(maxBytes);
+  public static MapWithFailures<PubsubMessage, PubsubMessage, PubsubMessage> toBytes(int maxBytes) {
+    return LimitPayloadSize.of(maxBytes);
   }
 
   /** Return a transform that will send messages to error output if payload exceeds mb megabytes. */
-  public static LimitPayloadSize toMB(int mb) {
-    return new LimitPayloadSize(mb * 1024 * 1024);
+  public static MapWithFailures<PubsubMessage, PubsubMessage, PubsubMessage> toMB(int mb) {
+    return LimitPayloadSize.of(mb * 1024 * 1024);
   }
 
-  @Override
-  public Result<PCollection<PubsubMessage>, PubsubMessage> expand(
-      PCollection<PubsubMessage> elements) {
-    return elements.apply(
-        MapElements.into(TypeDescriptor.of(PubsubMessage.class)).via((PubsubMessage message) -> {
-          message = PubsubConstraints.ensureNonNull(message);
-          int numBytes = message.getPayload().length;
-          if (numBytes > maxBytes) {
-            countPayloadTooLarge.inc();
-            throw new PayloadTooLargeException("Message payload is " + numBytes
-                + "bytes, larger than the" + " configured limit of " + maxBytes);
+  /** Factory method to create mapper instance. */
+  public static MapWithFailures<PubsubMessage, PubsubMessage, PubsubMessage> of(int maxBytes) {
+    final Counter countPayloadTooLarge = Metrics.counter(LimitPayloadSize.class,
+        "payload_too_large");
+    return MapElements.into(TypeDescriptor.of(PubsubMessage.class)).via((PubsubMessage msg) -> {
+      msg = PubsubConstraints.ensureNonNull(msg);
+      int numBytes = msg.getPayload().length;
+      if (numBytes > maxBytes) {
+        countPayloadTooLarge.inc();
+        throw new PayloadTooLargeException("Message payload is " + numBytes
+            + "bytes, larger than the" + " configured limit of " + maxBytes);
+      }
+      return msg;
+    }).exceptionsInto(TypeDescriptor.of(PubsubMessage.class))
+        .exceptionsVia((ExceptionElement<PubsubMessage> ee) -> {
+          try {
+            throw ee.exception();
+          } catch (PayloadTooLargeException e) {
+            return FailureMessage.of("LimitPayloadSize", ee.element(), ee.exception());
           }
-          return message;
-        }).exceptionsInto(TypeDescriptor.of(PubsubMessage.class))
-            .exceptionsVia((ExceptionElement<PubsubMessage> ee) -> {
-              try {
-                throw ee.exception();
-              } catch (PayloadTooLargeException e) {
-                return FailureMessage.of(this, ee.element(), ee.exception());
-              }
-            }));
-  }
-
-  ////////
-
-  private final int maxBytes;
-
-  private final Counter countPayloadTooLarge = Metrics.counter(LimitPayloadSize.class,
-      "payload_too_large");
-
-  private LimitPayloadSize(int maxBytes) {
-    this.maxBytes = maxBytes;
+        });
   }
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/LimitPayloadSizeTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/LimitPayloadSizeTest.java
@@ -30,7 +30,7 @@ public class LimitPayloadSizeTest {
     WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage> result = pipeline //
         .apply(Create.of(Iterables.concat(passingPayloads, failingPayloads))) //
         .apply(InputFileFormat.text.decode()).output() //
-        .apply(LimitPayloadSize.toBytes(500));
+        .apply("LimitPayloadSize", LimitPayloadSize.toBytes(500));
 
     PAssert
         .that(result.output().apply("get success payload",

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/LimitPayloadSizeTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/LimitPayloadSizeTest.java
@@ -9,6 +9,7 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.WithFailures;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.commons.lang3.StringUtils;
@@ -26,7 +27,7 @@ public class LimitPayloadSizeTest {
         StringUtils.repeat("abcdefg", 50));
     List<String> failingPayloads = ImmutableList.of(StringUtils.repeat("abcdefghij", 51));
 
-    WithErrors.Result<PCollection<PubsubMessage>> result = pipeline //
+    WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage> result = pipeline //
         .apply(Create.of(Iterables.concat(passingPayloads, failingPayloads))) //
         .apply(InputFileFormat.text.decode()).output() //
         .apply(LimitPayloadSize.toBytes(500));
@@ -36,7 +37,7 @@ public class LimitPayloadSizeTest {
             MapElements.into(TypeDescriptors.strings()).via(m -> new String(m.getPayload())))) //
         .containsInAnyOrder(passingPayloads);
     PAssert
-        .that(result.errors().apply("get failure payload",
+        .that(result.failures().apply("get failure payload",
             MapElements.into(TypeDescriptors.strings()).via(m -> new String(m.getPayload())))) //
         .containsInAnyOrder(failingPayloads);
 


### PR DESCRIPTION
I started looking into https://github.com/mozilla/gcp-ingestion/issues/118

For now, this only refactors `LimitPayloadSize` to use `MapElements.WithFailures`. It's probably best to discuss on a small example whether it makes sense to go forward and refactor the rest. Refactoring the remaining classes should be pretty similar.