### PR TITLE
Bug 1605199 - Forward deletion pings to amplitude

### DIFF
--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/util/Json.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/util/Json.java
@@ -16,6 +16,7 @@ import com.google.cloud.bigquery.Schema;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -158,6 +159,10 @@ public class Json {
 
   public static ObjectNode readObjectNode(String data) throws IOException {
     return readObjectNode(data.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static JsonNode readJsonNode(InputStream data) throws IOException {
+    return MAPPER.readTree(data);
   }
 
   /**

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Amplitude.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Amplitude.java
@@ -1,0 +1,132 @@
+package com.mozilla.telemetry.ingestion.sink.io;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.pubsub.v1.PubsubMessage;
+import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import com.mozilla.telemetry.ingestion.core.util.Json;
+import com.mozilla.telemetry.ingestion.sink.util.BatchWrite;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+public class Amplitude {
+
+  public static class Client {
+
+    private final URL url;
+    private final String basicAuth;
+
+    @VisibleForTesting
+    Client(String url, String username, String password) {
+      try {
+        this.url = new URL(url);
+      } catch (MalformedURLException e) {
+        throw new IllegalArgumentException(e);
+      }
+      this.basicAuth = "Basic " + Base64.getEncoder()
+          .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+    }
+
+    public Client(String username, String password) {
+      this("https://amplitude.com/api/2/deletions/users", username, password);
+    }
+
+    @VisibleForTesting
+    HttpURLConnection getConnection() throws IOException {
+      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+      conn.setRequestProperty("Authorization", basicAuth);
+      return conn;
+    }
+  }
+
+  public static class Delete extends BatchWrite<PubsubMessage, String, String, Void> {
+
+    // TODO this should be an amplitude service provider, so that tests can mock requests
+    private final Client client;
+
+    /** Constructor. */
+    public Delete(Client client, long maxBytes, int maxMessages, Duration maxDelay,
+        Executor executor) {
+      super(maxBytes, maxMessages, maxDelay, null, executor);
+      this.client = client;
+    }
+
+    @Override
+    protected String encodeInput(PubsubMessage input) {
+      return input.getAttributesOrThrow(Attribute.CLIENT_ID);
+    }
+
+    @Override
+    protected String getBatchKey(PubsubMessage input) {
+      return ""; // this is ignored, and null is not a valid batch key
+    }
+
+    @Override
+    protected Batch getBatch(String ignore) {
+      return new Batch();
+    }
+
+    @VisibleForTesting
+    class Batch extends BatchWrite<PubsubMessage, String, String, Void>.Batch {
+
+      private final ArrayNode userIds;
+
+      private Batch() {
+        super();
+        this.userIds = Json.createArrayNode();
+      }
+
+      @Override
+      protected CompletableFuture<Void> close() {
+        // https://help.amplitude.com/hc/en-us/articles/360000398191-User-Privacy-API#h_5be848c6-64b7-4ae4-ad6d-a784b05dcb8b
+        ObjectNode body = Json.createObjectNode().put("requester", "shredder")
+            // skip invalid ID because not every deletion request will have already uploaded events
+            .put("ignore_invalid_id", "True")
+            // don't delete from multiple projects. If False then response will be a json object, if
+            // True then response will be a json array of objects
+            .put("delete_from_org", "False");
+        body.set("user_ids", userIds);
+        try {
+          HttpURLConnection conn = client.getConnection();
+          conn.setRequestProperty("Content-Type", "application/json");
+          conn.setRequestMethod("POST");
+          conn.setDoOutput(true);
+          conn.setDoInput(true);
+          try (OutputStream os = conn.getOutputStream()) {
+            os.write(Json.asBytes(body));
+          }
+          assert conn.getResponseCode() == 200;
+          try (InputStream stream = conn.getInputStream()) {
+            // verify that the response was JSON and don't validate the number of IDs returned,
+            // because not every deletion request is "valid" (i.e. has already uploaded events)
+            Json.readJsonNode(stream);
+          }
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+        return CompletableFuture.completedFuture(null);
+      }
+
+      @Override
+      protected void write(String userId) {
+        userIds.add(userId);
+      }
+
+      @Override
+      protected long getByteSize(String userId) {
+        return userId.length();
+      }
+    }
+  }
+}

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/Env.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/Env.java
@@ -25,6 +25,12 @@ public class Env {
     unused = new HashSet<>(env.keySet());
   }
 
+  private void checkIncluded(String key) {
+    if (!include.contains(key)) {
+      throw new IllegalArgumentException("key missing from include: " + key);
+    }
+  }
+
   /**
    * Throw an {@link IllegalArgumentException} for any environment variables set but not used.
    */
@@ -35,13 +41,12 @@ public class Env {
   }
 
   public boolean containsKey(String key) {
+    checkIncluded(key);
     return env.containsKey(key);
   }
 
   private Optional<String> optString(String key) {
-    if (!include.contains(key)) {
-      throw new IllegalArgumentException("key missing from include: " + key);
-    }
+    checkIncluded(key);
     unused.remove(key);
     return Optional.ofNullable(env.get(key));
   }

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/AmplitudeDeleteTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/AmplitudeDeleteTest.java
@@ -1,0 +1,48 @@
+package com.mozilla.telemetry.ingestion.sink.io;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.pubsub.v1.PubsubMessage;
+import com.mozilla.telemetry.ingestion.core.util.Json;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ForkJoinPool;
+import org.junit.Test;
+
+public class AmplitudeDeleteTest {
+
+  @Test
+  public void canSucceedWithMock() throws IOException {
+    Amplitude.Client client = mock(Amplitude.Client.class);
+    Amplitude.Delete output = new Amplitude.Delete(client, 0, 0, Duration.ZERO,
+        ForkJoinPool.commonPool());
+    HttpURLConnection conn = mock(HttpURLConnection.class);
+    when(client.getConnection()).thenReturn(conn);
+    ByteArrayOutputStream body = new ByteArrayOutputStream();
+    when(conn.getOutputStream()).thenReturn(body);
+    when(conn.getResponseCode()).thenReturn(200);
+    when(conn.getInputStream())
+        .thenReturn(new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8)));
+
+    output.apply(PubsubMessage.newBuilder().putAttributes("client_id", "x")
+        .putAttributes("document_namespace", "telemetry").build()).join();
+
+    assertEquals(
+        ImmutableMap.of("requester", "shredder", "ignore_invalid_id", "True", "delete_from_org",
+            "False", "user_ids", ImmutableList.of("x")),
+        Json.asMap(Json.readObjectNode(body.toByteArray())));
+  }
+
+  @Test
+  public void canSucceedOnLocalhost() {
+    // TODO test with a local http server
+  }
+}


### PR DESCRIPTION
This contains all of the boilerplate for setting up a new ingestion-sink output that writes client ids from deletion requests to amplitude.

Search for `TODO` to find all of the spots that need to be filled out with the actual implementation of sending a deletion request to amplitude.