### PR TITLE
Make exception handlers more specific

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/Deduplicate.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/Deduplicate.java
@@ -228,10 +228,15 @@ public class Deduplicate {
             }
             return el;
           }).exceptionsInto(TypeDescriptor.of(PubsubMessage.class))
-              .exceptionsVia((ExceptionElement<PubsubMessage> ee) -> FailureMessage.of(
-                  Deduplicate.class.getSimpleName(), //
-                  ee.element(), //
-                  ee.exception())));
+              .exceptionsVia((ExceptionElement<PubsubMessage> ee) -> {
+                try {
+                  throw ee.exception();
+                } catch (IllegalArgumentException e) {
+                  return FailureMessage.of(Deduplicate.class.getSimpleName(), //
+                      ee.element(), //
+                      ee.exception());
+                }
+              }));
     }
   }
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -101,7 +101,7 @@ public class MessageScrubber {
    * <p>Constructors are required to provide a bug number to aid interpretation of these
    * errors. The constructor also increments a per-bug counter metric.
    */
-  private abstract static class MessageScrubberException extends RuntimeException {
+  abstract static class MessageScrubberException extends RuntimeException {
 
     MessageScrubberException(String bugNumber) {
       super(bugNumber);

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -114,10 +114,15 @@ public class ParseUri {
       attributes.remove(Attribute.MESSAGE_ID);
       return new PubsubMessage(payload, attributes);
     }).exceptionsInto(TypeDescriptor.of(PubsubMessage.class))
-        .exceptionsVia((WithFailures.ExceptionElement<PubsubMessage> ee) -> FailureMessage.of(
-            ParseUri.class.getSimpleName(), //
-            ee.element(), //
-            ee.exception()));
+        .exceptionsVia((WithFailures.ExceptionElement<PubsubMessage> ee) -> {
+          try {
+            throw ee.exception();
+          } catch (UncheckedIOException | InvalidUriException e) {
+            return FailureMessage.of(ParseUri.class.getSimpleName(), //
+                ee.element(), //
+                ee.exception());
+          }
+        });
   }
 
   /**


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/gcp-ingestion/issues/1199

This makes every `exceptionsVia` rethrow the exception and catch only the specific expected classes we want to handle.