### PR TITLE
Share BQ listing caches between workers

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/KeyByBigQueryTableDestination.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/KeyByBigQueryTableDestination.java
@@ -93,13 +93,6 @@ public class KeyByBigQueryTableDestination extends PTransform<PCollection<Pubsub
 
     // Get and cache a listing of table names for this dataset.
     Set<String> tablesInDataset;
-    if (tableListingCache == null) {
-      // We need to be very careful about settings for the cache here. We have had significant
-      // issues in the past due to exceeding limits on BigQuery API requests; see
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1623000
-      tableListingCache = CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(10))
-          .build();
-    }
     try {
       tablesInDataset = tableListingCache.get(datasetRef, () -> {
         Set<String> tableSet = new HashSet<>();
@@ -153,8 +146,15 @@ public class KeyByBigQueryTableDestination extends PTransform<PCollection<Pubsub
   private final ValueProvider<String> partitioningField;
   private final ValueProvider<List<String>> clusteringFields;
 
+  // We need to be very careful about settings for the cache here. We have had significant
+  // issues in the past due to exceeding limits on BigQuery API requests; see
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1623000
+  // This cache is a static field so that it can be shared between all threads on a worker,
+  // reducing the number of needed API calls.
+  private static final Cache<DatasetReference, Set<String>> tableListingCache = CacheBuilder
+      .newBuilder().expireAfterWrite(Duration.ofMinutes(10)).build();
+
   // We'll instantiate these on first use.
-  private transient Cache<DatasetReference, Set<String>> tableListingCache;
   private transient Cache<String, String> normalizedNameCache;
   private transient BigQuery bqService;
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -94,8 +94,15 @@ public class PubsubMessageToTableRow implements Serializable {
   private final ValueProvider<TableRowFormat> tableRowFormat;
   private final KeyByBigQueryTableDestination keyByBigQueryTableDestination;
 
+  // We need to be very careful about settings for the cache here. We have had significant
+  // issues in the past due to exceeding limits on BigQuery API requests; see
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1623000
+  // This cache is a static field so that it can be shared between all threads on a worker,
+  // reducing the number of needed API calls.
+  private static final Cache<TableReference, Schema> tableSchemaCache = CacheBuilder.newBuilder()
+      .expireAfterWrite(Duration.ofMinutes(10)).build();
+
   // We'll instantiate these on first use.
-  private transient Cache<TableReference, Schema> tableSchemaCache;
   private transient Cache<String, String> normalizedNameCache;
   private transient BigQuerySchemaStore schemaStore;
   private transient BigQuery bqService;
@@ -183,13 +190,6 @@ public class PubsubMessageToTableRow implements Serializable {
             "The schema store does not contain a BigQuery schema for this table: " + tableSpec, e);
       }
     } else {
-      if (tableSchemaCache == null) {
-        // We need to be very careful about settings for the cache here. We have had significant
-        // issues in the past due to exceeding limits on BigQuery API requests; see
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=1623000
-        tableSchemaCache = CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(10))
-            .build();
-      }
       if (bqService == null) {
         bqService = BigQueryOptions.newBuilder().setProjectId(ref.getProjectId())
             .setRetrySettings(RETRY_SETTINGS).build().getService();


### PR DESCRIPTION
Implements intervention (2) as discussed in
https://bugzilla.mozilla.org/show_bug.cgi?id=1623000#c9

This should cause a ~8x decrease in rate of datasets.get requests.