### PR TITLE
Check if blob exists in BigQuery.Load

### DIFF
--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/config/SinkConfig.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/config/SinkConfig.java
@@ -67,7 +67,7 @@ public class SinkConfig {
   // Executor for CompletableFuture::*Async to use instead of ForkJoinPool.commonPool(), because
   // the default parallelism is 1 in stage and prod.
   private static final Executor DEFAULT_EXECUTOR = new ForkJoinPool(
-      Math.max(Runtime.getRuntime().availableProcessors() * 2, 10));
+      Math.max(Runtime.getRuntime().availableProcessors() * 20, 100));
   // BigQuery.Write.Batch.getByteSize reports protobuf size, which can be ~1/3rd more
   // efficient than the JSON that actually gets sent over HTTP, so we use to 60% of the
   // 10MB API limit by default.


### PR DESCRIPTION
This prevents the entire load operation from failing due to a single missing uri, because blobs may take longer to become available in GCS than it takes for them to reach `BigQuery.Load`.

This also mitigates an issue in stage where missing blobs are blocking existing blobs from being loaded.