### PR TITLE
Close batches from a synchronized context

### DIFF
--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/BigQuery.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/BigQuery.java
@@ -104,12 +104,12 @@ public class BigQuery {
       }
 
       @Override
-      protected synchronized CompletableFuture<InsertAllResponse> close(Void ignore) {
+      protected CompletableFuture<InsertAllResponse> close() {
         return CompletableFuture.completedFuture(bigQuery.insertAll(builder.build()));
       }
 
       @Override
-      protected synchronized void write(PubsubMessage input) {
+      protected void write(PubsubMessage input) {
         Map<String, Object> content = Json.asMap(encoder.apply(input));
         builder.addRow(content);
       }
@@ -198,7 +198,7 @@ public class BigQuery {
 
       //
       @Override
-      protected synchronized CompletableFuture<Void> close(Void ignore1) {
+      protected CompletableFuture<Void> close() {
         List<String> sourceUris = sourceBlobIds.stream().map(BlobIdToString::apply)
             .collect(Collectors.toList());
         boolean loadSuccess = true;
@@ -225,7 +225,7 @@ public class BigQuery {
       }
 
       @Override
-      protected synchronized void write(PubsubMessage input) {
+      protected void write(PubsubMessage input) {
         sourceBlobIds.add(BlobId.of(input.getAttributesOrThrow(BlobInfoToPubsubMessage.BUCKET),
             input.getAttributesOrThrow(BlobInfoToPubsubMessage.NAME)));
       }

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
@@ -101,7 +101,7 @@ public class Gcs {
       }
 
       @Override
-      protected CompletableFuture<Void> close(Void ignore) {
+      protected CompletableFuture<Void> close() {
         try {
           writer.close();
         } catch (IOException e) {

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/BatchWriteTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/BatchWriteTest.java
@@ -35,7 +35,7 @@ public class BatchWriteTest {
     class Batch extends BatchWrite<String, String, String, Void>.Batch {
 
       @Override
-      protected CompletableFuture<Void> close(Void ignore) {
+      protected CompletableFuture<Void> close() {
         return CompletableFuture.runAsync(() -> {
         });
       }


### PR DESCRIPTION
to prevent `write` after `close`

Without this we could lose messages, e.g. as seen in [bug 1612371 comment 14](https://bugzilla.mozilla.org/show_bug.cgi?id=1612371#c14), but only when writing to GCS, because that's the only implementation of `BatchWrite` that didn't have `synchronized` on `close`.