### PR TITLE
Mark more namespaces and non-Firefox apps as unwanted data

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -8,8 +8,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.beam.sdk.metrics.Metrics;
 
@@ -26,26 +29,6 @@ public class MessageScrubber {
       .put("org-mozilla-vrbrowser-dev", "1614410") //
       .put("org-mozilla-fenix-performancetest", "1614412") //
       .put("org-mozilla-vrbrowser-wavevr", "1614411") //
-      .put("default-browser-agent", "1626020") //
-      .put("META-INF", "1626022") //
-      .build();
-
-  private static final Map<String, String> IGNORED_APPS = ImmutableMap.<String, String>builder()
-      .put("FirefoxOS", "1618684") //
-      .put("Ordissimo", "1592010") //
-      .put("adloops", "1592010") //
-      .put("agendissimo", "1592010") //
-      .put("ZeroWeb", "1592010") //
-      .put("CoreApp", "1592010") //
-      .put("webissimo3", "1592010") //
-      .put("Bitcentral%20Core", "1592010") //
-      .put("Zotero", "1592010") //
-      .put("adloops", "1592010") //
-      .put("facebook", "1592010") //
-      .put("vkb_browser", "1592010") //
-      .put("maps", "1592010") //
-      .put("gmail", "1592010") //
-      .put("selfcheckKiosk", "1592010") //
       .build();
 
   /**
@@ -99,8 +82,15 @@ public class MessageScrubber {
       throw new UnwantedDataException(IGNORED_NAMESPACES.get(namespace));
     }
 
-    if (IGNORED_APPS.containsKey(appName)) {
-      throw new UnwantedDataException(IGNORED_APPS.get(appName));
+    if ("FirefoxOS".equals(appName)) {
+      throw new UnwantedDataException("1618684");
+    }
+
+    // event, main, and modules are the only document types that will get aggregated
+    Set<String> docTypes = new HashSet<>(Arrays.asList("event", "main", "modules"));
+    if (ParseUri.TELEMETRY.equals(namespace) && docTypes.contains(docType)
+        && !"Firefox".equals(appName)) {
+      throw new UnwantedDataException("1592010");
     }
 
     // Check for other signatures that we want to send to error output, but which should appear

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -26,6 +26,8 @@ public class MessageScrubber {
       .put("org-mozilla-vrbrowser-dev", "1614410") //
       .put("org-mozilla-fenix-performancetest", "1614412") //
       .put("org-mozilla-vrbrowser-wavevr", "1614411") //
+      .put("default-browser-agent", "1626020") //
+      .put("META-INF", "1626022") //
       .build();
 
   private static final Map<String, String> IGNORED_APPS = ImmutableMap.<String, String>builder()

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -5,14 +5,12 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.beam.sdk.metrics.Metrics;
 
@@ -31,8 +29,8 @@ public class MessageScrubber {
       .put("org-mozilla-vrbrowser-wavevr", "1614411") //
       .build();
 
-  private static final Set<String> FIREFOX_ONLY_DOCTYPES = new HashSet<>(
-      Arrays.asList("event", "main", "modules"));
+  private static final ImmutableSet<String> FIREFOX_ONLY_DOCTYPES = ImmutableSet.of("event", "main",
+      "modules");
 
   /**
    * Inspect the contents of the payload and return true if the content matches a known pattern

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -37,6 +37,15 @@ public class MessageScrubber {
       .put("agendissimo", "1592010") //
       .put("ZeroWeb", "1592010") //
       .put("CoreApp", "1592010") //
+      .put("webissimo3", "1592010") //
+      .put("Bitcentral%20Core", "1592010") //
+      .put("Zotero", "1592010") //
+      .put("adloops", "1592010") //
+      .put("facebook", "1592010") //
+      .put("vkb_browser", "1592010") //
+      .put("maps", "1592010") //
+      .put("gmail", "1592010") //
+      .put("selfcheckKiosk", "1592010") //
       .build();
 
   /**

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -31,6 +31,9 @@ public class MessageScrubber {
       .put("org-mozilla-vrbrowser-wavevr", "1614411") //
       .build();
 
+  private static final Set<String> FIREFOX_ONLY_DOCTYPES = new HashSet<>(
+      Arrays.asList("event", "main", "modules"));
+
   /**
    * Inspect the contents of the payload and return true if the content matches a known pattern
    * we want to scrub and the message should not be sent downstream.
@@ -86,9 +89,9 @@ public class MessageScrubber {
       throw new UnwantedDataException("1618684");
     }
 
-    // event, main, and modules are the only document types that will get aggregated
-    Set<String> docTypes = new HashSet<>(Arrays.asList("event", "main", "modules"));
-    if (ParseUri.TELEMETRY.equals(namespace) && docTypes.contains(docType)
+    // These document types receive a significant number of pings with malformed `build_id`s due to
+    // third-party builds where `appName != "Firefox"`
+    if (ParseUri.TELEMETRY.equals(namespace) && FIREFOX_ONLY_DOCTYPES.contains(docType)
         && !"Firefox".equals(appName)) {
       throw new UnwantedDataException("1592010");
     }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -87,6 +87,26 @@ public class MessageScrubberTest {
   }
 
   @Test
+  public void testUnwantedDataBug1626020() {
+    Map<String, String> attributes = ImmutableMap.<String, String>builder()
+        .put(Attribute.DOCUMENT_NAMESPACE, "default-browser-agent")
+        .put(Attribute.DOCUMENT_TYPE, "baseline").build();
+
+    assertThrows(UnwantedDataException.class,
+        () -> MessageScrubber.scrub(attributes, Json.createObjectNode()));
+  }
+
+  @Test
+  public void testUnwantedDataBug1626022() {
+    Map<String, String> attributes = ImmutableMap.<String, String>builder()
+        .put(Attribute.DOCUMENT_NAMESPACE, "META-INF").put(Attribute.DOCUMENT_TYPE, "baseline")
+        .build();
+
+    assertThrows(UnwantedDataException.class,
+        () -> MessageScrubber.scrub(attributes, Json.createObjectNode()));
+  }
+
+  @Test
   public void testUnwantedDataBug1618684() {
     Map<String, String> attributes = ImmutableMap.<String, String>builder()
         .put(Attribute.APP_NAME, "FirefoxOS").build();

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -87,26 +87,6 @@ public class MessageScrubberTest {
   }
 
   @Test
-  public void testUnwantedDataBug1626020() {
-    Map<String, String> attributes = ImmutableMap.<String, String>builder()
-        .put(Attribute.DOCUMENT_NAMESPACE, "default-browser-agent")
-        .put(Attribute.DOCUMENT_TYPE, "baseline").build();
-
-    assertThrows(UnwantedDataException.class,
-        () -> MessageScrubber.scrub(attributes, Json.createObjectNode()));
-  }
-
-  @Test
-  public void testUnwantedDataBug1626022() {
-    Map<String, String> attributes = ImmutableMap.<String, String>builder()
-        .put(Attribute.DOCUMENT_NAMESPACE, "META-INF").put(Attribute.DOCUMENT_TYPE, "baseline")
-        .build();
-
-    assertThrows(UnwantedDataException.class,
-        () -> MessageScrubber.scrub(attributes, Json.createObjectNode()));
-  }
-
-  @Test
   public void testUnwantedDataBug1618684() {
     Map<String, String> attributes = ImmutableMap.<String, String>builder()
         .put(Attribute.APP_NAME, "FirefoxOS").build();
@@ -121,7 +101,9 @@ public class MessageScrubberTest {
 
     for (String app : unwantedApps) {
       Map<String, String> attributes = ImmutableMap.<String, String>builder()
-          .put(Attribute.APP_NAME, app).build();
+          .put(Attribute.APP_NAME, app) //
+          .put(Attribute.DOCUMENT_NAMESPACE, "telemetry") //
+          .put(Attribute.DOCUMENT_TYPE, "main").build();
 
       assertThrows(UnwantedDataException.class,
           () -> MessageScrubber.scrub(attributes, Json.createObjectNode()));

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParsePayloadTest.java
@@ -144,6 +144,7 @@ public class ParsePayloadTest {
     // printf '{"version":4}' | base64 -> eyJ2ZXJzaW9uIjo0fQ==
     String input = "{\"attributeMap\":" //
         + "{\"document_namespace\":\"telemetry\"" //
+        + ",\"app_name\":\"Firefox\"" //
         + ",\"document_id\":\"2c3a0767-d84a-4d02-8a92-fa54a3376049\"" //
         + ",\"document_type\":\"main\"" //
         + "},\"payload\":\"eyJ2ZXJzaW9uIjo0fQ==\"}";


### PR DESCRIPTION
This marks `default-browser-agent` and `META-INF` namespaces as well as some non-Firefox apps as unwanted data:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1626020
* https://bugzilla.mozilla.org/show_bug.cgi?id=1626022
* https://bugzilla.mozilla.org/show_bug.cgi?id=1592010

There is a [query to get all non-Firefox apps](https://bugzilla.mozilla.org/show_bug.cgi?id=1592010) which returns quite a long list. I only added the ones with more than 2000 pings in the past 10 days. Not sure what the threshold should be here.