### PR TITLE
Bug 1626301 Allow "Solaris" to normalize to "Linux"

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/NormalizeAttributes.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/NormalizeAttributes.java
@@ -61,7 +61,8 @@ public class NormalizeAttributes
       return WINDOWS;
     } else if (name.startsWith("Darwin")) {
       return MAC;
-    } else if (name.contains("Linux") || name.contains("BSD") || name.contains("SunOS")) {
+    } else if (name.contains("Linux") || name.contains("BSD") || name.contains("SunOS")
+        || name.contains("Solaris")) {
       return LINUX;
     } else if (name.startsWith("iOS") || name.contains("iPhone")) {
       return IOS;

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/util/NormalizeAttributesTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/util/NormalizeAttributesTest.java
@@ -52,6 +52,7 @@ public class NormalizeAttributesTest {
     assertEquals("Linux", NormalizeAttributes.normalizeOs("Linux"));
     assertEquals("Linux", NormalizeAttributes.normalizeOs("GNU/Linux"));
     assertEquals("Linux", NormalizeAttributes.normalizeOs("SunOS"));
+    assertEquals("Linux", NormalizeAttributes.normalizeOs("Solaris"));
     assertEquals("Linux", NormalizeAttributes.normalizeOs("FreeBSD"));
     assertEquals("Linux", NormalizeAttributes.normalizeOs("GNU/kFreeBSD"));
     assertEquals("Other", NormalizeAttributes.normalizeOs("AIX"));


### PR DESCRIPTION
Glean may report "Solaris" as an OS value whereas we currently only recognize "SunOS" from desktop telemetry.