### PR TITLE
Fetch dataset info less often to avoid BigQuery API limits

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/KeyByBigQueryTableDestination.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/KeyByBigQueryTableDestination.java
@@ -94,7 +94,11 @@ public class KeyByBigQueryTableDestination extends PTransform<PCollection<Pubsub
     // Get and cache a listing of table names for this dataset.
     Set<String> tablesInDataset;
     if (tableListingCache == null) {
-      tableListingCache = CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(1)).build();
+      // We need to be very careful about settings for the cache here. We have had significant
+      // issues in the past due to exceeding limits on BigQuery API requests; see
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1623000
+      tableListingCache = CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(10))
+          .build();
     }
     try {
       tablesInDataset = tableListingCache.get(datasetRef, () -> {

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -184,7 +184,10 @@ public class PubsubMessageToTableRow implements Serializable {
       }
     } else {
       if (tableSchemaCache == null) {
-        tableSchemaCache = CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(1))
+        // We need to be very careful about settings for the cache here. We have had significant
+        // issues in the past due to exceeding limits on BigQuery API requests; see
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1623000
+        tableSchemaCache = CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(10))
             .build();
       }
       if (bqService == null) {


### PR DESCRIPTION
See motivation in https://bugzilla.mozilla.org/show_bug.cgi?id=1623000#c9

Note that this will introduce some latency in how soon we're able to start loading messages once a new table is put into place, but I think that matter is fairly trivial compared to the fact that schema deploys are generally at most once per day anyway.