### PR TITLE
Add bqMaxBytesPerPartition parameter to sink

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/ErrorOutputType.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/ErrorOutputType.java
@@ -99,8 +99,8 @@ public enum ErrorOutputType {
     public Write writeFailures(SinkOptions.Parsed options) {
       return new BigQueryOutput(options.getErrorOutput(), options.getErrorBqWriteMethod(),
           options.getParsedErrorBqTriggeringFrequency(), options.getInputType(),
-          options.getErrorBqNumFileShards(), StaticValueProvider.of(null),
-          StaticValueProvider.of(null), options.getSchemasLocation(),
+          options.getErrorBqNumFileShards(), options.getBqMaxBytesPerPartition(),
+          StaticValueProvider.of(null), StaticValueProvider.of(null), options.getSchemasLocation(),
           StaticValueProvider.of(TableRowFormat.raw), options.getErrorBqPartitioningField(),
           options.getErrorBqClusteringFields());
     }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/OutputType.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/OutputType.java
@@ -71,10 +71,10 @@ public enum OutputType {
     public Write write(SinkOptions.Parsed options) {
       return new BigQueryOutput(options.getOutput(), options.getBqWriteMethod(),
           options.getParsedBqTriggeringFrequency(), options.getInputType(),
-          options.getBqNumFileShards(), options.getBqStreamingDocTypes(),
-          options.getBqStrictSchemaDocTypes(), options.getSchemasLocation(),
-          options.getOutputTableRowFormat(), options.getBqPartitioningField(),
-          options.getBqClusteringFields());
+          options.getBqNumFileShards(), options.getBqMaxBytesPerPartition(),
+          options.getBqStreamingDocTypes(), options.getBqStrictSchemaDocTypes(),
+          options.getSchemasLocation(), options.getOutputTableRowFormat(),
+          options.getBqPartitioningField(), options.getBqClusteringFields());
     }
   };
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
@@ -105,6 +105,19 @@ public interface SinkOptions extends PipelineOptions {
 
   void setBqTriggeringFrequency(String value);
 
+  // When writing to main_v4 in batch mode, we sometimes see memory exceeded errors for
+  // BigQuery load jobs; we have found empirically that limiting the total data size per
+  // load job to 100 GB leads to reliable performance.
+  @Description("Maximum number of bytes to load into a single BigQuery table before rolling"
+      + " to an additional partition; this is generally only relevant when writing main_v4 in batch"
+      + " mode; we have found empirically that 500 GB per load job is low enough to avoid memory"
+      + " exceeded errors in load jobs yet high enough to avoid creating too many intermediate"
+      + " tables such that the final copy job fails")
+  @Default.Long(500 * (1L << 30))
+  Long getBqMaxBytesPerPartition();
+
+  void setBqMaxBytesPerPartition(Long value);
+
   @Description("Number of file shards to stage for BigQuery when writing via file_loads")
   @Default.Integer(100)
   int getBqNumFileShards();


### PR DESCRIPTION
Per Google case 22669857 we found that a recent batch job was failing due to
having too many tables created for `main_v4`. This increases the allowed size
for intermediate tables and exposes that value as a compile-time parameter.