### PR TITLE
Refactor to use MapElements.WithFailures in ParsePayload

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -66,7 +66,8 @@ public class Decoder extends Sink {
             .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())) //
             // See discussion in https://github.com/mozilla/gcp-ingestion/issues/776
             .apply("LimitPayloadSize", LimitPayloadSize.toMB(8)).failuresTo(errorCollections) //
-            .apply(ParsePayload.of(options.getSchemasLocation())).errorsTo(errorCollections) //
+            .apply("ParsePayload", ParsePayload.of(options.getSchemasLocation())) //
+            .failuresTo(errorCollections) //
             .apply(ParseUserAgent.of()) //
             .apply(NormalizeAttributes.of()) //
             .apply("AddMetadata", AddMetadata.of()).failuresTo(errorCollections) //

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -23,11 +23,18 @@ public class MessageScrubber {
    * Special exception to signal that a message is affected by a specific bug and should
    * be written to error output.
    */
-  public static class AffectedByBugException extends Exception {
+  public static class AffectedByBugException extends RuntimeException {
 
     public AffectedByBugException(String bugNumber) {
       super(bugNumber);
     }
+  }
+
+  /**
+   * Special exception class that signals that a given message should not be sent
+   * downstream to either success or error output.
+   */
+  public static class MessageShouldBeDroppedException extends RuntimeException {
   }
 
   /**

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java
@@ -9,7 +9,7 @@ import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
 import com.mozilla.telemetry.ingestion.core.schema.JSONSchemaStore;
 import com.mozilla.telemetry.ingestion.core.schema.SchemaNotFoundException;
 import com.mozilla.telemetry.metrics.PerDocTypeCounter;
-import com.mozilla.telemetry.transforms.MapElementsWithErrors;
+import com.mozilla.telemetry.transforms.FailureMessage;
 import com.mozilla.telemetry.transforms.PubsubConstraints;
 import com.mozilla.telemetry.util.BeamFileInputStream;
 import com.mozilla.telemetry.util.Json;
@@ -27,6 +27,12 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.WithFailures;
+import org.apache.beam.sdk.transforms.WithFailures.Result;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
 
@@ -37,7 +43,8 @@ import org.everit.json.schema.ValidationException;
  * <p>There are several unrelated concerns all packed into this single transform so that we
  * incur the cost of parsing the JSON only once.
  */
-public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<PubsubMessage> {
+public class ParsePayload extends
+    PTransform<PCollection<PubsubMessage>, Result<PCollection<PubsubMessage>, PubsubMessage>> {
 
   public static ParsePayload of(ValueProvider<String> schemasLocation) {
     return new ParsePayload(schemasLocation);
@@ -61,93 +68,111 @@ public class ParsePayload extends MapElementsWithErrors.ToPubsubMessageFrom<Pubs
   }
 
   @Override
-  protected PubsubMessage processElement(PubsubMessage message) throws SchemaNotFoundException,
-      IOException, MessageShouldBeDroppedException, MessageScrubber.AffectedByBugException {
-    message = PubsubConstraints.ensureNonNull(message);
-    Map<String, String> attributes = new HashMap<>(message.getAttributeMap());
+  public Result<PCollection<PubsubMessage>, PubsubMessage> expand(
+      PCollection<PubsubMessage> messages) {
+    return messages.apply(
+        MapElements.into(TypeDescriptor.of(PubsubMessage.class)).via((PubsubMessage message) -> {
+          message = PubsubConstraints.ensureNonNull(message);
+          Map<String, String> attributes = new HashMap<>(message.getAttributeMap());
 
-    if (schemaStore == null) {
-      schemaStore = JSONSchemaStore.of(schemasLocation.get(), BeamFileInputStream::open);
-    }
+          if (schemaStore == null) {
+            schemaStore = JSONSchemaStore.of(schemasLocation.get(), BeamFileInputStream::open);
+          }
 
-    final int submissionBytes = message.getPayload().length;
+          final int submissionBytes = message.getPayload().length;
 
-    ObjectNode json;
-    try {
-      json = parseTimed(message.getPayload());
-    } catch (IOException e) {
-      Map<String, String> attrs = schemaStore.docTypeExists(message.getAttributeMap())
-          ? message.getAttributeMap()
-          : null; // null attributes will cause docType to show up as "unknown_doc_type" in metrics
-      PerDocTypeCounter.inc(attrs, "error_json_parse");
-      PerDocTypeCounter.inc(attrs, "error_submission_bytes", submissionBytes);
-      throw e;
-    }
+          ObjectNode json;
+          try {
+            json = parseTimed(message.getPayload());
+          } catch (IOException e) {
+            Map<String, String> attrs = schemaStore.docTypeExists(message.getAttributeMap())
+                ? message.getAttributeMap()
+                : null; // null attributes will cause docType to show up as "unknown_doc_type"
+            // in metrics
+            PerDocTypeCounter.inc(attrs, "error_json_parse");
+            PerDocTypeCounter.inc(attrs, "error_submission_bytes", submissionBytes);
+            throw new RuntimeException(e);
+          }
 
-    // In case this message is being replayed from an error output where AddMetadata has already
-    // been applied, we strip out any existing metadata fields and put them into attributes.
-    AddMetadata.stripPayloadMetadataToAttributes(attributes, json);
+          // In case this message is being replayed from an error output where AddMetadata has
+          // already
+          // been applied, we strip out any existing metadata fields and put them into attributes.
+          AddMetadata.stripPayloadMetadataToAttributes(attributes, json);
 
-    // Prevent message that need to be scrubbed from going to success.
-    MessageScrubber.scrub(attributes, json);
+          // Prevent message that need to be scrubbed from going to success.
+          MessageScrubber.scrub(attributes, json);
 
-    // Potentially mutates the value of json to redact specific fields.
-    MessageScrubber.redact(attributes, json);
+          // Potentially mutates the value of json to redact specific fields.
+          MessageScrubber.redact(attributes, json);
 
-    boolean validDocType = schemaStore.docTypeExists(attributes);
-    if (!validDocType) {
-      PerDocTypeCounter.inc(null, "error_invalid_doc_type");
-      PerDocTypeCounter.inc(null, "error_submission_bytes", submissionBytes);
-      throw new SchemaNotFoundException(String.format("No such docType: %s/%s",
-          attributes.get("document_namespace"), attributes.get("document_type")));
-    }
+          boolean validDocType = schemaStore.docTypeExists(attributes);
+          if (!validDocType) {
+            PerDocTypeCounter.inc(null, "error_invalid_doc_type");
+            PerDocTypeCounter.inc(null, "error_submission_bytes", submissionBytes);
+            throw new SchemaNotFoundException(String.format("No such docType: %s/%s",
+                attributes.get("document_namespace"), attributes.get("document_type")));
+          }
 
-    // If no "document_version" attribute was parsed from the URI, this element must be from the
-    // /submit/telemetry endpoint and we now need to grab version from the payload.
-    if (!attributes.containsKey("document_version")) {
-      Optional<JsonNode> version = Stream.of(json.path("version"), json.path("v"))
-          .filter(JsonNode::isValueNode).findFirst();
-      if (version.isPresent()) {
-        attributes.put(Attribute.DOCUMENT_VERSION, version.get().asText());
-      } else {
-        PerDocTypeCounter.inc(attributes, "error_missing_version");
-        PerDocTypeCounter.inc(attributes, "error_submission_bytes", submissionBytes);
-        throw new SchemaNotFoundException("Element was assumed to be a telemetry message because"
-            + " it contains no document_version attribute, but the payload does not include"
-            + " the top-level 'version' or 'v' field expected for a telemetry document");
-      }
-    }
+          // If no "document_version" attribute was parsed from the URI, this element must be from
+          // the
+          // /submit/telemetry endpoint and we now need to grab version from the payload.
+          if (!attributes.containsKey("document_version")) {
+            Optional<JsonNode> version = Stream.of(json.path("version"), json.path("v"))
+                .filter(JsonNode::isValueNode).findFirst();
+            if (version.isPresent()) {
+              attributes.put(Attribute.DOCUMENT_VERSION, version.get().asText());
+            } else {
+              PerDocTypeCounter.inc(attributes, "error_missing_version");
+              PerDocTypeCounter.inc(attributes, "error_submission_bytes", submissionBytes);
+              throw new SchemaNotFoundException(
+                  "Element was assumed to be a telemetry message because it contains no"
+                      + " document_version attribute, but the payload does not include"
+                      + " the top-level 'version' or 'v' field expected for a telemetry document");
+            }
+          }
 
-    // Throws SchemaNotFoundException if there's no schema
-    Schema schema;
-    try {
-      schema = schemaStore.getSchema(attributes);
-    } catch (SchemaNotFoundException e) {
-      PerDocTypeCounter.inc(attributes, "error_schema_not_found");
-      PerDocTypeCounter.inc(attributes, "error_submission_bytes", submissionBytes);
-      throw e;
-    }
+          // Throws SchemaNotFoundException if there's no schema
+          Schema schema;
+          try {
+            schema = schemaStore.getSchema(attributes);
+          } catch (SchemaNotFoundException e) {
+            PerDocTypeCounter.inc(attributes, "error_schema_not_found");
+            PerDocTypeCounter.inc(attributes, "error_submission_bytes", submissionBytes);
+            throw e;
+          }
 
-    try {
-      validateTimed(schema, json);
-    } catch (ValidationException e) {
-      PerDocTypeCounter.inc(attributes, "error_schema_validation");
-      PerDocTypeCounter.inc(attributes, "error_submission_bytes", submissionBytes);
-      throw e;
-    }
+          try {
+            validateTimed(schema, json);
+          } catch (ValidationException e) {
+            PerDocTypeCounter.inc(attributes, "error_schema_validation");
+            PerDocTypeCounter.inc(attributes, "error_submission_bytes", submissionBytes);
+            throw e;
+          } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+          }
 
-    addAttributesFromPayload(attributes, json);
+          addAttributesFromPayload(attributes, json);
 
-    // https://github.com/mozilla/gcp-ingestion/issues/780
-    // We need to be careful to consistently use our util methods (which use Jackson) for
-    // serializing and deserializing JSON to reduce the possibility of introducing encoding
-    // issues. We previously called json.toString().getBytes() here without specifying a charset.
-    byte[] normalizedPayload = Json.asBytes(json);
+          // https://github.com/mozilla/gcp-ingestion/issues/780
+          // We need to be careful to consistently use our util methods (which use Jackson) for
+          // serializing and de-serializing JSON to reduce the possibility of introducing encoding
+          // issues. We previously called json.toString().getBytes() here without specifying a
+          // charset.
+          try {
+            byte[] normalizedPayload = Json.asBytes(json);
 
-    PerDocTypeCounter.inc(attributes, "valid_submission");
-    PerDocTypeCounter.inc(attributes, "valid_submission_bytes", submissionBytes);
+            PerDocTypeCounter.inc(attributes, "valid_submission");
+            PerDocTypeCounter.inc(attributes, "valid_submission_bytes", submissionBytes);
 
-    return new PubsubMessage(normalizedPayload, attributes);
+            return new PubsubMessage(normalizedPayload, attributes);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }).exceptionsInto(TypeDescriptor.of(PubsubMessage.class))
+            .exceptionsVia((WithFailures.ExceptionElement<PubsubMessage> ee) -> FailureMessage.of(
+                ParsePayload.class.getSimpleName(), //
+                ee.element(), //
+                ee.exception())));
   }
 
   private void addAttributesFromPayload(Map<String, String> attributes, ObjectNode json) {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
@@ -329,7 +329,7 @@ public class ParseUriTest extends TestWithDeterministicJson {
     PAssert.that(uriExceptions).containsInAnyOrder(expectedExceptions);
 
     ValueProvider<String> schemas = pipeline.newProvider("schemas.tar.gz");
-    PCollection<String> schemaExceptions = output.apply(ParsePayload.of(schemas)).errors()
+    PCollection<String> schemaExceptions = output.apply(ParsePayload.of(schemas)).failures()
         .apply("EncodeJsonErrors", OutputFileFormat.json.encode());
     PAssert.that(schemaExceptions).empty();
 


### PR DESCRIPTION
Refactoring `ParsePayload` to use `MapWithFailures` as part of #118

Only `Deduplicate` is left to be refactored.