### PR TITLE
Don't wrap exceptions in RuntimeException in ParsePayload

### DIFF
--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
@@ -129,7 +129,7 @@ public class ParsePayloadTest {
         .into(TypeDescriptors.strings()).via(message -> message.getAttribute("exception_class")));
 
     PAssert.that(result.output()).empty();
-    PAssert.that(exceptions).containsInAnyOrder("java.lang.RuntimeException",
+    PAssert.that(exceptions).containsInAnyOrder("java.io.IOException",
         "com.mozilla.telemetry.ingestion.core.schema.SchemaNotFoundException",
         "com.mozilla.telemetry.ingestion.core.schema.SchemaNotFoundException",
         "com.mozilla.telemetry.ingestion.core.schema.SchemaNotFoundException");


### PR DESCRIPTION
It looks like #1172 led to less interpretable error aggregation for monitoring.