### PR TITLE
Bug 1614428 c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0 sending malformed payloads

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -111,9 +111,17 @@ public class MessageScrubber {
    */
   public static void writeToErrors(Map<String, String> attributes, ObjectNode json)
       throws MessageShouldBeDroppedException, AffectedByBugException {
-    if (ParseUri.TELEMETRY.equals(attributes.get(Attribute.DOCUMENT_NAMESPACE)) //
-        && "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0".equals(attributes.get(Attribute.CLIENT_ID))) {
+    if ("c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0".equals(attributes.get(Attribute.CLIENT_ID))
+        || Optional.of(json) // Glean pings: client_info.client_id
+            .map(j -> j.path("client_info").path("client_id").textValue())
+            .filter(s -> s.contains("c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0")) //
+            .isPresent()
+        || Optional.of(json) // legacy telemetry pings: client_id
+            .map(j -> j.path("client_id").textValue())
+            .filter(s -> s.contains("c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0")) //
+            .isPresent()) {
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1489560
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1614428
       handleBug("1489560", ScrubAction.SEND_TO_ERRORS);
     }
   }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -93,14 +93,11 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
     // been applied, we strip out any existing metadata fields and put them into attributes.
     AddMetadata.stripPayloadMetadataToAttributes(attributes, json);
 
-    // Prevent message that need to be scrubbed from going to success or error output.
+    // Prevent message that need to be scrubbed from going to success.
     MessageScrubber.scrub(attributes, json);
 
     // Potentially mutates the value of json to redact specific fields.
     MessageScrubber.redact(attributes, json);
-
-    // Write messages that are affected by a specific bug to error output.
-    MessageScrubber.writeToErrors(attributes, json);
 
     boolean validDocType = schemaStore.docTypeExists(attributes);
     if (!validDocType) {

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -99,6 +99,9 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
     // Potentially mutates the value of json to redact specific fields.
     MessageScrubber.redact(attributes, json);
 
+    // Write messages that are affected by a specific bug to error output.
+    MessageScrubber.writeToErrors(attributes, json);
+
     boolean validDocType = schemaStore.docTypeExists(attributes);
     if (!validDocType) {
       PerDocTypeCounter.inc(null, "error_invalid_doc_type");
@@ -142,9 +145,6 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
     }
 
     addAttributesFromPayload(attributes, json);
-
-    // Write messages that are affected by a specific bug to error output.
-    MessageScrubber.writeToErrors(attributes, json);
 
     // https://github.com/mozilla/gcp-ingestion/issues/780
     // We need to be careful to consistently use our util methods (which use Jackson) for

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -189,6 +189,9 @@ public class MessageScrubberTest {
     ValueProvider<String> schemasLocation = pipeline.newProvider("schemas.tar.gz");
     ValueProvider<String> schemaAliasesLocation = pipeline.newProvider(null);
 
+    // payloads here are:
+    // {"client_info":{"client_id":"c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0"}}
+    // {"client_info":{"client_id":"f0ffeec0-ffee-c0ff-eec0-ffeec0ffeecc"}}
     final List<String> input = Arrays.asList("{\"attributeMap\": {" //
         + "\"document_namespace\": \"glean\"" //
         + ",\"document_type\": \"glean\"" //

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -171,14 +171,14 @@ public class MessageScrubberTest {
         ImmutableMap.<String, String>builder().put(Attribute.DOCUMENT_NAMESPACE, "glean").build());
 
     assertThrows(AffectedByBugException.class,
-        () -> MessageScrubber.writeToErrors(attributes, pingToBeScrubbed));
+        () -> MessageScrubber.scrub(attributes, pingToBeScrubbed));
 
     ObjectNode validPing = Json.readObjectNode(("{\n" //
         + "  \"client_info\": {\n" //
         + "    \"client_id\": null" //
         + "  }}").getBytes(StandardCharsets.UTF_8));
 
-    MessageScrubber.writeToErrors(attributes, validPing);
+    MessageScrubber.scrub(attributes, validPing);
   }
 
   @Test
@@ -189,13 +189,13 @@ public class MessageScrubberTest {
     ValueProvider<String> schemasLocation = pipeline.newProvider("schemas.tar.gz");
     ValueProvider<String> schemaAliasesLocation = pipeline.newProvider(null);
 
-    final List<String> input = Arrays.asList("{\"attributeMap\":{" //
+    final List<String> input = Arrays.asList("{\"attributeMap\": {" //
         + "\"document_namespace\": \"glean\"" //
         + ",\"document_type\": \"glean\"" //
         + ",\"document_version\": \"1\"" //
         + "},\"payload\": \"eyJjbGllbnRfaW5mbyI6eyJjbGllbnRfaWQiOiJjMGZmZWVjMC"
         + "1mZmVlLWMwZmYtZWVjMC1mZmVlYzBmZmVlYzAifX0=\"}",
-        "{\"attributeMap\":{" //
+        "{\"attributeMap\": {" //
             + "\"document_namespace\": \"glean\"" //
             + ",\"document_type\": \"glean\"" //
             + ",\"document_version\": \"1\"" //

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
@@ -148,9 +148,11 @@ public class ParsePayloadTest {
     ValueProvider<String> schemaAliasesLocation = pipeline.newProvider(null);
 
     // printf '{"version":4}' | base64 -> eyJ2ZXJzaW9uIjo0fQ==
-    String input = "{\"attributeMap\":" + "{\"document_namespace\":\"telemetry\""
-        + ",\"document_id\":\"2c3a0767-d84a-4d02-8a92-fa54a3376049\""
-        + ",\"document_type\":\"main\"" + "},\"payload\":\"eyJ2ZXJzaW9uIjo0fQ==\"}";
+    String input = "{\"attributeMap\":" //
+        + "{\"document_namespace\":\"telemetry\"" //
+        + ",\"document_id\":\"2c3a0767-d84a-4d02-8a92-fa54a3376049\"" //
+        + ",\"document_type\":\"main\"" //
+        + "},\"payload\":\"eyJ2ZXJzaW9uIjo0fQ==\"}";
 
     WithErrors.Result<PCollection<PubsubMessage>> result = pipeline.apply(Create.of(input))
         .apply(InputFileFormat.json.decode())


### PR DESCRIPTION
In https://github.com/mozilla/gcp-ingestion/pull/1127 scrubbing of messages with client_id `c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0` was implemented. There messages are scrubbed after parsing the payload and schema validation.

In https://bugzilla.mozilla.org/show_bug.cgi?id=1614428 I noticed that these clients send malformed payload. In this specific case `app_build` is not part of `client_info`. In this PR,  message scrubbing and writing them to errors has been moved before schema validation. I also did some refactoring as suggested in https://github.com/mozilla/gcp-ingestion/pull/1127#discussion_r378269519