### PR TITLE
Skip ci jobs on gh-pages branch deployed by mkdocs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
         name: Build and deploy docs
         command: |
           if [ $CIRCLE_BRANCH == "master" ]; then
-            mkdocs gh-deploy
+            mkdocs gh-deploy -m "[ci skip] Deployed {sha} with MkDocs version: {version}"
           fi
 
   ingestion-edge:


### PR DESCRIPTION
There is no circleci config on this branch, so it will always fail.