### PR TITLE
Remove ValueProvider usage for storage api options

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Read.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/io/Read.java
@@ -74,8 +74,8 @@ public abstract class Read extends PTransform<PBegin, PCollection<PubsubMessage>
     private final ValueProvider<String> tableSpec;
     private final BigQueryReadMethod method;
     private final Source source;
-    private final ValueProvider<String> rowRestriction;
-    private final ValueProvider<List<String>> selectedFields;
+    private final String rowRestriction;
+    private final List<String> selectedFields;
 
     public enum Source {
       TABLE, QUERY
@@ -83,7 +83,7 @@ public abstract class Read extends PTransform<PBegin, PCollection<PubsubMessage>
 
     /** Constructor. */
     public BigQueryInput(ValueProvider<String> tableSpec, BigQueryReadMethod method, Source source,
-        ValueProvider<String> rowRestriction, ValueProvider<List<String>> selectedFields) {
+        String rowRestriction, List<String> selectedFields) {
       this.tableSpec = tableSpec;
       this.method = method;
       this.source = source;

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
@@ -69,17 +69,17 @@ public interface SinkOptions extends PipelineOptions {
       + " value is supported; a likely choice to limit partitions would be something like"
       + " \"CAST(submission_timestamp AS DATE) BETWEEN '2020-01-10' AND '2020-01-14'\"; see"
       + " https://cloud.google.com/bigquery/docs/reference/storage/rpc/google.cloud.bigquery.storage.v1beta1#tablereadoptions")
-  ValueProvider<String> getBqRowRestriction();
+  String getBqRowRestriction();
 
-  void setBqRowRestriction(ValueProvider<String> value);
+  void setBqRowRestriction(String value);
 
   @Description("When --bqReadMethod=storageapi, all fields of the input table are read by default,"
       + " but this option can take a comma-separated list of field names, in which case only the"
       + " listed fields will be read, saving costs; when reading decoded payload_bytes, none of the"
       + " metadata fields are needed, so setting --bqSelectedFields=payload is recommended")
-  ValueProvider<List<String>> getBqSelectedFields();
+  List<String> getBqSelectedFields();
 
-  void setBqSelectedFields(ValueProvider<List<String>> value);
+  void setBqSelectedFields(List<String> value);
 
   @Description("Name of time partitioning field of destination tables;"
       + " defaults to submission_timestamp")


### PR DESCRIPTION
Remove the ValueProvider so that the storage api can be used in batch jobs, and so that it can be run without explicitly setting the options.  If I'm understanding correctly, this prevents the options from being used in templated jobs but that isn't an issue right now?