### PR TITLE
Bug: ParseProxy must occur before GeoCityLookup

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -57,9 +57,10 @@ public class Decoder extends Sink {
     Optional.of(pipeline) //
         .map(p -> p //
             .apply(options.getInputType().read(options)) //
-            // We apply GeoCityLookup first so that IP address is already removed before any
-            // message gets routed to error output; see
+            // We apply ParseProxy and GeoCityLookup first so that IP address is already removed
+            // before any message gets routed to error output; see
             // https://github.com/mozilla/gcp-ingestion/issues/1096
+            .apply(ParseProxy.of()) //
             .apply(GeoCityLookup.of(options.getGeoCityDatabase(), options.getGeoCityFilter())) //
             .apply(ParseUri.of()).errorsTo(errorCollections) //
             .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())) //
@@ -67,7 +68,6 @@ public class Decoder extends Sink {
             .apply(
                 ParsePayload.of(options.getSchemasLocation(), options.getSchemaAliasesLocation()))
             .errorsTo(errorCollections) //
-            .apply(ParseProxy.of()) //
             .apply(ParseUserAgent.of()) //
             .apply(NormalizeAttributes.of()) //
             .apply(AddMetadata.of()).errorsTo(errorCollections) //


### PR DESCRIPTION
Fixup to #1106 which has not yet been deployed to prod.
Geo lookup is broken in current master.