### PR TITLE
Draft docs for AET decryption support

### DIFF
--- a/docs/architecture/edge_service_specification.md
+++ b/docs/architecture/edge_service_specification.md
@@ -50,6 +50,8 @@ required group attributes {
   optional string x_pingsender_version // example: "1.0"
   optional string x_debug_id           // example: "my_debug_session_1"
   optional string x_pipeline_proxy     // time that the AWS->GCP tee received the message, example: "2018-03-12T21:02:18.123456Z"
+  optional string x_ecosystem_anon_id  // Anonymized identifier for Account Ecosystem Telemetry
+  optional string x_prev_ecosystem_anon_id  // Previous anon_id value; sent when rotating identifiers
 }
 ```
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -49,7 +49,7 @@ This document specifies the architecture for GCP Ingestion as a whole.
 - Should retry transient Cloud Storage errors indefinitely
     - Should use exponential back-off to determine retry timing
 
-### `EcosystemDecoder`
+### `EcosystemDecryptor`
 
 - Must have access restricted to a limited set of operators
 - Must load a bundle of private keys from Cloud KMS

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -10,6 +10,9 @@ This document specifies the architecture for GCP Ingestion as a whole.
   Firefox) to PubSub `Raw Topics`
 - The Dataflow `Landfill Sink` job copies messages from PubSub `Raw Topics` to
   `Cloud Storage`
+- The Dataflow `EcosystemDecryptor` job reads from a `Raw Topic` specific to
+  Account Ecosystem Telemetry (AET), decrypting AET-specific identifiers
+  stored as attributes and republishing to a special decrypted `Raw Topic`
 - The Dataflow `Decoder` job decodes messages from PubSub `Raw Topics` to
   PubSub `Decoded Topics`
     - The Dataflow `Decoder` job checks for existence of `document_id`s in
@@ -45,6 +48,15 @@ This document specifies the architecture for GCP Ingestion as a whole.
 - Must accept configuration mapping PubSub topics to Cloud Storage locations
 - Should retry transient Cloud Storage errors indefinitely
     - Should use exponential back-off to determine retry timing
+
+### `EcosystemDecoder`
+
+- Must have access restricted to a limited set of operators
+- Must load a bundle of private keys from Cloud KMS
+- Must replace attribute `x_ecosystem_anon_id` with the decrypted form
+  `ecosystem_user_id`
+- Must replace attribute `x_prev_ecosystem_anon_id` (if present) with the
+  decrypted form `prev_ecosystem_user_id`
 
 ### Decoder
 

--- a/docs/ingestion-beam/decoder-job.md
+++ b/docs/ingestion-beam/decoder-job.md
@@ -41,6 +41,16 @@ unmodified.
 Attempt to extract browser, browser version, and os from the `user_agent`
 attribute, drop any nulls, and remove `user_agent` from attributes.
 
+### Parse Payload
+
+1. Parse the payload as a JSON object
+1. Validate that the parsed object matches the target schema
+    * send any non-validating messages to error output
+1. If present, move decrypted Account Ecosystem Telemetry identifiers into the payload
+    * values are taken from message attributes `ecosystem_user_id` and
+      `prev_ecosystem_user_id` and placed into the payload as top-level fields
+      `ecosystem_user_id` and `prev_ecosystem_user_id`
+
 ## Executing
 
 Decoder jobs are executed the [same way as sink jobs](../sink-job/#executing)

--- a/docs/ingestion-beam/ecosystem-decryptor-job.md
+++ b/docs/ingestion-beam/ecosystem-decryptor-job.md
@@ -1,0 +1,26 @@
+# EcosystemDecryptor Job
+
+A job for decrypting identifiers used in Account Ecosystem Telemetry.
+Defined in the `com.mozilla.telemetry.EcosystemDecryptor` class ([source](https://github.com/mozilla/gcp-ingestion/blob/master/ingestion-beam/src/main/java/com/mozilla/telemetry/EcosystemDecryptor.java)).
+On startup, this job loads a bundle of private keys by contacting GCP's KMS service.
+
+## Transforms
+
+These transforms are currently executed against each message in order.
+
+### Decrypt Account Ecosystem Telemetry Identifiers
+
+Strips encrypted AET attributes from the message, decrypts them using the
+loaded bundle of data pipeline private keys, and adds attributes for the
+decrypted IDs:
+
+* Input attribute `x_ecosystem_anon_id` will be transformed to output attribute
+  `ecosystem_user_id`
+* Input attribute `x_prev_ecosystem_anon_id` (if present) will be transformed to
+  output attribute `prev_ecosystem_user_id`
+
+## Formats
+
+The input `x_ecosystem_anon_id` and `x_prev_ecosystem_anon_id` attribute strings must
+be JOSE JWE objects in Compact Serialization form. The emitted `ecosystem_user_id`
+and `prev_ecosystem_user_id` attribute strings are UUIDs in 36-character hex standard form.

--- a/docs/ingestion-edge/index.md
+++ b/docs/ingestion-edge/index.md
@@ -58,7 +58,8 @@ environment variables:
   will fail, defaults to `0` which disables the check
 - `METADATA_HEADERS`: a JSON list of headers to preserve as PubSub message
   attributes, defaults to `["Content-Length", "Date", "DNT", "User-Agent",
-  "X-Forwarded-For", "X-Pingsender-Version", "X-Pipeline-Proxy", "X-Debug-ID"]`;
+  "X-Forwarded-For", "X-Pingsender-Version", "X-Pipeline-Proxy", "X-Debug-ID",
+  "X-Ecoystem-Anon-ID", "X-Prev-Ecosystem-Anon-ID"]`;
   the message attribute name will be the header name in lowercase and with `-`
   converted to `_`
 - `PUBLISH_TIMEOUT_SECONDS`: a float indicating the maximum number of seconds


### PR DESCRIPTION
Details here will likely change, but the intention of this draft PR is to make a first pass at a concrete specification of the interface for AET decryption to help move the overall AET design discussion forward.

The current version of the rendered docs (without the changes in this PR) is available at https://mozilla.github.io/gcp-ingestion/

The basic interface proposed here means that clients sending AET pings would include the anon_id as a header named `X-Ecosystem-Anon-ID`. The schemas for the target tables in BigQuery would be expected to include a top-level string-type field named `ecosystem_user_id` that would get populated with the decrypted value.