### PR TITLE
Timeout periodically for gcs and file_loads

### DIFF
--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
@@ -35,9 +35,9 @@ public class Gcs {
       private final PubsubMessageToObjectNode encoder;
 
       public Ndjson(Storage storage, long maxBytes, int maxMessages, Duration maxDelay,
-          PubsubMessageToTemplatedString batchKeyTemplate, Format format,
+          Duration minDelay, PubsubMessageToTemplatedString batchKeyTemplate, Format format,
           Function<BlobInfo, CompletableFuture<Void>> batchCloseHook) {
-        super(storage, maxBytes, maxMessages, maxDelay, batchKeyTemplate, batchCloseHook);
+        super(storage, maxBytes, maxMessages, maxDelay, minDelay, batchKeyTemplate, batchCloseHook);
         this.encoder = new PubsubMessageToObjectNode(format);
       }
 
@@ -56,9 +56,9 @@ public class Gcs {
     private final Function<BlobInfo, CompletableFuture<Void>> batchCloseHook;
 
     private Write(Storage storage, long maxBytes, int maxMessages, Duration maxDelay,
-        PubsubMessageToTemplatedString batchKeyTemplate,
+        Duration minDelay, PubsubMessageToTemplatedString batchKeyTemplate,
         Function<BlobInfo, CompletableFuture<Void>> batchCloseHook) {
-      super(maxBytes, maxMessages, maxDelay, batchKeyTemplate);
+      super(maxBytes, maxMessages, maxDelay, minDelay, batchKeyTemplate);
       this.storage = storage;
       this.batchCloseHook = batchCloseHook;
     }

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/Env.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/Env.java
@@ -59,4 +59,8 @@ public class Env {
   public Duration getDuration(String key, String defaultValue) {
     return Time.parseJavaDuration(getString(key, defaultValue));
   }
+
+  public Optional<Duration> optDuration(String key) {
+    return optString(key).map(Time::parseJavaDuration);
+  }
 }


### PR DESCRIPTION
produce fewer and larger gcs files without increasing the frequency of BigQuery loads by producing and loading files periodically.

todo:
- [ ] add a config to offset to the loader's period to minimize best-case delay