### PR TITLE
Remove outdated explicit dependencies

### DIFF
--- a/ingestion-beam/pom.xml
+++ b/ingestion-beam/pom.xml
@@ -25,13 +25,6 @@
     </repositories>
 
     <dependencies>
-        <!-- Include opencensus explicitly at the top of the dependency list
-             since the dataflow runner may pull in an old version transitively -->
-        <dependency>
-            <groupId>io.opencensus</groupId>
-            <artifactId>opencensus-api</artifactId>
-            <version>0.17.0</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-runners-direct-java</artifactId>

--- a/ingestion-sink/pom.xml
+++ b/ingestion-sink/pom.xml
@@ -44,11 +44,6 @@
             <version>1.7.30</version>
         </dependency>
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${org-json.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
             <version>1.19.0</version>

--- a/ingestion-sink/pom.xml
+++ b/ingestion-sink/pom.xml
@@ -45,7 +45,6 @@
             <version>1.7.30</version>
         </dependency>
         <dependency>
-        <dependency>
             <groupId>io.opencensus</groupId>
             <artifactId>opencensus-api</artifactId>
             <version>${opencensus.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,6 @@
         <jackson.version>2.9.10</jackson.version>
         <avro.version>1.8.2</avro.version>
 
-        <!-- Keep this dependency version in sync with what is pulled in by jackson;
-             check https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-json-org/2.9.10 -->
-        <org-json.version>20171018</org-json.version>
-
         <!-- Set empty default. -->
         <exec.mainClass></exec.mainClass>
     </properties>


### PR DESCRIPTION
Removes the explicit `opencensus-api` dependency introduced in #902,
because `StorageIntegrationTest` is no longer broken by incompatible
versions (https://circleci.com/gh/mozilla/gcp-ingestion/16157).

Removes the explicit `org.json` dependency from ingestion-sink, because
it was only used for `PubsubMessageToJSONObject`, which became
`PubsubMessageToObjectNode`.