### PR TITLE
Allow null records in PubsubMessageToObjectNode

### DIFF
--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
@@ -69,6 +69,18 @@ public class PubsubMessageToTableRowTest extends TestWithDeterministicJson {
   }
 
   @Test
+  public void testNullRecord() throws Exception {
+    Map<String, Object> parent = new HashMap<>();
+    Map<String, Object> additionalProperties = new HashMap<>();
+    parent.put("record", null);
+    List<Field> bqFields = ImmutableList.of(
+        Field.of("record", LegacySQLTypeName.RECORD, Field.of("field", LegacySQLTypeName.STRING)));
+    TRANSFORM.transformForBqSchema(parent, bqFields, additionalProperties);
+    assertEquals("{\"record\":null}", Json.asString(parent));
+    assertEquals("{}", Json.asString(additionalProperties));
+  }
+
+  @Test
   public void testCoerceEmptyObjectToJsonString() throws Exception {
     Map<String, Object> parent = new HashMap<>();
     parent.put("payload", new HashMap<>());

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/transform/PubsubMessageToObjectNode.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/transform/PubsubMessageToObjectNode.java
@@ -344,10 +344,13 @@ public abstract class PubsubMessageToObjectNode implements Function<PubsubMessag
           updateParent(parent, name, processTupleField(jsonFieldName, field.getSubFields(),
               (ArrayNode) value, additionalProperties));
         } else {
-          final ObjectNode props = additionalProperties == null ? null : Json.createObjectNode();
-          transformForBqSchema((ObjectNode) value, field.getSubFields(), props);
-          if (!Json.isNullOrEmpty(props)) {
-            additionalProperties.set(jsonFieldName, props);
+          // Only transform value if it is not null
+          if (!value.isNull()) {
+            final ObjectNode props = additionalProperties == null ? null : Json.createObjectNode();
+            transformForBqSchema((ObjectNode) value, field.getSubFields(), props);
+            if (!Json.isNullOrEmpty(props)) {
+              additionalProperties.set(jsonFieldName, props);
+            }
           }
           updateParent(parent, name, value);
         }

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/transform/PubsubMessageToObjectNode.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/transform/PubsubMessageToObjectNode.java
@@ -345,8 +345,9 @@ public abstract class PubsubMessageToObjectNode implements Function<PubsubMessag
               (ArrayNode) value, additionalProperties));
         } else {
           // Only transform value if it is not null
-          if (!value.isNull()) {
-            final ObjectNode props = additionalProperties == null ? null : Json.createObjectNode();
+          if (value.isObject()) {
+            final ObjectNode props = (additionalProperties == null) ? null
+                : Json.createObjectNode();
             transformForBqSchema((ObjectNode) value, field.getSubFields(), props);
             if (!Json.isNullOrEmpty(props)) {
               additionalProperties.set(jsonFieldName, props);

--- a/ingestion-sink/src/test/resources/testdata/payload-format-expected.ndjson
+++ b/ingestion-sink/src/test/resources/testdata/payload-format-expected.ndjson
@@ -19,3 +19,4 @@
 {"test_tuple":{"f0_":"string","f1_":5,"f2_":true}}
 {"additional_properties":{"test_tuple":[null,"x",6]},"test_tuple":{"f0_":"{\"key\":\"value\"}"}}
 {"test_nested_list":[{"list":["a","b","c"]}],"test_nested_csv":[{"list":"a,b,c"}],"test_list":["a","b","c"]}
+{}

--- a/ingestion-sink/src/test/resources/testdata/payload-format-input.ndjson
+++ b/ingestion-sink/src/test/resources/testdata/payload-format-input.ndjson
@@ -19,3 +19,4 @@
 {"attributeMap":{"document_namespace":"live-sink","document_type":"test","document_version":"1"},"payload":{"test_tuple":["string",5,true]}}
 {"attributeMap":{"document_namespace":"live-sink","document_type":"test","document_version":"1"},"payload":{"test_tuple":[{"key":"value"},"x",6]}}
 {"attributeMap":{"document_namespace":"live-sink","document_type":"test","document_version":"1"},"payload":{"test_nested_list":[["a","b","c"]],"test_nested_csv":[{"list":"a,b,c"}],"test_list":["a","b","c"]}}
+{"attributeMap":{"document_namespace":"live-sink","document_type":"test","document_version":"1"},"payload":{"test_record":null}}


### PR DESCRIPTION
Fixes [this trace](https://gist.github.com/relud/04959f1de0c097a6706552d18fcf908d) reported to me by @whd via slack on Monday.

I would expect the offending message to retry indefinitely, but I don't see any sign of a message like that in [the subcription](https://console.cloud.google.com/cloudpubsub/subscription/detail/telemetry-decoded.bq-sink-payload?project=moz-fx-data-inge-nonprod-9cc2).

Regardless I think it's appropriate to fix this, because it is a regression from the beam sink's behavior.