### PR TITLE
Fix #1249 - Remove the date parameter from geolite2 fetch

### DIFF
--- a/ingestion-beam/bin/download-geolite2
+++ b/ingestion-beam/bin/download-geolite2
@@ -5,7 +5,7 @@
 # This script downloads and extracts the free GeoLite2 city database
 # from MaxMind for use in development.
 BASE_DIR="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")"
-DOWNLOAD_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&date=20200107&license_key=${MM_LICENSE_KEY}&suffix=tar.gz"
+DOWNLOAD_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${MM_LICENSE_KEY}&suffix=tar.gz"
 LOCAL_ARCHIVE=/tmp/GeoLite2-City.mmdb.gz
 LOCAL_EXTRACTED=/tmp/GeoLite2-City.mmdb
 


### PR DESCRIPTION
Fixes #1249 by removing the date parameter. 