### PR TITLE
PubsubMessageToTableRow implements Serializable

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -27,6 +27,7 @@ import com.mozilla.telemetry.util.BeamFileInputStream;
 import com.mozilla.telemetry.util.GzipUtil;
 import com.mozilla.telemetry.util.Json;
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ import org.apache.beam.sdk.values.KV;
  * <p>We also perform some manipulation of the parsed JSON to match details of our table
  * schemas in BigQuery.
  */
-public class PubsubMessageToTableRow {
+public class PubsubMessageToTableRow implements Serializable {
 
   public static PubsubMessageToTableRow of(ValueProvider<List<String>> strictSchemaDocTypes,
       ValueProvider<String> schemasLocation, ValueProvider<String> schemasAliasesLocation,


### PR DESCRIPTION
Fix as suggested in https://github.com/mozilla/gcp-ingestion/pull/1142#discussion_r380806163 to fix https://circleci.com/gh/mozilla/gcp-ingestion/21386?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification