### PR TITLE
Limit decoded payload size to 8 MB

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -211,7 +211,7 @@ view.
 ## Limits
 
 - The maximum `Content-Length` accepted at the edge is 1 MB; larger payloads
-  will be dropped
+  will be dropped and [the request will return a 413 response code](https://mozilla.github.io/gcp-ingestion/architecture/edge_service_specification/#server-requestresponse)
 - The maximum payload size after being decompressed in the Decoder is 8 MB;
   larger payloads will trigger a `PayloadTooLarge` exception and be sent to
   error output

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -208,10 +208,15 @@ comfortable that the new implementation is stable, we could cut users over to
 the new implementation by simply changing the definition of the user-facing
 view.
 
-## Known Issues
+## Limits
 
-- Hard limit of 10,000 columns per table in BigQuery
-- Max of 100,000 streaming inserts per second per BigQuery table
+- The maximum `Content-Length` accepted at the edge is 1 MB; larger payloads
+  will be dropped
+- The maximum payload size after being decompressed in the Decoder is 8 MB;
+  larger payloads will trigger a `PayloadTooLarge` exception and be sent to
+  error output
+- Hard limit of 10,000 columns per table in BigQuery (see [Load job limits](https://cloud.google.com/bigquery/quotas#load_jobs))
+- Max of 1,000,000 streaming inserts per second per BigQuery table, lower if we populate `insertId` (see [Streaming insert limits](https://cloud.google.com/bigquery/quotas#streaming_inserts))
 - A PubSub topic without any subscriptions drops all messages until a subscription is created
 - API Rate Limit: 20 req/sec
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -64,7 +64,8 @@ public class Decoder extends Sink {
             .apply(GeoCityLookup.of(options.getGeoCityDatabase(), options.getGeoCityFilter())) //
             .apply(ParseUri.of()).errorsTo(errorCollections) //
             .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())) //
-            .apply("LimitPayloadSize", LimitPayloadSize.toMB(10)).failuresTo(errorCollections) //
+            // See discussion in https://github.com/mozilla/gcp-ingestion/issues/776
+            .apply("LimitPayloadSize", LimitPayloadSize.toMB(8)).failuresTo(errorCollections) //
             .apply(
                 ParsePayload.of(options.getSchemasLocation(), options.getSchemaAliasesLocation()))
             .errorsTo(errorCollections) //


### PR DESCRIPTION
Closes #776 and also addresses documentation request in
https://bugzilla.mozilla.org/show_bug.cgi?id=1605503