### PR TITLE
Detect errors on bq load in ingestion-sink

### DIFF
--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/config/SinkConfig.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/config/SinkConfig.java
@@ -9,6 +9,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.pubsub.v1.PubsubMessage;
 import com.mozilla.telemetry.ingestion.sink.io.BigQuery;
+import com.mozilla.telemetry.ingestion.sink.io.BigQuery.BigQueryErrors;
 import com.mozilla.telemetry.ingestion.sink.io.Gcs;
 import com.mozilla.telemetry.ingestion.sink.io.Pubsub;
 import com.mozilla.telemetry.ingestion.sink.transform.BlobInfoToPubsubMessage;
@@ -245,8 +246,8 @@ public class SinkConfig {
         // fallbackOutput sends messages to fileOutput when rejected by streamingOutput due to size
         Function<PubsubMessage, CompletableFuture<Void>> fallbackOutput = message -> streamingOutput
             .apply(message).thenApply(CompletableFuture::completedFuture).exceptionally(t -> {
-              if (t.getCause() instanceof BigQuery.WriteErrors) {
-                BigQuery.WriteErrors cause = (BigQuery.WriteErrors) t.getCause();
+              if (t.getCause() instanceof BigQueryErrors) {
+                BigQueryErrors cause = (BigQueryErrors) t.getCause();
                 if (cause.errors.size() == 1 && cause.errors.get(0).getMessage()
                     .startsWith("Maximum allowed row size exceeded")) {
                   return fileOutput.apply(message);

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/BigQueryLoadIntegrationTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/BigQueryLoadIntegrationTest.java
@@ -1,0 +1,113 @@
+package com.mozilla.telemetry.ingestion.sink.io;
+
+import static org.junit.Assert.assertEquals;
+
+import avro.shaded.com.google.common.collect.ImmutableList;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.pubsub.v1.PubsubMessage;
+import com.mozilla.telemetry.ingestion.sink.io.BigQuery.BigQueryErrors;
+import com.mozilla.telemetry.ingestion.sink.transform.BlobInfoToPubsubMessage;
+import com.mozilla.telemetry.ingestion.sink.util.BigQueryDataset;
+import com.mozilla.telemetry.ingestion.sink.util.GcsBucket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BigQueryLoadIntegrationTest {
+
+  @Rule
+  public final GcsBucket gcs = new GcsBucket();
+
+  @Rule
+  public final BigQueryDataset bq = new BigQueryDataset();
+
+  private String createTable() {
+    final StandardTableDefinition tableDef = StandardTableDefinition
+        .of(Schema.of(Field.of("payload", LegacySQLTypeName.STRING)));
+    final TableId tableId = TableId.of(bq.project, bq.dataset, "test_load_v1");
+    bq.bigquery.create(TableInfo.newBuilder(tableId, tableDef).build());
+    return tableId.getProject() + "." + tableId.getDataset() + "." + tableId.getTable();
+  }
+
+  private BlobInfo generateBlobId(String outputTable) {
+    return BlobInfo
+        .newBuilder(BlobId.of(gcs.bucket,
+            "OUTPUT_TABLE=" + outputTable + "/" + UUID.randomUUID().toString() + ".ndjson"))
+        .build();
+  }
+
+  private BlobInfo createBlob(String outputTable, String content) {
+    return gcs.storage.create(generateBlobId(outputTable),
+        content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void canLoad() throws Exception {
+    final String outputTable = createTable();
+    final BlobInfo blobInfo = createBlob(outputTable, "{\"payload\":\"canLoad\"}");
+    // load blob
+    final BigQuery.Load loader = new BigQuery.Load(bq.bigquery, gcs.storage, 0, 0, Duration.ZERO,
+        ForkJoinPool.commonPool(), BigQuery.Load.Delete.onSuccess);
+    loader.apply(BlobInfoToPubsubMessage.apply(blobInfo)).join();
+    // check result
+    final List<String> actual = StreamSupport
+        .stream(bq.bigquery.query(QueryJobConfiguration.of("SELECT * FROM `" + outputTable + "`"))
+            .iterateAll().spliterator(), false)
+        .map(row -> row.get("payload").getStringValue()).collect(Collectors.toList());
+    assertEquals(ImmutableList.of("canLoad"), actual);
+  }
+
+  @Test
+  public void failsOnMissingBlob() {
+    final String outputTable = createTable();
+    final BlobInfo missingBlob = generateBlobId(outputTable);
+    final BlobInfo presentBlob = createBlob(outputTable, "{}");
+    // load single batch with missing and present blobs
+    final BigQuery.Load loader = new BigQuery.Load(bq.bigquery, gcs.storage, 10, 2,
+        Duration.ofMillis(500), ForkJoinPool.commonPool(), BigQuery.Load.Delete.onSuccess);
+    final CompletableFuture<Void> missing = loader
+        .apply(PubsubMessage.newBuilder().putAttributes("bucket", missingBlob.getBucket())
+            .putAttributes("name", missingBlob.getName()).putAttributes("size", "0").build());
+    final CompletableFuture<Void> present = loader
+        .apply(BlobInfoToPubsubMessage.apply(presentBlob));
+    // require single batch of both messages
+    assertEquals(ImmutableList.of(2),
+        loader.batches.values().stream().map(b -> b.size).collect(Collectors.toList()));
+    // require both futures throw BigQueryErrors about missingBlob URI
+    Optional<List<String>> expected = Optional.of(ImmutableList
+        .of("Not found: URI gs://" + missingBlob.getBucket() + "/" + missingBlob.getName()));
+    for (CompletableFuture f : ImmutableList.of(missing, present)) {
+      Optional<BigQueryErrors> actual = Optional.empty();
+      try {
+        f.join();
+      } catch (CompletionException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof BigQueryErrors) {
+          actual = Optional.of((BigQueryErrors) cause);
+        } else {
+          throw e;
+        }
+      }
+      assertEquals(!f.equals(missing) ? "missingBlob" : "presentBlob", expected, actual
+          .map(e -> e.errors.stream().map(BigQueryError::getMessage).collect(Collectors.toList())));
+    }
+  }
+}

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/BigQueryTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/BigQueryTest.java
@@ -91,7 +91,7 @@ public class BigQueryTest {
     assertThat((int) output.batches.get(BATCH_KEY).byteSize, lessThanOrEqualTo(MAX_BYTES));
   }
 
-  @Test(expected = BigQuery.WriteErrors.class)
+  @Test(expected = BigQuery.BigQueryErrors.class)
   public void failsOnInsertErrors() throws Throwable {
     when(response.getErrorsFor(0)).thenReturn(ImmutableList.of(new BigQueryError("", "", "")));
 


### PR DESCRIPTION
without this the `failsOnMissingBlob` test showed that missing blob errors were completely ignored.

cc @whd