### PR TITLE
Fix #1273 - Update GeoLite2-City extraction for new directory structure

### DIFF
--- a/ingestion-beam/bin/download-geolite2
+++ b/ingestion-beam/bin/download-geolite2
@@ -6,13 +6,27 @@
 # from MaxMind for use in development.
 BASE_DIR="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")"
 DOWNLOAD_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${MM_LICENSE_KEY}&suffix=tar.gz"
-LOCAL_ARCHIVE=/tmp/GeoLite2-City.mmdb.gz
-LOCAL_EXTRACTED=/tmp/GeoLite2-City.mmdb
 
 set -e
 
+# The GeoLite2-City archive is structured as follows:
+#
+#   x GeoLite2-City_20200428/
+#   x GeoLite2-City_20200428/README.txt
+#   x GeoLite2-City_20200428/COPYRIGHT.txt
+#   x GeoLite2-City_20200428/GeoLite2-City.mmdb
+#   x GeoLite2-City_20200428/LICENSE.txt
+#
+# Download and extract the mmdb into the current directory if it doesn't exist.
 test -f "$BASE_DIR/$(basename "$LOCAL_EXTRACTED")" || (
-    curl -o "$LOCAL_ARCHIVE" "$DOWNLOAD_URL"
-    gunzip -f "$LOCAL_ARCHIVE"
-    mv "$LOCAL_EXTRACTED" "$BASE_DIR"
+    working=$(mktemp -d)
+    cd "$working"
+
+    archive=GeoLite2-City.mmdb.gz
+    curl -o "$archive" "$DOWNLOAD_URL"
+    tar -zxvf "$archive"
+    extracted=$(find "$working" -name '*.mmdb')
+
+    cd -
+    mv "$extracted" "$BASE_DIR"
 )

--- a/ingestion-beam/bin/download-geolite2
+++ b/ingestion-beam/bin/download-geolite2
@@ -4,10 +4,12 @@
 
 # This script downloads and extracts the free GeoLite2 city database
 # from MaxMind for use in development.
+set -e
+
+: ${MM_LICENSE_KEY?"maxmind license must be set, see decoder docs for more details"}
 BASE_DIR="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")"
 DOWNLOAD_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${MM_LICENSE_KEY}&suffix=tar.gz"
-
-set -e
+DB_NAME="GeoLite2-City.mmdb"
 
 # The GeoLite2-City archive is structured as follows:
 #
@@ -18,14 +20,14 @@ set -e
 #   x GeoLite2-City_20200428/LICENSE.txt
 #
 # Download and extract the mmdb into the current directory if it doesn't exist.
-test -f "$BASE_DIR/$(basename "$LOCAL_EXTRACTED")" || (
+test -f "$BASE_DIR/$DB_NAME" || (
     working=$(mktemp -d)
     cd "$working"
 
     archive=GeoLite2-City.mmdb.gz
     curl -o "$archive" "$DOWNLOAD_URL"
     tar -zxvf "$archive"
-    extracted=$(find "$working" -name '*.mmdb')
+    extracted=$(find "$working" -name "$DB_NAME")
 
     cd -
     mv "$extracted" "$BASE_DIR"


### PR DESCRIPTION
This fixes #1273. The GeoLite2-Cirty archive now includes several additional files that caused the `download-geolite` script to generate an invalid mmdb binary. This fixes issues with the `GeoCityLookup` step of the beam pipeline when running the decoder locally for integration testing purposes. 