### PR TITLE
Add script for benchmarking Pioneer decryption

### DIFF
--- a/bin/mvn
+++ b/bin/mvn
@@ -36,6 +36,7 @@ docker run $INTERACTIVE_FLAGS --rm \
     -v "$GIT_TOPLEVEL":/var/maven/project \
     -w /var/maven/project/"$GIT_PREFIX" \
     -v ~/.m2:/var/maven/.m2 \
+    -e MAVEN_OPTS \
     -e MAVEN_CONFIG=/var/maven/.m2 \
     -e GOOGLE_APPLICATION_CREDENTIALS \
     $MOUNT_CREDENTIALS_FLAGS \

--- a/ingestion-beam/bin/run-pioneer-benchmark
+++ b/ingestion-beam/bin/run-pioneer-benchmark
@@ -7,13 +7,16 @@
 # Initial findings show that for every 1 minute spent on ParsePayload, there are
 # 3 minutes spend on DecryptPioneerPayloads. Peak throughput in ParsePayload
 # goes from 3360 elements/sec to 2466 elements/sec when adding encryption.
+#
+# This script requires the use of GNU Coreutils. This may be installed on MacOS
+# via homebrew: `brew install coreutils`.
 
 set -ex
 
 export MAVEN_OPTS="-Xms8g -Xmx8g"
 reset=${RESET:-false}
 project=$(gcloud config get-value project)
-bucket="gs://${BUCKET:-$project}"
+bucket="gs://${BUCKET?bucket value must be specified}"
 prefix="ingestion-beam-benchmark"
 staging="benchmark_staging"
 
@@ -24,7 +27,7 @@ if [[ ! -f document_sample.ndjson ]]; then
     exit 1
 fi
 
-if [[ ! -f pioneer_benchmark_data.ndjson ]] || ${reset}; then
+if [[ ! -f pioneer_benchmark_data.ndjson ]] || [[ ${reset} == "true" ]]; then
     # generate the data using the document sample, this may take a while depending on your machine
     ./bin/mvn clean compile exec:java -Dexec.mainClass=com.mozilla.telemetry.PioneerBenchmarkGenerator
 fi

--- a/ingestion-beam/bin/run-pioneer-benchmark
+++ b/ingestion-beam/bin/run-pioneer-benchmark
@@ -1,4 +1,12 @@
 #!/bin/bash
+# Runs a benchmark that can be used to quantify the overhead of the
+# DecryptPioneerPayloads step. A document sample of ingested data is encrypted
+# using JOSE and is run through the Pioneer-enabled decoder. This is compared
+# against the plaintext data.
+#
+# Initial findings show that for every 1 minute spent on ParsePayload, there are
+# 3 minutes spend on DecryptPioneerPayloads. Peak throughput in ParsePayload
+# goes from 3360 elements/sec to 2466 elements/sec when adding encryption.
 
 set -ex
 
@@ -7,8 +15,14 @@ reset=${RESET:-false}
 project=$(gcloud config get-value project)
 bucket="gs://${BUCKET:-$project}"
 prefix="ingestion-beam-benchmark"
-staging=benchmark_staging
+staging="benchmark_staging"
 
+cd "$(dirname "$0")/.."
+
+if [[ ! -f document_sample.ndjson ]]; then
+    echo "missing document_sample.ndjson, run download-document-sample"
+    exit 1
+fi
 
 if [[ ! -f pioneer_benchmark_data.ndjson ]] || ${reset}; then
     # generate the data using the document sample, this may take a while depending on your machine
@@ -26,6 +40,7 @@ if [[ ! -d $staging ]]; then
     mkdir -p $plaintext
     mkdir -p $ciphertext
     mkdir -p $metadata
+    # shuffle to avoid data skew, and to prepare for file splitting if necessary
     shuf document_sample.ndjson > $plaintext/part-0.ndjson
     shuf pioneer_benchmark_data.ndjson > $ciphertext/part-0.ndjson
     cp pioneer_benchmark_key.json $staging/metadata/key.json
@@ -36,6 +51,8 @@ if [[ ! -d $staging ]]; then
     cp cities15000.txt $metadata
     cp GeoLite2-City.mmdb $metadata
 fi
+
+# this can take a while, depending on your upload speed (~1 GB of data)
 gsutil -m rsync -R -d $staging/ "$bucket/$prefix/"
 
 # plaintext

--- a/ingestion-beam/run-pioneer-benchmark
+++ b/ingestion-beam/run-pioneer-benchmark
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+./bin/mvn compile exec:java \
+    -Dexec.mainClass=com.mozilla.telemetry.PioneerBenchmarkGenerator \
+    -Dexec.args="\
+    --inputFileFormat=json \
+    --inputType=file \
+    --input=document_sample.ndjson \
+    --outputFileFormat=json \
+    --outputType=file \
+    --output=output/out \
+    --errorOutputType=file \
+    --errorOutput=tmp/error
+"

--- a/ingestion-beam/run-pioneer-benchmark
+++ b/ingestion-beam/run-pioneer-benchmark
@@ -1,14 +1,6 @@
 #!/bin/bash
 
-./bin/mvn compile exec:java \
-    -Dexec.mainClass=com.mozilla.telemetry.PioneerBenchmarkGenerator \
-    -Dexec.args="\
-    --inputFileFormat=json \
-    --inputType=file \
-    --input=document_sample.ndjson \
-    --outputFileFormat=json \
-    --outputType=file \
-    --output=output/out \
-    --errorOutputType=file \
-    --errorOutput=tmp/error
-"
+export MAVEN_OPTS="-Xms8g -Xmx8g"
+
+mvn compile exec:java \
+    -Dexec.mainClass=com.mozilla.telemetry.PioneerBenchmarkGenerator

--- a/ingestion-beam/run-pioneer-benchmark
+++ b/ingestion-beam/run-pioneer-benchmark
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+set -e
+
 export MAVEN_OPTS="-Xms8g -Xmx8g"
 reset=${RESET:-false}
+
+cd "$(dirname "$0")/.."
 
 if [[ ! -f pioneer_benchmark_data.ndjson ]] || ${reset}; then
     # generate the data using the document sample
@@ -23,8 +27,6 @@ cd -
 rm -r benchmark_data
 mv $tmp_dir/benchmark_data/ benchmark_data/
 
-# unfortunately, it is not possible to run beam locally with the document sample due to OOM issues.
-
 # mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dexec.args="\
 #     --geoCityDatabase=GeoLite2-City.mmdb \
 #     --geoCityFilter=cities15000.txt \
@@ -39,7 +41,7 @@ mv $tmp_dir/benchmark_data/ benchmark_data/
 #     --errorOutputType=stderr
 # "
 
-./bin/mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dexec.args="\
+mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dexec.args="\
     --geoCityDatabase=GeoLite2-City.mmdb \
     --geoCityFilter=cities15000.txt \
     --schemasLocation=schemas.tar.gz \

--- a/ingestion-beam/run-pioneer-benchmark
+++ b/ingestion-beam/run-pioneer-benchmark
@@ -1,6 +1,52 @@
 #!/bin/bash
 
 export MAVEN_OPTS="-Xms8g -Xmx8g"
+reset=${RESET:-false}
 
-mvn compile exec:java \
-    -Dexec.mainClass=com.mozilla.telemetry.PioneerBenchmarkGenerator
+if [[ ! -f pioneer_benchmark_data.ndjson ]] || ${reset}; then
+    # generate the data using the document sample
+    mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.PioneerBenchmarkGenerator
+fi
+
+# Shuffle the raw data to avoid data skew when splitting into smaller files.
+# Since the `split` command in BSD doesn't support the `-C` option to split
+# files by maximum size and ending line break, we'll shuffle the data and use
+# the `-l` option to limit by lines.
+tmp_dir=$(mktemp -d)
+shuf document_sample.ndjson > $tmp_dir/shuffled_sample
+cd $tmp_dir
+mkdir -p benchmark_data/raw
+lines=$(wc -l < shuffled_sample)
+chunk=$((lines / 6))
+split -l $chunk shuffled_sample benchmark_data/raw/part-
+cd -
+rm -r benchmark_data
+mv $tmp_dir/benchmark_data/ benchmark_data/
+
+# unfortunately, it is not possible to run beam locally with the document sample due to OOM issues.
+
+# mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dexec.args="\
+#     --geoCityDatabase=GeoLite2-City.mmdb \
+#     --geoCityFilter=cities15000.txt \
+#     --schemasLocation=schemas.tar.gz \
+#     --pioneerEnabled=true \
+#     --pioneerMetadataLocation=pioneer_benchmark_metadata.json \
+#     --pioneerDecompressPayload=false \
+#     --inputType=file \
+#     --input=pioneer_benchmark_data.json \
+#     --outputType=file \
+#     --output=pioneer_output \
+#     --errorOutputType=stderr
+# "
+
+./bin/mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dexec.args="\
+    --geoCityDatabase=GeoLite2-City.mmdb \
+    --geoCityFilter=cities15000.txt \
+    --schemasLocation=schemas.tar.gz \
+    --inputType=file \
+    --input='benchmark_data/raw/part-*' \
+    --outputType=file \
+    --output=benchmark_data/output/raw/ \
+    --errorOutputType=file \
+    --errorOutput=benchmark_data/error/
+"

--- a/ingestion-beam/run-pioneer-benchmark
+++ b/ingestion-beam/run-pioneer-benchmark
@@ -1,54 +1,83 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 export MAVEN_OPTS="-Xms8g -Xmx8g"
 reset=${RESET:-false}
+project=$(gcloud config get-value project)
+bucket="gs://${BUCKET:-$project}"
+prefix="ingestion-beam-benchmark"
+staging=benchmark_staging
 
-cd "$(dirname "$0")/.."
 
 if [[ ! -f pioneer_benchmark_data.ndjson ]] || ${reset}; then
-    # generate the data using the document sample
-    mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.PioneerBenchmarkGenerator
+    # generate the data using the document sample, this may take a while depending on your machine
+    ./bin/mvn clean compile exec:java -Dexec.mainClass=com.mozilla.telemetry.PioneerBenchmarkGenerator
 fi
 
-# Shuffle the raw data to avoid data skew when splitting into smaller files.
-# Since the `split` command in BSD doesn't support the `-C` option to split
-# files by maximum size and ending line break, we'll shuffle the data and use
-# the `-l` option to limit by lines.
-tmp_dir=$(mktemp -d)
-shuf document_sample.ndjson > $tmp_dir/shuffled_sample
-cd $tmp_dir
-mkdir -p benchmark_data/raw
-lines=$(wc -l < shuffled_sample)
-chunk=$((lines / 6))
-split -l $chunk shuffled_sample benchmark_data/raw/part-
-cd -
-rm -r benchmark_data
-mv $tmp_dir/benchmark_data/ benchmark_data/
+# assert bucket can be read
+gsutil ls "$bucket" &> /dev/null
 
-# mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dexec.args="\
-#     --geoCityDatabase=GeoLite2-City.mmdb \
-#     --geoCityFilter=cities15000.txt \
-#     --schemasLocation=schemas.tar.gz \
-#     --pioneerEnabled=true \
-#     --pioneerMetadataLocation=pioneer_benchmark_metadata.json \
-#     --pioneerDecompressPayload=false \
-#     --inputType=file \
-#     --input=pioneer_benchmark_data.json \
-#     --outputType=file \
-#     --output=pioneer_output \
-#     --errorOutputType=stderr
-# "
+# generate a new folder and sync it to gcs, assumes a bucket value
+if [[ ! -d $staging ]]; then
+    plaintext=$staging/input/plaintext
+    ciphertext=$staging/input/ciphertext
+    metadata=$staging/metadata
+    mkdir -p $plaintext
+    mkdir -p $ciphertext
+    mkdir -p $metadata
+    shuf document_sample.ndjson > $plaintext/part-0.ndjson
+    shuf pioneer_benchmark_data.ndjson > $ciphertext/part-0.ndjson
+    cp pioneer_benchmark_key.json $staging/metadata/key.json
+    # compute the location of the remote key and insert it into the metadata
+    remote_key="$bucket/$prefix/metadata/key.json"
+    jq "(.. | .private_key_uri?) |= \"$remote_key\"" pioneer_benchmark_metadata.json > $staging/metadata/metadata.json
+    cp schemas.tar.gz $metadata
+    cp cities15000.txt $metadata
+    cp GeoLite2-City.mmdb $metadata
+fi
+gsutil -m rsync -R -d $staging/ "$bucket/$prefix/"
 
-mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dexec.args="\
-    --geoCityDatabase=GeoLite2-City.mmdb \
-    --geoCityFilter=cities15000.txt \
-    --schemasLocation=schemas.tar.gz \
+# plaintext
+./bin/mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dexec.args="\
+    --runner=Dataflow \
+    --profilingAgentConfiguration='{\"APICurated\": true}'
+    --project=$project \
+    --autoscalingAlgorithm=NONE \
+    --workerMachineType=n1-standard-1 \
+    --gcpTempLocation=$bucket/tmp \
+    --numWorkers=2 \
+    --geoCityDatabase=$bucket/$prefix/metadata/GeoLite2-City.mmdb \
+    --geoCityFilter=$bucket/$prefix/metadata/cities15000.txt \
+    --schemasLocation=$bucket/$prefix/metadata/schemas.tar.gz \
     --inputType=file \
-    --input='benchmark_data/raw/part-*' \
+    --input=$bucket/$prefix/input/plaintext/'part-*' \
     --outputType=file \
-    --output=benchmark_data/output/raw/ \
+    --output=$bucket/$prefix/output/plaintext/ \
     --errorOutputType=file \
-    --errorOutput=benchmark_data/error/
+    --errorOutput=$bucket/$prefix/error/plaintext/ \
+"
+
+# ciphertext
+./bin/mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dexec.args="\
+    --runner=Dataflow \
+    --profilingAgentConfiguration='{\"APICurated\": true}'
+    --project=$project \
+    --autoscalingAlgorithm=NONE \
+    --workerMachineType=n1-standard-1 \
+    --gcpTempLocation=$bucket/tmp \
+    --numWorkers=2 \
+    --pioneerEnabled=true \
+    --pioneerMetadataLocation=$bucket/$prefix/metadata/metadata.json \
+    --pioneerKmsEnabled=false \
+    --pioneerDecompressPayload=false \
+    --geoCityDatabase=$bucket/$prefix/metadata/GeoLite2-City.mmdb \
+    --geoCityFilter=$bucket/$prefix/metadata/cities15000.txt \
+    --schemasLocation=$bucket/$prefix/metadata/schemas.tar.gz \
+    --inputType=file \
+    --input=$bucket/$prefix/input/ciphertext/'part-*' \
+    --outputType=file \
+    --output=$bucket/$prefix/output/ciphertext/ \
+    --errorOutputType=file \
+    --errorOutput=$bucket/$prefix/error/ciphertext/ \
 "

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
@@ -23,10 +23,12 @@ import org.jose4j.jwk.JsonWebKey.OutputControlLevel;
 import org.jose4j.keys.EllipticCurves;
 import org.jose4j.lang.JoseException;
 
+/** Generate a dataset for benchmarking the DecryptPioneerPayloads transform. */
 public class PioneerBenchmarkGenerator {
 
-  final static ObjectMapper mapper = new ObjectMapper();
+  static final ObjectMapper mapper = new ObjectMapper();
 
+  /** Encrypt a payload using a public key and insert it into an envelope. */
   public static byte[] encrypt(byte[] data, PublicKey key) throws IOException, JoseException {
     JsonWebEncryption jwe = new JsonWebEncryption();
     jwe.setPayload(new String(data, Charsets.UTF_8));
@@ -39,6 +41,7 @@ public class PioneerBenchmarkGenerator {
     return Json.asString(node).getBytes(Charsets.UTF_8);
   }
 
+  /** Read a Pubsub ndjson message wrapping failures in an Optional. */
   public static Optional<PubsubMessage> parsePubsub(String data) {
     try {
       return Optional.of(Json.readPubsubMessage(data));
@@ -48,6 +51,7 @@ public class PioneerBenchmarkGenerator {
     }
   }
 
+  /** Encrypt the payload in a Pubsub message and place it into an envelope. */
   public static Optional<String> transform(PubsubMessage message, PublicKey key) {
     try {
       PubsubMessage encryptedMessage = new PubsubMessage(encrypt(message.getPayload(), key),
@@ -63,10 +67,10 @@ public class PioneerBenchmarkGenerator {
    * Pioneer parameters and envelope. Write out the relevant metadata files for
    * the single key in use. */
   public static void main(final String[] args) throws JoseException, IOException {
-    Path inputPath = Paths.get("document_sample.ndjson");
-    Path outputPath = Paths.get("pioneer_benchmark_data.ndjson");
-    Path keyPath = Paths.get("pioneer_benchmark_key.json");
-    Path metadataPath = Paths.get("pioneer_benchmark_metadata.json");
+    final Path inputPath = Paths.get("document_sample.ndjson");
+    final Path outputPath = Paths.get("pioneer_benchmark_data.ndjson");
+    final Path keyPath = Paths.get("pioneer_benchmark_key.json");
+    final Path metadataPath = Paths.get("pioneer_benchmark_metadata.json");
 
     EllipticCurveJsonWebKey key = EcJwkGenerator.generateJwk(EllipticCurves.P256);
     HashSet<String> namespaces = new HashSet<String>();

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
@@ -1,13 +1,16 @@
 package com.mozilla.telemetry;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Charsets;
 import com.mozilla.telemetry.util.Json;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.PublicKey;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
@@ -35,9 +38,17 @@ public class PioneerBenchmarkGenerator {
     return Json.asString(node).getBytes(Charsets.UTF_8);
   }
 
-  public static Optional<String> transform(String data, PublicKey key) {
+  public static Optional<PubsubMessage> parsePubsub(String data) {
     try {
-      PubsubMessage message = Json.readPubsubMessage(data);
+      return Optional.of(Json.readPubsubMessage(data));
+    } catch (Exception e) {
+      e.printStackTrace();
+      return Optional.empty();
+    }
+  }
+
+  public static Optional<String> transform(PubsubMessage message, PublicKey key) {
+    try {
       PubsubMessage encryptedMessage = new PubsubMessage(encrypt(message.getPayload(), key),
           message.getAttributeMap());
       return Optional.of(Json.asString(encryptedMessage));
@@ -47,18 +58,46 @@ public class PioneerBenchmarkGenerator {
     }
   }
 
-  public static void main(final String[] args) throws JoseException {
+  /** Read in documents in the shape of Pubsub ndjson files and encrypt using
+   * Pioneer parameters and envelope. Write out the relevant metadata files for
+   * the single key in use. */
+  public static void main(final String[] args) throws JoseException, IOException {
+    Path inputPath = Paths.get("document_sample.ndjson");
+    Path outputPath = Paths.get("pioneer_benchmark_data.ndjson");
+    Path keyPath = Paths.get("pioneer_benchmark_key.ndjson");
+    Path metadataPath = Paths.get("pioneer_benchmark_metadata.json");
+
     EllipticCurveJsonWebKey key = EcJwkGenerator.generateJwk(EllipticCurves.P256);
-    // write the key to disk
-    // write the metadata file
+    HashSet<String> namespaces = new HashSet<String>();
 
-    try (Stream<String> stream = Files.lines(Paths.get("document_sample.ndjson"))) {
-
-      Files.write(Paths.get("pioneer_benchmark.ndjson"),
-          (Iterable<String>) stream.map(s -> transform(s, key.getPublicKey()))
-              .filter(Optional::isPresent).map(Optional::get)::iterator);
+    // runs in ~2:30 min
+    try (Stream<String> stream = Files.lines(inputPath)) {
+      // side-effects to get the set of attributes
+      Files.write(outputPath, (Iterable<String>) stream.map(PioneerBenchmarkGenerator::parsePubsub)
+          .filter(Optional::isPresent).map(Optional::get).map(message -> {
+            // side-effects and side-input
+            namespaces.add(message.getAttribute("document_namespace"));
+            return transform(message, key.getPublicKey());
+          }).filter(Optional::isPresent).map(Optional::get)::iterator);
     } catch (IOException e) {
       e.printStackTrace();
     }
+
+    // write out the key
+    Files.write(keyPath, key.toJson().getBytes(Charsets.UTF_8));
+
+    // write out the metadata
+    ArrayNode metadata = mapper.createArrayNode();
+    for (String namespace : namespaces) {
+      ObjectNode node = mapper.createObjectNode();
+      node.put("private_key_id", namespace);
+      // TODO: write this to the appropriate location like gcs, if relevant
+      node.put("private_key_uri", keyPath.toString());
+      // empty value
+      node.put("kms_resource_id", "");
+      metadata.add(node);
+    }
+    Files.write(metadataPath, metadata.toPrettyString().getBytes(Charsets.UTF_8));
+
   }
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
@@ -1,36 +1,49 @@
 package com.mozilla.telemetry;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mozilla.telemetry.util.Json;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.PublicKey;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.jose4j.jwk.EcJwkGenerator;
+import org.jose4j.jwk.EllipticCurveJsonWebKey;
+import org.jose4j.keys.EllipticCurves;
+import org.jose4j.lang.JoseException;
 
 public class PioneerBenchmarkGenerator {
 
-  // create a temporary directory
-  // generate a keyfile metadata
-  // encode all of the messages
-  // upload into a temporary directory (or named directory)
   final static ObjectMapper mapper = new ObjectMapper();
 
-  public static Optional<String> transform(String data) {
+  public static byte[] encrypt(byte[] data, PublicKey key) {
+    return data;
+  }
+
+  public static Optional<String> transform(String data, PublicKey key) {
     try {
-      JsonNode node = mapper.readTree(data);
-      return Optional.of(node.get("attributeMap").get("document_namespace").toString());
+      PubsubMessage message = Json.readPubsubMessage(data);
+      PubsubMessage encryptedMessage = new PubsubMessage(encrypt(message.getPayload(), key),
+          message.getAttributeMap());
+      return Optional.of(Json.asString(encryptedMessage));
     } catch (IOException e) {
       e.printStackTrace();
       return Optional.empty();
     }
   }
 
-  public static void main(final String[] args) {
+  public static void main(final String[] args) throws JoseException {
+    EllipticCurveJsonWebKey key = EcJwkGenerator.generateJwk(EllipticCurves.P256);
+    // write the key to disk
+    // write the metadata file
+
     try (Stream<String> stream = Files.lines(Paths.get("document_sample.ndjson"))) {
 
-      Files.write(Paths.get("output.ndjson"), (Iterable<String>) stream.map(s -> transform(s))
-          .filter(Optional::isPresent).map(Optional::get)::iterator);
+      Files.write(Paths.get("output.ndjson"),
+          (Iterable<String>) stream.map(s -> transform(s, key.getPublicKey()))
+              .filter(Optional::isPresent).map(Optional::get)::iterator);
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
@@ -1,0 +1,36 @@
+package com.mozilla.telemetry;
+
+import com.mozilla.telemetry.options.SinkOptions;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+
+public class PioneerBenchmarkGenerator {
+  // create a temporary directory
+  // generate a keyfile metadata
+  // encode all of the messages
+  // upload into a temporary directory (or named directory)
+
+  public static void main(final String[] args) {
+    run(args);
+  }
+
+  public interface PioneerBenchmarkOptions extends SinkOptions {
+  }
+
+  public static PipelineResult run(final String[] args) {
+    PioneerBenchmarkOptions options = PipelineOptionsFactory.fromArgs(args).withValidation()
+        .as(PioneerBenchmarkOptions.class);
+
+    // parsed sink options
+    SinkOptions.Parsed sinkOptions = SinkOptions.parseSinkOptions(options);
+
+    Pipeline p = Pipeline.create(sinkOptions);
+
+    p.apply(options.getInputType().read(sinkOptions)) //
+        .apply(options.getOutputType().write(sinkOptions));
+    return p.run();
+
+  }
+
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
@@ -19,6 +19,7 @@ import org.jose4j.jwe.JsonWebEncryption;
 import org.jose4j.jwe.KeyManagementAlgorithmIdentifiers;
 import org.jose4j.jwk.EcJwkGenerator;
 import org.jose4j.jwk.EllipticCurveJsonWebKey;
+import org.jose4j.jwk.JsonWebKey.OutputControlLevel;
 import org.jose4j.keys.EllipticCurves;
 import org.jose4j.lang.JoseException;
 
@@ -64,7 +65,7 @@ public class PioneerBenchmarkGenerator {
   public static void main(final String[] args) throws JoseException, IOException {
     Path inputPath = Paths.get("document_sample.ndjson");
     Path outputPath = Paths.get("pioneer_benchmark_data.ndjson");
-    Path keyPath = Paths.get("pioneer_benchmark_key.ndjson");
+    Path keyPath = Paths.get("pioneer_benchmark_key.json");
     Path metadataPath = Paths.get("pioneer_benchmark_metadata.json");
 
     EllipticCurveJsonWebKey key = EcJwkGenerator.generateJwk(EllipticCurves.P256);
@@ -84,7 +85,7 @@ public class PioneerBenchmarkGenerator {
     }
 
     // write out the key
-    Files.write(keyPath, key.toJson().getBytes(Charsets.UTF_8));
+    Files.write(keyPath, key.toJson(OutputControlLevel.INCLUDE_PRIVATE).getBytes(Charsets.UTF_8));
 
     // write out the metadata
     ArrayNode metadata = mapper.createArrayNode();

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/PioneerBenchmarkGenerator.java
@@ -1,36 +1,38 @@
 package com.mozilla.telemetry;
 
-import com.mozilla.telemetry.options.SinkOptions;
-import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.PipelineResult;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class PioneerBenchmarkGenerator {
+
   // create a temporary directory
   // generate a keyfile metadata
   // encode all of the messages
   // upload into a temporary directory (or named directory)
+  final static ObjectMapper mapper = new ObjectMapper();
+
+  public static Optional<String> transform(String data) {
+    try {
+      JsonNode node = mapper.readTree(data);
+      return Optional.of(node.get("attributeMap").get("document_namespace").toString());
+    } catch (IOException e) {
+      e.printStackTrace();
+      return Optional.empty();
+    }
+  }
 
   public static void main(final String[] args) {
-    run(args);
+    try (Stream<String> stream = Files.lines(Paths.get("document_sample.ndjson"))) {
+
+      Files.write(Paths.get("output.ndjson"), (Iterable<String>) stream.map(s -> transform(s))
+          .filter(Optional::isPresent).map(Optional::get)::iterator);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
   }
-
-  public interface PioneerBenchmarkOptions extends SinkOptions {
-  }
-
-  public static PipelineResult run(final String[] args) {
-    PioneerBenchmarkOptions options = PipelineOptionsFactory.fromArgs(args).withValidation()
-        .as(PioneerBenchmarkOptions.class);
-
-    // parsed sink options
-    SinkOptions.Parsed sinkOptions = SinkOptions.parseSinkOptions(options);
-
-    Pipeline p = Pipeline.create(sinkOptions);
-
-    p.apply(options.getInputType().read(sinkOptions)) //
-        .apply(options.getOutputType().write(sinkOptions));
-    return p.run();
-
-  }
-
 }


### PR DESCRIPTION
This adds scripts for measuring the overhead of the `DecryptPioneerPayloads` step in Dataflow. This particular run contained 58,933 elements, which is 528.53 MB plaintext and      692.03 MB ciphertext. Each job had ~1 minute total clock time on `ParsePayload`. The Pioneer enabled job had 3 minutes on the `DecryptPioneerPayloads` step. The difference in vCPU/hr (0.096 plaintext vs 0.14 ciphertext) doesn't accurately capture the difference above since there is the startup and cleanup overhead of the job.

* [baseline dataflow job](https://console.cloud.google.com/dataflow/jobsDetail/locations/us-central1/jobs/2020-04-30_12_08_03-13899129925267677039?project=amiyaguchi-dev)
* [pioneer enabled dataflow job](https://console.cloud.google.com/dataflow/jobsDetail/locations/us-central1/jobs/2020-04-30_12_08_43-191213889725123005?project=amiyaguchi-dev)
* [baseline profiling](https://console.cloud.google.com/profiler/decoder-0-0430190751-f2be1cb9/cpu?project=amiyaguchi-dev)
* [pioneer-enabled profiling](https://console.cloud.google.com/profiler/decoder-0-0430190833-f2251679/cpu?project=amiyaguchi-dev)
