### PR TITLE
Ensure PubsubMessageMixin has been applied for Json.asString

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/Json.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/Json.java
@@ -77,6 +77,13 @@ public class Json extends com.mozilla.telemetry.ingestion.core.util.Json {
   }
 
   /**
+   * Duplicate asString from core Json#asString to ensure PubsubMessageMixin has been applied.
+   */
+  public static String asString(Object data) throws IOException {
+    return MAPPER.writeValueAsString(data);
+  }
+
+  /**
    * Jackson mixin for decoding {@link PubsubMessage} from json.
    *
    * <p>This is necessary because jackson can automatically determine how to encode


### PR DESCRIPTION
This fixes tests on macOS due to the interaction of static methods and static variables between `com.mozilla.telemetry.util.Json` and `com.mozilla.telemetry.ingestion.core.util.Json`