### PR TITLE
Refactor parsing of client ID from payload

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
 import com.mozilla.telemetry.transforms.MapElementsWithErrors.MessageShouldBeDroppedException;
@@ -79,16 +80,10 @@ public class MessageScrubber {
   // see bug 1489560
   private static boolean bug1489560Affected(Map<String, String> attributes, ObjectNode json) {
     final String affectedClientId = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+    Map<String, String> tempAttributes = Maps.newHashMap();
+    ParsePayload.addClientIdFromPayload(tempAttributes, json);
 
-    return affectedClientId.equals(attributes.get(Attribute.CLIENT_ID))
-        // glean pings: client_info.client_id
-        || Optional.of(json).map(j -> j.path("client_info").path(Attribute.CLIENT_ID).textValue())
-            .filter(s -> s.contains(affectedClientId)) //
-            .isPresent()
-        // legacy telemetry pings: client_id
-        || Optional.of(json).map(j -> j.path(Attribute.CLIENT_ID).textValue())
-            .filter(s -> s.contains(affectedClientId)) //
-            .isPresent();
+    return affectedClientId.equals(tempAttributes.get(Attribute.CLIENT_ID));
   }
 
   // See bug 1603487 for discussion of affected versions, etc.

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -214,7 +214,13 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
         .ifPresent(v -> attributes.put(Attribute.SAMPLE_ID, Long.toString(calculateSampleId(v))));
   }
 
-  /** Extracts the client ID from the payload and adds it to `attributes`. */
+  /**
+   * Extracts the client ID from the payload and adds it to `attributes`.
+   *
+   * <p>Side-effect: JSON payload is modified in this method. The client ID is normalized
+   * in place in the JSON payload to avoid code duplication when extracting information from
+   * different ping structures.
+   */
   public static void addClientIdFromPayload(Map<String, String> attributes, ObjectNode json) {
     // Try to get glean-style client_info object.
     JsonNode gleanClientInfo = getGleanClientInfo(json);

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -156,9 +156,8 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
   }
 
   private void addAttributesFromPayload(Map<String, String> attributes, ObjectNode json) {
-
     // Try to get glean-style client_info object.
-    JsonNode gleanClientInfo = json.path("client_info");
+    JsonNode gleanClientInfo = getGleanClientInfo(json);
 
     // Try to get "common ping"-style os object.
     JsonNode commonPingOs = json.path("environment").path("system").path("os");
@@ -201,7 +200,7 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
           .ifPresent(v -> attributes.put(Attribute.OS_VERSION, v));
     }
 
-    ParsePayload.addClientIdFromPayload(attributes, json);
+    addClientIdFromPayload(attributes, json);
 
     // Add sample id, usually based on hashing clientId, but some other IDs are also supported to
     // allow sampling on non-telemetry pings.
@@ -218,7 +217,7 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
   /** Extracts the client ID from the payload and adds it to `attributes`. */
   public static void addClientIdFromPayload(Map<String, String> attributes, ObjectNode json) {
     // Try to get glean-style client_info object.
-    JsonNode gleanClientInfo = json.path("client_info");
+    JsonNode gleanClientInfo = getGleanClientInfo(json);
 
     if (gleanClientInfo.isObject()) {
       // from glean ping
@@ -249,6 +248,11 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
             json.put("clientId", v);
           });
     }
+  }
+
+  /** Tries to extract glean-style client_info object from payload. */
+  private static JsonNode getGleanClientInfo(ObjectNode json) {
+    return json.path("client_info");
   }
 
   @VisibleForTesting


### PR DESCRIPTION
As discussed in https://github.com/mozilla/gcp-ingestion/pull/1135#issuecomment-586454028 factoring out parsing of client ID would help avoiding duplicate code when scrubbing messages.