### PR TITLE
Use bom packages to handle versions for multi-package libraries

### DIFF
--- a/ingestion-beam/pom.xml
+++ b/ingestion-beam/pom.xml
@@ -46,26 +46,60 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Keep these dependency versions in sync with what is pulled in by beam;
+                 check https://mvnrepository.com/artifact/org.apache.beam/beam-sdks-java-io-google-cloud-platform/2.19.0
+
+                 Does not use libraries-bom to determine versions as of beam 2.19 because the lowest
+                 version available uses google-cloud-bom 0.84.0-alpha, but 0.79.0-alpha is needed to
+                 match what is pulled in by beam
+
+                 Does not use google-cloud-bom 0.79.0-alpha to determine versions as of beam 2.19
+                 because that causes integration tests to fail on dataflow with
+                 java.lang.NoSuchMethodError and java.lang.NoClassDefFoundError
+
+                 These versions are not shared via a property, because they are independently
+                 versioned and more recent versions do not match -->
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-bigquery</artifactId>
+                <version>1.61.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-pubsub</artifactId>
+                <version>1.61.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-storage</artifactId>
+                <version>1.61.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-runners-direct-java</artifactId>
-            <version>${beam.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-            <version>${beam.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-extensions-json-jackson</artifactId>
-            <version>${beam.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
-            <version>${beam.version}</version>
+        </dependency>
+        <dependency>
+            <!-- redefine dep from parent pom.xml to use the version from dependencyManagement -->
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-bigquery</artifactId>
         </dependency>
         <!-- The latest stable version of cloud kms is 1.38.0 at the time of writing. There are
             conflicts in the dependencies (com.google.api.gax.grpc) that cause issues with
@@ -78,13 +112,11 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-pubsub</artifactId>
-            <version>${google-cloud.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>${google-cloud.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/ingestion-sink/pom.xml
+++ b/ingestion-sink/pom.xml
@@ -14,8 +14,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <log4j.version>2.13.1</log4j.version>
-        <opencensus.version>0.23.0</opencensus.version>
+        <log4j.version>2.13.2</log4j.version>
+        <opencensus.version>0.26.0</opencensus.version>
         <exec.mainClass>com.mozilla.telemetry.ingestion.sink.Sink</exec.mainClass>
     </properties>
 
@@ -41,21 +41,43 @@
         </profile>
     </profiles>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Use com.google.cloud/libraries-bom to ensure compatible versions of components from
+                 guava, protobuf, grpc-java, google-http-java-client and google-cloud-java
+
+                 https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM#maven
+
+                 This cannot go in the parent pom.xml because it breaks beam -->
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>4.1.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-pubsub</artifactId>
-            <version>${google-cloud.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
-            <version>${google-cloud.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>${google-cloud.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -66,14 +88,12 @@
             <!-- Use log4j implementation of slf4j -->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <!-- Runtime dependency for log4j yaml config support
                  https://logging.apache.org/log4j/2.x/runtime-dependencies.html#log4j-core -->
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -113,6 +133,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <!-- specify version because test-jars are not included in log4j-bom -->
             <version>${log4j.version}</version>
             <type>test-jar</type>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
 
         <!-- Keep these dependency versions in sync with what is pulled in by beam;
              check https://mvnrepository.com/artifact/org.apache.beam -->
-        <google-cloud.version>1.61.0</google-cloud.version>
         <jackson.version>2.10.2</jackson.version>
         <avro.version>1.8.2</avro.version>
 
@@ -72,6 +71,25 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.beam</groupId>
+                <artifactId>beam-sdks-java-bom</artifactId>
+                <version>${beam.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- dependencies for ingestion-core must be specified here -->
         <dependency>
@@ -82,12 +100,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
-            <version>${google-cloud.version}</version>
+            <!-- This version is a placeholder that is overridden in downstream modules,
+                 and it should only ever be used when testing ingestion-core directly -->
+            <version>1.61.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -102,7 +121,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-json-org</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
`google-cloud.version` is insufficient for `google-cloud-java`
dependencies, because the packages don't share version numbering.

[google-cloud-java#quickstart](https://github.com/googleapis/google-cloud-java#quickstart)
indicates the correct way to determine `google-cloud-java` dependency
versions is via the `libraries-bom` package from `com.google.cloud`.

In light of that, using Jackson and Beam BOMs seemed appropriate.

This unblocks updating opencensus in ingestion-sink.

This also adds `-DtrimStackTrace=false` to maven test commands, because I found it very helpful in debugging this change.