### PR TITLE
Always provide executor to CompletableFuture::*Async

### DIFF
--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/BigQuery.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/BigQuery.java
@@ -24,11 +24,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class BigQuery {
 
@@ -59,16 +58,14 @@ public class BigQuery {
   public static class Write
       extends BatchWrite<PubsubMessage, PubsubMessage, TableId, InsertAllResponse> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Write.class);
-
     private final com.google.cloud.bigquery.BigQuery bigQuery;
     private final PubsubMessageToObjectNode encoder;
 
     /** Constructor. */
     public Write(com.google.cloud.bigquery.BigQuery bigQuery, long maxBytes, int maxMessages,
-        Duration maxDelay, PubsubMessageToTemplatedString batchKeyTemplate,
+        Duration maxDelay, PubsubMessageToTemplatedString batchKeyTemplate, Executor executor,
         PubsubMessageToObjectNode encoder) {
-      super(maxBytes, maxMessages, maxDelay, batchKeyTemplate);
+      super(maxBytes, maxMessages, maxDelay, batchKeyTemplate, executor);
       this.bigQuery = bigQuery;
       this.encoder = encoder;
     }
@@ -153,8 +150,8 @@ public class BigQuery {
 
     /** Constructor. */
     public Load(com.google.cloud.bigquery.BigQuery bigQuery, Storage storage, long maxBytes,
-        int maxFiles, Duration maxDelay, Delete delete) {
-      super(maxBytes, maxFiles, maxDelay, null);
+        int maxFiles, Duration maxDelay, Executor executor, Delete delete) {
+      super(maxBytes, maxFiles, maxDelay, null, executor);
       this.bigQuery = bigQuery;
       this.storage = storage;
       this.delete = delete;

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,9 +36,10 @@ public class Gcs {
       private final PubsubMessageToObjectNode encoder;
 
       public Ndjson(Storage storage, long maxBytes, int maxMessages, Duration maxDelay,
-          PubsubMessageToTemplatedString batchKeyTemplate, PubsubMessageToObjectNode encoder,
+          PubsubMessageToTemplatedString batchKeyTemplate, Executor executor,
+          PubsubMessageToObjectNode encoder,
           Function<BlobInfo, CompletableFuture<Void>> batchCloseHook) {
-        super(storage, maxBytes, maxMessages, maxDelay, batchKeyTemplate, batchCloseHook);
+        super(storage, maxBytes, maxMessages, maxDelay, batchKeyTemplate, executor, batchCloseHook);
         this.encoder = encoder;
       }
 
@@ -55,9 +57,9 @@ public class Gcs {
     private final Function<BlobInfo, CompletableFuture<Void>> batchCloseHook;
 
     private Write(Storage storage, long maxBytes, int maxMessages, Duration maxDelay,
-        PubsubMessageToTemplatedString batchKeyTemplate,
+        PubsubMessageToTemplatedString batchKeyTemplate, Executor executor,
         Function<BlobInfo, CompletableFuture<Void>> batchCloseHook) {
-      super(maxBytes, maxMessages, maxDelay, batchKeyTemplate);
+      super(maxBytes, maxMessages, maxDelay, batchKeyTemplate, executor);
       this.storage = storage;
       this.batchCloseHook = batchCloseHook;
     }

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/TimedFuture.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/TimedFuture.java
@@ -1,0 +1,24 @@
+package com.mozilla.telemetry.ingestion.sink.util;
+
+import java.time.Duration;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A non-blocking Future that will complete after some amount of time has passed.
+ */
+public class TimedFuture extends CompletableFuture<Void> {
+
+  public TimedFuture(Duration delay) {
+    new Timer().schedule(new CompleteTask(), delay.toMillis());
+  }
+
+  private class CompleteTask extends TimerTask {
+
+    @Override
+    public void run() {
+      complete(null);
+    }
+  }
+}

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/BigQueryTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/BigQueryTest.java
@@ -23,6 +23,7 @@ import com.mozilla.telemetry.ingestion.sink.transform.PubsubMessageToTemplatedSt
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ForkJoinPool;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,7 +50,7 @@ public class BigQueryTest {
     when(bigQuery.insertAll(any())).thenReturn(response);
     when(response.getErrorsFor(anyLong())).thenReturn(ImmutableList.of());
     output = new BigQuery.Write(bigQuery, MAX_BYTES, MAX_MESSAGES, MAX_DELAY, BATCH_KEY_TEMPLATE,
-        PubsubMessageToObjectNode.Raw.of());
+        ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of());
   }
 
   @Test
@@ -60,7 +61,7 @@ public class BigQueryTest {
   @Test
   public void canSendWithNoDelay() {
     output = new BigQuery.Write(bigQuery, MAX_BYTES, MAX_MESSAGES, Duration.ofMillis(0),
-        BATCH_KEY_TEMPLATE, PubsubMessageToObjectNode.Raw.of());
+        BATCH_KEY_TEMPLATE, ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of());
     output.apply(EMPTY_MESSAGE);
     assertEquals(1, output.batches.get(BATCH_KEY).size);
   }
@@ -111,7 +112,7 @@ public class BigQueryTest {
   public void canHandleProjectInTableId() {
     output = new BigQuery.Write(bigQuery, MAX_BYTES, MAX_MESSAGES, NO_DELAY,
         PubsubMessageToTemplatedString.forBigQuery("project.dataset.table"),
-        PubsubMessageToObjectNode.Raw.of());
+        ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of());
     output.apply(EMPTY_MESSAGE).join();
     assertNotNull(output.batches.get(TableId.of("project", "dataset", "table")));
   }
@@ -119,7 +120,7 @@ public class BigQueryTest {
   @Test
   public void canHandleDocumentId() {
     output = new BigQuery.Write(bigQuery, MAX_BYTES, MAX_MESSAGES, NO_DELAY, BATCH_KEY_TEMPLATE,
-        PubsubMessageToObjectNode.Raw.of());
+        ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of());
     output.apply(PubsubMessage.newBuilder().putAttributes("document_id", "id").build()).join();
     List<InsertAllRequest.RowToInsert> rows = ((BigQuery.Write.Batch) output.batches
         .get(BATCH_KEY)).builder.build().getRows();
@@ -133,7 +134,7 @@ public class BigQueryTest {
   public void canHandleDynamicTableId() {
     output = new BigQuery.Write(bigQuery, MAX_BYTES, MAX_MESSAGES, NO_DELAY,
         PubsubMessageToTemplatedString.forBigQuery("${dataset}.${table}"),
-        PubsubMessageToObjectNode.Raw.of());
+        ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of());
     output.apply(PubsubMessage.newBuilder().putAttributes("dataset", "dataset")
         .putAttributes("table", "table").build()).join();
     assertNotNull(output.batches.get(TableId.of("dataset", "table")));
@@ -143,7 +144,7 @@ public class BigQueryTest {
   public void canHandleDynamicTableIdWithEmptyValues() {
     output = new BigQuery.Write(bigQuery, MAX_BYTES, MAX_MESSAGES, NO_DELAY,
         PubsubMessageToTemplatedString.forBigQuery("${dataset}_.${table}_"),
-        PubsubMessageToObjectNode.Raw.of());
+        ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of());
     output.apply(
         PubsubMessage.newBuilder().putAttributes("dataset", "").putAttributes("table", "").build())
         .join();
@@ -154,7 +155,7 @@ public class BigQueryTest {
   public void canHandleDynamicTableIdWithDefaults() {
     output = new BigQuery.Write(bigQuery, MAX_BYTES, MAX_MESSAGES, NO_DELAY,
         PubsubMessageToTemplatedString.forBigQuery("${dataset:-dataset}.${table:-table}"),
-        PubsubMessageToObjectNode.Raw.of());
+        ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of());
     output.apply(EMPTY_MESSAGE).join();
     assertNotNull(output.batches.get(TableId.of("dataset", "table")));
   }
@@ -164,7 +165,7 @@ public class BigQueryTest {
     output = new BigQuery.Write(bigQuery, MAX_BYTES, MAX_MESSAGES, NO_DELAY,
         PubsubMessageToTemplatedString
             .forBigQuery("${document_namespace}.${document_type}_${suffix}"),
-        PubsubMessageToObjectNode.Raw.of());
+        ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of());
     output.apply(PubsubMessage.newBuilder().putAttributes("document_namespace", "my-namespace")
         .putAttributes("document_type", "myDocType").putAttributes("suffix", "my-suffix").build())
         .join();
@@ -175,14 +176,14 @@ public class BigQueryTest {
   public void failsOnMissingAttributes() {
     new BigQuery.Write(bigQuery, MAX_BYTES, MAX_MESSAGES, NO_DELAY,
         PubsubMessageToTemplatedString.forBigQuery("${dataset}.${table}"),
-        PubsubMessageToObjectNode.Raw.of()).apply(EMPTY_MESSAGE);
+        ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of()).apply(EMPTY_MESSAGE);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void failsOnInvalidTable() {
     new BigQuery.Write(bigQuery, MAX_BYTES, MAX_MESSAGES, NO_DELAY,
-        PubsubMessageToTemplatedString.forBigQuery(""), PubsubMessageToObjectNode.Raw.of())
-            .apply(EMPTY_MESSAGE);
+        PubsubMessageToTemplatedString.forBigQuery(""), ForkJoinPool.commonPool(),
+        PubsubMessageToObjectNode.Raw.of()).apply(EMPTY_MESSAGE);
   }
 
   @Test(expected = NullPointerException.class)

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/GcsWriteTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/GcsWriteTest.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ForkJoinPool;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,7 +44,7 @@ public class GcsWriteTest {
   public void mockBigQueryResponse() {
     storage = mock(Storage.class);
     output = new Gcs.Write.Ndjson(storage, MAX_BYTES, MAX_MESSAGES, MAX_DELAY, BATCH_KEY_TEMPLATE,
-        PubsubMessageToObjectNode.Raw.of(), this::batchCloseHook);
+        ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of(), this::batchCloseHook);
   }
 
   @Test
@@ -57,7 +58,8 @@ public class GcsWriteTest {
   @Test
   public void canSendWithNoDelay() {
     output = new Gcs.Write.Ndjson(storage, MAX_BYTES, MAX_MESSAGES, Duration.ofMillis(0),
-        BATCH_KEY_TEMPLATE, PubsubMessageToObjectNode.Raw.of(), this::batchCloseHook);
+        BATCH_KEY_TEMPLATE, ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of(),
+        this::batchCloseHook);
     output.apply(EMPTY_MESSAGE).join();
     assertEquals(1, output.batches.get(BATCH_KEY).size);
     assertEquals(EMPTY_MESSAGE_SIZE, output.batches.get(BATCH_KEY).byteSize);

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/PubsubReadIntegrationTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/PubsubReadIntegrationTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,7 +39,7 @@ public class PubsubReadIntegrationTest {
             .map(channelProvider -> builder.setChannelProvider(channelProvider)
                 .setCredentialsProvider(pubsub.noCredentialsProvider))
             .orElse(builder),
-        m -> m));
+        m -> m, ForkJoinPool.commonPool()));
 
     input.get().run();
 
@@ -68,7 +69,7 @@ public class PubsubReadIntegrationTest {
             .map(channelProvider -> builder.setChannelProvider(channelProvider)
                 .setCredentialsProvider(pubsub.noCredentialsProvider))
             .orElse(builder),
-        m -> m));
+        m -> m, ForkJoinPool.commonPool()));
 
     input.get().run();
 

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/PubsubWriteIntegrationTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/PubsubWriteIntegrationTest.java
@@ -7,6 +7,7 @@ import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.mozilla.telemetry.ingestion.sink.util.SinglePubsubTopic;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.Rule;
@@ -23,16 +24,18 @@ public class PubsubWriteIntegrationTest {
 
   @Test
   public void canWriteToStaticDestination() {
-    new Pubsub.Write(pubsub.getTopic(), 1, b -> b, m -> m).apply(PubsubMessage.newBuilder()
-        .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8))).build()).join();
+    new Pubsub.Write(pubsub.getTopic(), ForkJoinPool.commonPool(), b -> b, m -> m)
+        .apply(PubsubMessage.newBuilder()
+            .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8))).build())
+        .join();
     assertEquals(ImmutableList.of("test"), pubsub.pull(1, false).stream()
         .map(m -> m.getData().toStringUtf8()).collect(Collectors.toList()));
   }
 
   @Test
   public void canWriteToDynamicDestination() {
-    new Pubsub.Write("${topic}", 1, b -> b, m -> m).apply(PubsubMessage.newBuilder()
-        .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8)))
+    new Pubsub.Write("${topic}", ForkJoinPool.commonPool(), b -> b, m -> m).apply(PubsubMessage
+        .newBuilder().setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8)))
         .putAttributes("topic", pubsub.getTopic()).build()).join();
     assertEquals(ImmutableList.of("test"), pubsub.pull(1, false).stream()
         .map(m -> m.getData().toStringUtf8()).collect(Collectors.toList()));

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/BatchWriteTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/BatchWriteTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
 import org.junit.Test;
 
 public class BatchWriteTest {
@@ -13,7 +14,7 @@ public class BatchWriteTest {
     int batchCount = 0;
 
     private NoopBatchWrite(long maxBytes, int maxMessages, Duration maxDelay) {
-      super(maxBytes, maxMessages, maxDelay, null);
+      super(maxBytes, maxMessages, maxDelay, null, ForkJoinPool.commonPool());
     }
 
     @Override


### PR DESCRIPTION
and use a non-blocking timeout for BatchWrite.