### PR TITLE
Prevent setting unallowed settings for storageapi query input

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Read.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Read.java
@@ -151,7 +151,7 @@ public abstract class Read extends PTransform<PBegin, PCollection<PubsubMessage>
         case QUERY:
           read = read.fromQuery(tableSpec).usingStandardSql();
       }
-      if (method == BigQueryReadMethod.storageapi) {
+      if (source == Source.TABLE && method == BigQueryReadMethod.storageapi) {
         if (rowRestriction != null) {
           read = read.withRowRestriction(rowRestriction);
         }


### PR DESCRIPTION
Query inputs don't allow row restriction and selected fields (compilation error).  This change got query input working.