### PR TITLE
Remove nulls from arrays in beam PubsubMessageToTableRow

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRow.java
@@ -328,15 +328,6 @@ public class PubsubMessageToTableRow implements Serializable {
       List<Object> records = value.filter(List.class::isInstance).map(List.class::cast)
           .orElse(ImmutableList.of());
       List<Object> repeatedAdditionalProperties = new ArrayList<>();
-      records.stream().filter(Map.class::isInstance).map(Map.class::cast).forEach(record -> {
-        Map<String, Object> props = additionalProperties == null ? null : new HashMap<>();
-        transformForBqSchema(record, field.getSubFields(), props);
-        if (props != null && !props.isEmpty()) {
-          repeatedAdditionalProperties.add(props);
-        } else {
-          repeatedAdditionalProperties.add(null);
-        }
-      });
       // Arrays of tuples cannot be transformed in place, instead each element of the parent array
       // will need to reference a new transformed object.
       if (records.stream().allMatch(List.class::isInstance)) {
@@ -348,13 +339,32 @@ public class PubsubMessageToTableRow implements Serializable {
           if (props != null && !props.isEmpty()) {
             repeatedAdditionalProperties.add(props);
           } else {
-            repeatedAdditionalProperties.add(null);
+            repeatedAdditionalProperties.add(Collections.emptyMap());
           }
           records.set(i, (Object) m);
         }
+      } else {
+        records.forEach(untypedRecord -> {
+          if (untypedRecord instanceof Map) {
+            Map<String, Object> record = (Map<String, Object>) untypedRecord;
+            Map<String, Object> props = additionalProperties == null ? null : new HashMap<>();
+            transformForBqSchema(record, field.getSubFields(), props);
+            if (props != null && !props.isEmpty()) {
+              repeatedAdditionalProperties.add(props);
+            } else {
+              repeatedAdditionalProperties.add(Collections.emptyMap());
+            }
+          } else {
+            repeatedAdditionalProperties.add(null);
+          }
+        });
+        // BigQuery cannot load null values into an array, so we must filter them out here, but
+        // additionalProperties will have a null in the correct place in the array.
+        parent.put(name,
+            records.stream().filter(Map.class::isInstance).collect(Collectors.toList()));
       }
 
-      if (!repeatedAdditionalProperties.stream().allMatch(Objects::isNull)) {
+      if (!repeatedAdditionalProperties.stream().allMatch(m -> Collections.emptyMap().equals(m))) {
         additionalProperties.put(jsonFieldName, repeatedAdditionalProperties);
       }
       // If we've made it here, we have a basic type or a list of basic types.

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubMessageToTableRowTest.java
@@ -394,7 +394,7 @@ public class PubsubMessageToTableRowTest extends TestWithDeterministicJson {
     TRANSFORM.transformForBqSchema(parent, bqFields, additionalProperties);
     assertEquals(expected, Json.asString(parent));
 
-    String expectedAdditional = "{\"payload\":[null,{\"b\":22},null]}";
+    String expectedAdditional = "{\"payload\":[{},{\"b\":22},{}]}";
     assertEquals(expectedAdditional, Json.asString(additionalProperties));
   }
 
@@ -482,7 +482,25 @@ public class PubsubMessageToTableRowTest extends TestWithDeterministicJson {
     TRANSFORM.transformForBqSchema(parent, bqFields, additionalProperties);
     assertEquals(expected, Json.asString(parent));
 
-    String expectedAdditional = "{\"payload\":[null,[null,{\"b\":4}]]}";
+    String expectedAdditional = "{\"payload\":[null,[{},{\"b\":4}]]}";
+    assertEquals(expectedAdditional, Json.asString(additionalProperties));
+  }
+
+  @Test
+  public void testListWithNulls() throws Exception {
+    Map<String, Object> additionalProperties = new HashMap<>();
+    TableRow parent = Json.readTableRow(
+        ("{\"modules\":[{\"base_addr\":\"0x1390000\"},null]}").getBytes(StandardCharsets.UTF_8));
+    List<Field> bqFields = ImmutableList.of(Field
+        .newBuilder("modules", LegacySQLTypeName.RECORD,
+            Field.of("base_addr", LegacySQLTypeName.STRING)) //
+        .setMode(Mode.REPEATED).build() //
+    ); //
+    String expected = "{\"modules\":[{\"base_addr\":\"0x1390000\"}]}";
+    TRANSFORM.transformForBqSchema(parent, bqFields, additionalProperties);
+    assertEquals(expected, Json.asString(parent));
+
+    String expectedAdditional = "{\"modules\":[{},null]}";
     assertEquals(expectedAdditional, Json.asString(additionalProperties));
   }
 


### PR DESCRIPTION
In our reproduction of the pipeline instability incident in stage,
Google support found that we had some batch load jobs continually failing
due to loading nulls into REPEATED fields.

We were able to trace down a load job into crash_v4 where the field
`payload.strack_traces.modules` had some entries that were literal `null`.

In this PR, we strip out nulls from the JSON array. We need to change how we
handle additional_properties, though, in order to maintain order in the array.
Previously, we used `null` as a placeholder value for entries where the full
content was parsed into fields; now, we use `{}` instead so that we can
distinguish that case from literal `null` values appearing in the input array.

It appears that ingestion-sink must already be correctly stripping these out.
We should make sure we fully understand the behavior there along with this
change.

cc @whd