### PR TITLE
Use MapWithFailures for KeyByBigQueryTableDestination

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
@@ -446,7 +446,7 @@ public abstract class Write
       streamingInput.ifPresent(messages -> {
         WriteResult writeResult = messages //
             .apply(maybeCompress) //
-            .apply("KeyByBigQueryTableDestination", keyByBigQueryTableDestination.map()) //
+            .apply(keyByBigQueryTableDestination) //
             .failuresTo(errorCollections) //
             .apply(baseWriteTransform //
                 .withMethod(BigQueryWriteMethod.streaming.method)
@@ -495,7 +495,7 @@ public abstract class Write
         }
         messages //
             .apply(maybeCompress) //
-            .apply("KeyByBigQueryTableDestination", keyByBigQueryTableDestination.map()) //
+            .apply(keyByBigQueryTableDestination) //
             .failuresTo(errorCollections) //
             .apply(fileLoadsWrite);
       });

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Write.java
@@ -446,8 +446,8 @@ public abstract class Write
       streamingInput.ifPresent(messages -> {
         WriteResult writeResult = messages //
             .apply(maybeCompress) //
-            .apply(keyByBigQueryTableDestination) //
-            .errorsTo(errorCollections) //
+            .apply("KeyByBigQueryTableDestination", keyByBigQueryTableDestination.map()) //
+            .failuresTo(errorCollections) //
             .apply(baseWriteTransform //
                 .withMethod(BigQueryWriteMethod.streaming.method)
                 .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors()) //
@@ -495,8 +495,8 @@ public abstract class Write
         }
         messages //
             .apply(maybeCompress) //
-            .apply(keyByBigQueryTableDestination) //
-            .errorsTo(errorCollections) //
+            .apply("KeyByBigQueryTableDestination", keyByBigQueryTableDestination.map()) //
+            .failuresTo(errorCollections) //
             .apply(fileLoadsWrite);
       });
 


### PR DESCRIPTION
I continued refactoring `KeyByBigQueryTableDestination` to use `MapWithFailure` as part of https://github.com/mozilla/gcp-ingestion/issues/118