### PR TITLE
Bug 1625330 - Reduce DEFAULT_BATCH_MAX_DELAY to avoid OOM errors

### DIFF
--- a/ingestion-sink/Dockerfile
+++ b/ingestion-sink/Dockerfile
@@ -14,4 +14,4 @@ RUN mvn package
 
 FROM base
 COPY --from=build /app/ingestion-sink/target/*.jar /app/ingestion-sink/target/
-CMD exec java -jar /app/ingestion-sink/target/*with-dependencies.jar
+CMD exec java $JAVA_OPTS -jar /app/ingestion-sink/target/*with-dependencies.jar


### PR DESCRIPTION
see [Bug 1625330 comment 2](https://bugzilla.mozilla.org/show_bug.cgi?id=1625330#c2) for why this is likely worth doing.

I will test this in stage by setting `BATCH_MAX_DELAY=10s` and `BIG_QUERY_OUTPUT_MODE=file_loads`, and seeing if we hit OOM errors.