### PR TITLE
Upgrade to python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
   docs:
     docker:
-    - image: circleci/python:3.7
+    - image: circleci/python:3.8
     steps:
     - checkout
     - run:
@@ -30,7 +30,7 @@ jobs:
   ingestion-edge:
     working_directory: /root/project/ingestion-edge
     docker:
-    - image: python:3.7
+    - image: python:3.8
     steps:
     - &checkout
       checkout:

--- a/ingestion-edge/Dockerfile
+++ b/ingestion-edge/Dockerfile
@@ -1,11 +1,22 @@
-FROM python:3.7-stretch
+ARG PYTHON_VERSION=3.8
+
+# build requirements in separate stage because it requires gcc and libc-dev
+FROM python:${PYTHON_VERSION}-slim
 WORKDIR /app
-RUN apt-get update && apt-get install -y wrk
+RUN apt-get update && apt-get install -qqy gcc libc-dev
 COPY requirements.txt /app/
 COPY bin/include/common.sh /app/bin/include/
 COPY bin/build /app/bin/
 ENV VENV=false
 RUN bin/build
+
+FROM python:${PYTHON_VERSION}-slim
+WORKDIR /app
+# As of debian 10 there is no wrk package available for debian, so this relies
+# on relud/wrk to build wrk from source on debian 10:
+# https://github.com/relud/docker-wrk/blob/master/Dockerfile
+COPY --from=relud/wrk:4.1.0-buster /usr/local/bin/wrk /usr/local/bin/wrk
+COPY --from=0 /usr/local /usr/local
 COPY . /app
 ENV HOST=0.0.0.0 PORT=8000
 CMD exec gunicorn \

--- a/ingestion-edge/bin/build
+++ b/ingestion-edge/bin/build
@@ -2,6 +2,6 @@
 
 . "$(dirname "$0")"/include/common.sh
 
-if ${VENV:-true}; then python3.7 -m venv "$VENV_DIR"; source "$VENV_ACTIVATE"; fi
+if ${VENV:-true}; then python3.8 -m venv "$VENV_DIR"; source "$VENV_ACTIVATE"; fi
 
-python3.7 -m pip install --upgrade --no-cache-dir -r requirements.txt
+python3.8 -m pip install --upgrade --no-cache-dir -r requirements.txt

--- a/ingestion-edge/bin/lint
+++ b/ingestion-edge/bin/lint
@@ -8,4 +8,4 @@ if ${CLEAN_RELOCATES:-true}; then . bin/include/clean_relocates.sh; fi
 # only run lint tests (-k "not test_")
 # cover tests/load because the actual test is disabled (-o "testpaths=")
 # run linters ("${LINT_ARGS[@]}")
-exec python3.7 -m pytest -k "not test_" -o "testpaths=" "${LINT_ARGS[@]}" "$@"
+exec python3.8 -m pytest -k "not test_" -o "testpaths=" "${LINT_ARGS[@]}" "$@"

--- a/ingestion-edge/bin/pytest
+++ b/ingestion-edge/bin/pytest
@@ -5,4 +5,4 @@
 # remove .pyc files that appear to be relocated unless disabled
 if ${CLEAN_RELOCATES:-true}; then . bin/include/clean_relocates.sh; fi
 
-exec python3.7 -m pytest "$@"
+exec python3.8 -m pytest "$@"

--- a/ingestion-edge/requirements.txt
+++ b/ingestion-edge/requirements.txt
@@ -198,10 +198,6 @@ idna==2.8 \
     --hash=sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407 \
     --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c \
     # via httpcore, requests, yarl
-importlib-metadata==1.5.0 \
-    --hash=sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302 \
-    --hash=sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b \
-    # via pluggy, pytest
 kubernetes==10.0.1 \
     --hash=sha256:3770a496663396ad1def665eeadb947b3f45217a08b64b10c01a57e981ac8592 \
     --hash=sha256:a6dee02a1b39ea4bb9c4c2cc415ea0ada33d8ea0a920f7d4fb6d166989dcac01
@@ -501,10 +497,6 @@ yarl==1.3.0 \
     --hash=sha256:c9bb7c249c4432cd47e75af3864bc02d26c9594f49c82e2a28624417f0ae63b8 \
     --hash=sha256:e060906c0c585565c718d1c3841747b61c5439af2211e185f6739a9412dfbde1 \
     # via aiohttp
-zipp==2.2.0 \
-    --hash=sha256:5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50 \
-    --hash=sha256:d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e \
-    # via importlib-metadata
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.


### PR DESCRIPTION
This relies on [relud/wrk](https://hub.docker.com/r/relud/wrk) to build wrk from source on debian buster so that we are no longer stuck on debian stretch (see also #743).

This removes some dependencies because `pluggy` and `pytest` required `importlib-metadata` for `python < 3.8`

This fixes dependabot PRs because dependabot is building `requirements.txt` with `python3.8`.