### PR TITLE
Implement pubsub reads using pull API

### DIFF
--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
@@ -67,6 +67,15 @@ public class Gcs {
     }
 
     @Override
+    public void flush() {
+      super.flush();
+      // propagate flush to batchCloseHook
+      if (batchCloseHook instanceof BatchWrite) {
+        ((BatchWrite) batchCloseHook).flush();
+      }
+    }
+
+    @Override
     protected String getBatchKey(PubsubMessage input) {
       return batchKeyTemplate.apply(input);
     }

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Input.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Input.java
@@ -1,0 +1,8 @@
+package com.mozilla.telemetry.ingestion.sink.io;
+
+public interface Input {
+
+  void stop();
+
+  void run();
+}

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Pubsub.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Pubsub.java
@@ -3,55 +3,256 @@ package com.mozilla.telemetry.ingestion.sink.io;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.DeadlineExceededException;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.pubsub.v1.GetSubscriptionRequest;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.ReceivedMessage;
 import com.mozilla.telemetry.ingestion.sink.transform.PubsubMessageToTemplatedString;
+import com.mozilla.telemetry.ingestion.sink.util.BatchWrite;
+import com.mozilla.telemetry.ingestion.sink.util.CompletableFutures;
+import com.mozilla.telemetry.ingestion.sink.util.LeaseManager;
+import com.mozilla.telemetry.ingestion.sink.util.TimedFuture;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Pubsub {
 
-  private Pubsub() {
+  private static <T> MessageReceiver getReceiver(Logger logger,
+      Function<PubsubMessage, PubsubMessage> decompress,
+      Function<PubsubMessage, CompletableFuture<T>> output) {
+    // Synchronous CompletableFuture methods are executed by the thread that completes the
+    // future, or the current thread if the future is already complete. Use that here to
+    // minimize memory usage by doing as much work as immediately possible.
+    return (message, consumer) -> CompletableFuture.completedFuture(message).thenApply(decompress)
+        .thenCompose(output).whenComplete((result, exception) -> {
+          if (exception == null) {
+            consumer.ack();
+          } else {
+            // exception is always a CompletionException caused by the real exception
+            logger.warn("Exception while attempting to deliver message", exception.getCause());
+            consumer.nack();
+          }
+        });
   }
 
-  public static class Read {
+  public static class Pull implements Input {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Read.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Pull.class);
 
     @VisibleForTesting
-    public Subscriber subscriber;
+    final LeaseManager leaseManager;
+
+    private final SubscriberStub client;
+    private final String subscription;
+    private final Duration initialRenewDelay;
+    private final long initialDeadlineNanos;
+    private final MessageReceiver callback;
+    private final Executor executor;
+    private final int parallelism;
+    private final BatchWrite output;
+    private boolean running;
+    private final long maxOutstandingElementCount;
+    private final long maxOutstandingRequestBytes;
+    private final AtomicLong outstandingElementCount = new AtomicLong(0);
+    private final AtomicLong outstandingRequestBytes = new AtomicLong(0);
 
     /** Constructor. */
-    public <T> Read(String subscriptionName, Function<PubsubMessage, CompletableFuture<T>> output,
+    public <T> Pull(SubscriberStub client, String subscription,
+        Function<PubsubMessage, CompletableFuture<T>> output,
+        Function<PubsubMessage, PubsubMessage> decompress, Executor executor, int parallelism,
+        long maxOutstandingElementCount, long maxOutstandingRequestBytes,
+        LeaseManager leaseManager) {
+      this.client = client;
+      this.subscription = subscription;
+      Duration initialDeadline = Duration.ofSeconds(client.getSubscriptionCallable()
+          .call(GetSubscriptionRequest.newBuilder().setSubscription(subscription).build())
+          .getAckDeadlineSeconds());
+      initialRenewDelay = initialDeadline.dividedBy(2);
+      initialDeadlineNanos = initialDeadline.toNanos();
+      callback = getReceiver(LOG, decompress, output);
+      this.executor = executor;
+      this.parallelism = parallelism;
+      this.leaseManager = leaseManager;
+      this.maxOutstandingElementCount = maxOutstandingElementCount;
+      this.maxOutstandingRequestBytes = maxOutstandingRequestBytes;
+      if (output instanceof BatchWrite) {
+        this.output = (BatchWrite) output;
+      } else {
+        this.output = null;
+      }
+    }
+
+    private static final Random rand = new Random();
+    private final Set<TimedFuture> backoffTimers = new HashSet<>();
+
+    /** Stop pulling new messages, and immediately complete any backoffTimers. */
+    public void stop() {
+      // stop any running subscribers
+      running = false;
+      final List<TimedFuture> earlyBackoffTimers;
+      synchronized (this.backoffTimers) {
+        earlyBackoffTimers = new ArrayList<>(this.backoffTimers);
+      }
+      earlyBackoffTimers.forEach(t -> t.complete(null));
+    }
+
+    private void backoff() {
+      CompletableFuture<Void> future;
+      synchronized (backoffTimers) {
+        if (running) {
+          // wait for 5-15 seconds
+          final TimedFuture backoffTimer = new TimedFuture(
+              Duration.ofSeconds(5 + rand.nextInt(10)));
+          backoffTimers.add(backoffTimer);
+          future = backoffTimer.thenAccept(v -> {
+            synchronized (backoffTimers) {
+              backoffTimers.remove(backoffTimer);
+            }
+          });
+        } else {
+          future = CompletableFuture.completedFuture(null);
+        }
+      }
+      future.join();
+    }
+
+    private List<ReceivedMessage> pull() {
+      try {
+        return client
+            .pullCallable().call(PullRequest.newBuilder().setMaxMessages(10_000)
+                .setReturnImmediately(true).setSubscription(subscription).build())
+            .getReceivedMessagesList();
+      } catch (DeadlineExceededException ignore) {
+        return null;
+      }
+    }
+
+    private void allocateSubscriberCapacity(long byteSize) {
+      outstandingElementCount.incrementAndGet();
+      outstandingRequestBytes.addAndGet(byteSize);
+    }
+
+    private void freeSubscriberCapacity(long byteSize) {
+      outstandingElementCount.decrementAndGet();
+      outstandingRequestBytes.addAndGet(-byteSize);
+    }
+
+    private class LeaseWithSubscriberCapacity implements AckReplyConsumer {
+
+      final long byteSize;
+      final AckReplyConsumer lease;
+
+      private LeaseWithSubscriberCapacity(long byteSize, AckReplyConsumer lease) {
+        allocateSubscriberCapacity(byteSize);
+        this.byteSize = byteSize;
+        this.lease = lease;
+      }
+
+      @Override
+      public void ack() {
+        freeSubscriberCapacity(byteSize);
+        lease.ack();
+      }
+
+      @Override
+      public void nack() {
+        freeSubscriberCapacity(byteSize);
+        lease.nack();
+      }
+    }
+
+    private void subscriber() {
+      try {
+        while (running) {
+          if (outstandingElementCount.get() >= maxOutstandingElementCount
+              || outstandingRequestBytes.get() >= maxOutstandingRequestBytes) {
+            // prevent reading more messages without blocking already pulled messages
+            backoff();
+          } else {
+            TimedFuture renewTimer = new TimedFuture(initialRenewDelay);
+            long expiration = System.nanoTime() + initialDeadlineNanos;
+            List<ReceivedMessage> response = pull();
+            if (response != null && response.size() > 0) {
+              // add response to leaseManager and allocate subscriber capacity before executing
+              // callback, so that lease renew is not blocked by synchronous parts of callback
+              List<AckReplyConsumer> leases = response.stream()
+                  .map(r -> new LeaseWithSubscriberCapacity(r.getMessage().getSerializedSize(),
+                      leaseManager.lease(r.getAckId(), expiration, renewTimer)))
+                  .collect(Collectors.toList());
+              for (int i = 0; i < response.size(); i++) {
+                callback.receiveMessage(response.get(i).getMessage(), leases.get(i));
+              }
+            } else {
+              backoff();
+            }
+          }
+        }
+      } finally {
+        stop();
+      }
+    }
+
+    /** Run the subscriber until terminated. */
+    public void run() {
+      running = true;
+      List<CompletableFuture<Void>> subscribers = Stream
+          .generate(() -> CompletableFuture.runAsync(this::subscriber, executor)).limit(parallelism)
+          .collect(Collectors.toList());
+      try {
+        CompletableFutures.joinAllThenThrow(subscribers);
+      } finally {
+        // flush outputs then flush lease manager
+        if (output != null) {
+          output.flush();
+        }
+        leaseManager.flush();
+      }
+    }
+  }
+
+  public static class StreamingPull implements Input {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamingPull.class);
+
+    private Subscriber subscriber;
+
+    /** Constructor. */
+    public <T> StreamingPull(String subscriptionName,
+        Function<PubsubMessage, CompletableFuture<T>> output,
         Function<Subscriber.Builder, Subscriber.Builder> config,
         Function<PubsubMessage, PubsubMessage> decompress) {
       ProjectSubscriptionName subscription = ProjectSubscriptionName.parse(subscriptionName);
-      subscriber = config.apply(Subscriber.newBuilder(subscription,
-          // Synchronous CompletableFuture methods are executed by the thread that completes the
-          // future, or the current thread if the future is already complete. Use that here to
-          // minimize memory usage by doing as much work as immediately possible.
-          (message, consumer) -> CompletableFuture.completedFuture(message).thenApply(decompress)
-              .thenCompose(output).whenComplete((result, exception) -> {
-                if (exception == null) {
-                  consumer.ack();
-                } else {
-                  // exception is always a CompletionException caused by the real exception
-                  LOG.warn("Exception while attempting to deliver message", exception.getCause());
-                  consumer.nack();
-                }
-              })))
-          .build();
+      subscriber = config
+          .apply(Subscriber.newBuilder(subscription, getReceiver(LOG, decompress, output))).build();
+    }
+
+    public void stop() {
+      subscriber.stopAsync();
     }
 
     /** Run the subscriber until terminated. */

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/CompletableFutures.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/CompletableFutures.java
@@ -1,0 +1,34 @@
+package com.mozilla.telemetry.ingestion.sink.util;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+
+public class CompletableFutures {
+
+  public static <T> CompletableFuture<Void> allOf(List<CompletableFuture<T>> futures) {
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[] {}));
+  }
+
+  public static <T> CompletableFuture<T> orNull(CompletableFuture<T> future) {
+    return future.exceptionally(t -> null);
+  }
+
+  public static <T> CompletableFuture<Void> allExceptions(List<CompletableFuture<T>> futures) {
+    return allOf(futures.stream().map(CompletableFutures::orNull).collect(Collectors.toList()));
+  }
+
+  /** Join futures and throw the first exception after all futures are complete. */
+  public static <T> void joinAllThenThrow(List<CompletableFuture<T>> futures) {
+    try {
+      // wait for the first exception
+      allOf(futures).join();
+    } catch (CompletionException e) {
+      // wait for all exceptions
+      allExceptions(futures);
+      // throw first exception
+      throw (RuntimeException) e.getCause();
+    }
+  }
+}

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/LeaseManager.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/LeaseManager.java
@@ -1,0 +1,283 @@
+package com.mozilla.telemetry.ingestion.sink.util;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ModifyAckDeadlineRequest;
+import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.Measure.MeasureLong;
+import io.opencensus.stats.Stats;
+import io.opencensus.stats.StatsRecorder;
+import io.opencensus.stats.View;
+import io.opencensus.stats.ViewManager;
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LeaseManager
+    extends BatchWrite<LeaseManager.Lease, LeaseManager.Lease, LeaseManager.Action, Void> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LeaseManager.class);
+
+  private static final int MAX_ACK_IDS_PER_REQUEST = 1000;
+  private static final int MAX_ACK_DEADLINE_SECONDS = 600;
+
+  private final SubscriberStub client;
+  private final String subscription;
+  private final Duration renewFrequency;
+  private final int ackDeadlineSeconds;
+  private final long ackDeadlineNanos;
+  private final long maxApiDurationNanos;
+
+  /** Constructor. */
+  public LeaseManager(SubscriberStub client, String subscription, Duration ackDeadline,
+      Duration maxDelay, Duration maxApiDuration, Executor executor) {
+    super(0, MAX_ACK_IDS_PER_REQUEST, maxDelay, null, executor);
+    this.client = client;
+    this.subscription = subscription;
+    ackDeadlineSeconds = (int) ackDeadline.getSeconds();
+    Preconditions.checkArgument(ackDeadlineSeconds <= MAX_ACK_DEADLINE_SECONDS,
+        String.format("ack deadline must be less than %d seconds", MAX_ACK_DEADLINE_SECONDS));
+    ackDeadlineNanos = ackDeadline.toNanos();
+    // renew when the batch maxDelay will end no later than halfway through ackDeadline
+    renewFrequency = ackDeadline.dividedBy(2).minus(maxDelay);
+    // leases with less than this much time left before expiration when a batch close starts are
+    // dropped from the batch
+    maxApiDurationNanos = maxApiDuration.toNanos();
+  }
+
+  private static final StatsRecorder STATS_RECORDER = Stats.getStatsRecorder();
+  private static final Aggregation.Sum SUM_AGG = Aggregation.Sum.create();
+  private static final MeasureLong measureAckCount = MeasureLong.create("lease_manager_ack_count",
+      "The number of bytes received in ", "1");
+  private static final MeasureLong measureDropped = MeasureLong.create("lease_manager_dropped",
+      "The number of bytes received in ", "1");
+  private static final MeasureLong measureNackCount = MeasureLong.create("lease_manager_nack_count",
+      "The number of bytes received in ", "1");
+  private static final MeasureLong measureRenewCount = MeasureLong
+      .create("lease_manager_renew_count", "The number of bytes received in ", "1");
+
+  /**
+   * Register a view for every measure.
+   *
+   * <p>If this is not called, e.g. during unit tests, recorded values will not be exported.
+   */
+  public LeaseManager withOpenCensusMetrics() {
+    final ViewManager viewManager = Stats.getViewManager();
+    ImmutableMap.<MeasureLong, Aggregation>builder().put(measureAckCount, SUM_AGG)
+        .put(measureDropped, SUM_AGG).put(measureNackCount, SUM_AGG).put(measureRenewCount, SUM_AGG)
+        .build()
+        .forEach((measure, aggregation) -> viewManager
+            .registerView(View.create(View.Name.create(measure.getName()), measure.getDescription(),
+                measure, aggregation, ImmutableList.of())));
+    return this;
+  }
+
+  /** Create a managed lease. */
+  public AckReplyConsumer lease(String ackId, long expiration, CompletableFuture<Void> renewTimer) {
+    return new Lease(ackId, expiration).hold(renewTimer);
+  }
+
+  @Override
+  public void flush() {
+    batches.keySet().stream().sorted().map(batches::get).map(BatchWrite.Batch::flush)
+        .forEach(CompletableFuture::join);
+  }
+
+  @Override
+  protected Action getBatchKey(Lease lease) {
+    return lease.action;
+  }
+
+  @Override
+  protected Lease encodeInput(Lease input) {
+    return input;
+  }
+
+  @Override
+  protected Batch getBatch(Action action) {
+    return new Batch(this, action);
+  }
+
+  private class Batch extends BatchWrite<Lease, Lease, Action, Void>.Batch {
+
+    private final LeaseManager manager;
+    private final Action action;
+    private final List<Lease> leases = new LinkedList<>();
+
+    private Batch(LeaseManager manager, Action action) {
+      this.manager = manager;
+      this.action = action;
+    }
+
+    @Override
+    protected CompletableFuture<Void> close() {
+      // renewFrequency+maxDelay is half of the ack deadline for a message, but under heavy load
+      // this method may not be executed immediately. Prevent acting on expired leases by filtering
+      // out those that expire before another maxApiDurationNanos have passed.
+      final long minTimeout = System.nanoTime() + maxApiDurationNanos;
+      final List<Lease> openLeases = leases.stream().filter(l -> l.expiration >= minTimeout)
+          .collect(Collectors.toList());
+      final int dropped = leases.size() - openLeases.size();
+      STATS_RECORDER.newMeasureMap().put(action.getMeasure(), openLeases.size())
+          .put(measureDropped, dropped).record();
+      if (dropped > 0 && action != Action.nack) {
+        String timeoutSeconds = leases.stream().filter(l -> l.expiration < minTimeout)
+            .map(l -> Long.toString(Duration.ofNanos(minTimeout - l.expiration).getSeconds()))
+            .collect(Collectors.joining(", "));
+        LOG.warn(String.format("could not %s %d leases due to timeout; seconds since expired: %s",
+            action, dropped, timeoutSeconds));
+      }
+      if (openLeases.size() > 0) {
+        final List<String> ackIds = openLeases.stream().map(l -> l.ackId)
+            .collect(Collectors.toList());
+        final TimedFuture renewTimer = new TimedFuture(renewFrequency);
+        // calculate expiration as late as possible
+        final long expiration = System.nanoTime() + ackDeadlineNanos;
+        // try {
+        action.apply(manager, ackIds);
+        // } catch (RuntimeException e) {
+        // // TODO be more specific about the kinds of errors this retries
+        // // retry immediately
+        // final CompletableFuture<Void> completed = CompletableFuture.completedFuture(null);
+        // openLeases.forEach(l -> l.hold(completed));
+        // throw e;
+        // }
+        if (action == Action.renew) {
+          // TODO limit the amount of time a lease may be held
+          // schedule next renew
+          openLeases.forEach(l -> {
+            l.expiration = expiration;
+            l.hold(renewTimer);
+          });
+        }
+      }
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    protected void write(Lease lease) {
+      leases.add(lease);
+    }
+
+    @Override
+    protected long getByteSize(Lease lease) {
+      return 0; // TODO limit batch size based on lease.ackId.length()
+    }
+  }
+
+  public class Lease implements AckReplyConsumer {
+
+    private final String ackId;
+    private long expiration;
+    // new leases act the same as currently renewing leases
+    private Action action = Action.renew;
+
+    private Lease(String ackId, long expiration) {
+      this.ackId = ackId;
+      this.expiration = expiration;
+    }
+
+    @Override
+    public synchronized void ack() {
+      if (action == Action.renew) {
+        // wait for renew batch to complete, then have this::hold add it to the next ack batch
+        action = Action.ack;
+      } else if (action == null) {
+        // add to next ack batch
+        action = Action.ack;
+        apply(this);
+      }
+    }
+
+    @Override
+    public synchronized void nack() {
+      if (action == Action.renew) {
+        // wait for renew batch to complete, then have this::hold add it to the next nack batch
+        action = Action.nack;
+      } else if (action == null) {
+        // lease is not part of any batch, add to next nack batch
+        action = Action.nack;
+        apply(this);
+      }
+    }
+
+    private synchronized Lease hold(CompletableFuture<Void> renewTimer) {
+      if (action == Action.renew) {
+        // add to next renew batch after renewTimer completes
+        action = null;
+        renewTimer.thenAccept(v -> this.renew());
+      } else {
+        // add to next ack or nack batch now that renew is complete
+        apply(this);
+      }
+      return this;
+    }
+
+    private synchronized void renew() {
+      if (action == null) {
+        // add to next renew batch because ack or nack has not yet occurred
+        action = Action.renew;
+        apply(this);
+      }
+    }
+  }
+
+  enum Action {
+    renew {
+
+      @Override
+      public void apply(LeaseManager manager, List<String> ackIds) {
+        manager.client.modifyAckDeadlineCallable()
+            .call(ModifyAckDeadlineRequest.newBuilder().setSubscription(manager.subscription)
+                .addAllAckIds(ackIds).setAckDeadlineSeconds(manager.ackDeadlineSeconds).build());
+      }
+
+      @Override
+      public MeasureLong getMeasure() {
+        return measureRenewCount;
+      }
+    },
+    ack {
+
+      @Override
+      public void apply(LeaseManager manager, List<String> ackIds) {
+        manager.client.acknowledgeCallable().call(AcknowledgeRequest.newBuilder()
+            .setSubscription(manager.subscription).addAllAckIds(ackIds).build());
+      }
+
+      @Override
+      public MeasureLong getMeasure() {
+        return measureAckCount;
+      }
+    },
+    nack {
+
+      private static final int NACK_DEADLINE_SECONDS = 0;
+
+      @Override
+      public void apply(LeaseManager manager, List<String> ackIds) {
+        manager.client.modifyAckDeadlineCallable()
+            .call(ModifyAckDeadlineRequest.newBuilder().setSubscription(manager.subscription)
+                .addAllAckIds(ackIds).setAckDeadlineSeconds(NACK_DEADLINE_SECONDS).build());
+      }
+
+      @Override
+      public MeasureLong getMeasure() {
+        return measureNackCount;
+      }
+    };
+
+    public abstract void apply(LeaseManager manager, List<String> ackIds);
+
+    public abstract MeasureLong getMeasure();
+  }
+}

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/PubsubPullTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/PubsubPullTest.java
@@ -1,0 +1,111 @@
+package com.mozilla.telemetry.ingestion.sink.io;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ModifyAckDeadlineRequest;
+import com.google.pubsub.v1.PubsubMessage;
+import com.mozilla.telemetry.ingestion.sink.util.LeaseManager;
+import com.mozilla.telemetry.ingestion.sink.util.MockPubsub;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class PubsubPullTest {
+
+  private static final PubsubMessage TEST_MESSAGE = PubsubMessage.newBuilder()
+      .setData(ByteString.copyFrom("test".getBytes(StandardCharsets.UTF_8))).build();
+
+  @Rule
+  public final LoggerContextRule logs = new LoggerContextRule("log4j2-test.yaml");
+
+  private MockPubsub pubsub;
+
+  /** Prepare a mock BQ response. */
+  @Before
+  public void mockPubsubClient() {
+    pubsub = new MockPubsub().withSubscription("subscription", 600);
+    pubsub.withAcknowledge().withPullResponse(TEST_MESSAGE, "1");
+  }
+
+  private <T> Pubsub.Pull getInput(Function<PubsubMessage, CompletableFuture<T>> output) {
+    return new Pubsub.Pull(pubsub.client, "subscription", output, m -> m, ForkJoinPool.commonPool(),
+        1, 3, TEST_MESSAGE.getSerializedSize() * 3,
+        new LeaseManager(pubsub.client, "subscription", Duration.ofSeconds(600),
+            Duration.ofSeconds(1), Duration.ofSeconds(1), ForkJoinPool.commonPool()));
+  }
+
+  @Test
+  public void canReadOneMessage() {
+    AtomicReference<PubsubMessage> received = new AtomicReference<>();
+    AtomicReference<Input> input = new AtomicReference<>();
+
+    input.set(getInput(
+        // create a future with message
+        message -> CompletableFuture.completedFuture(message)
+            // add message to received
+            .thenAccept(received::set)
+            // stop the subscriber
+            .thenRun(() -> input.get().stop())));
+
+    input.get().run();
+    assertEquals(TEST_MESSAGE, received.get());
+  }
+
+  @Test
+  public void canHandleException() {
+    pubsub.withModifyAckDeadline() //
+        .withModifyAckDeadline() //
+        .withPullResponse(TEST_MESSAGE, "2") //
+        .withPullResponse(TEST_MESSAGE, "3");
+    List<PubsubMessage> received = new LinkedList<>();
+    AtomicReference<Pubsub.Pull> input = new AtomicReference<>();
+
+    input.set(getInput(message -> {
+      received.add(message);
+      switch (received.size()) {
+        // throw an immediate error to nack the first message
+        case 1:
+          throw new RuntimeException("first");
+          // throw a future error to nack the second message
+        case 2:
+          return CompletableFuture.completedFuture(null).thenRun(() -> {
+            throw new RuntimeException("second");
+          });
+        // succeed and stop on the third message
+        default:
+          input.get().stop();
+          return CompletableFuture.completedFuture(null);
+      }
+    }));
+
+    input.get().run();
+    assertEquals(Collections.nCopies(3, TEST_MESSAGE), received);
+    assertThat(logs.getListAppender("STDOUT").getMessages(),
+        contains(containsString("java.lang.RuntimeException: first"),
+            containsString("java.lang.RuntimeException: second")));
+    assertEquals(ImmutableList.of(0), pubsub.modifyAckDeadlineCallable.requests.stream()
+        .map(ModifyAckDeadlineRequest::getAckDeadlineSeconds).collect(Collectors.toList()));
+    assertEquals(ImmutableList.of(ImmutableList.of("1", "2")),
+        pubsub.modifyAckDeadlineCallable.requests.stream()
+            .map(ModifyAckDeadlineRequest::getAckIdsList).collect(Collectors.toList()));
+    assertEquals(ImmutableList.of(ImmutableList.of("3")), pubsub.acknowledgeCallable.requests
+        .stream().map(AcknowledgeRequest::getAckIdsList).collect(Collectors.toList()));
+  }
+}

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/LeaseManagerTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/LeaseManagerTest.java
@@ -1,0 +1,99 @@
+package com.mozilla.telemetry.ingestion.sink.util;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ModifyAckDeadlineRequest;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LeaseManagerTest {
+
+  private MockPubsub pubsub;
+  private LeaseManager leaseManager;
+  private Duration ackDeadline = Duration.ofSeconds(600);
+
+  /** Prepare a mock BQ response. */
+  @Before
+  public void mockPubsubClient() {
+    pubsub = new MockPubsub();
+    leaseManager = new LeaseManager(pubsub.client, "subscription", ackDeadline, Duration.ZERO,
+        Duration.ZERO, ForkJoinPool.commonPool());
+  }
+
+  @Test
+  public void canAckFirst() {
+    String ackId = UUID.randomUUID().toString();
+    pubsub.withAcknowledge();
+    CompletableFuture<Void> renewTimer = new CompletableFuture<>();
+    long expiration = System.nanoTime() + ackDeadline.toNanos();
+    leaseManager.lease(ackId, expiration, renewTimer).ack(); // immediately ack
+    leaseManager.flush(); // wait for batch to complete
+    renewTimer.complete(null);
+    assertEquals(ImmutableList.of(ImmutableList.of(ackId)), pubsub.acknowledgeCallable.requests
+        .stream().map(AcknowledgeRequest::getAckIdsList).collect(Collectors.toList()));
+    assertEquals(ImmutableList.of(), leaseManager.batches.entrySet().stream()
+        .filter(e -> !e.getValue().result.isDone()).collect(Collectors.toList()));
+  }
+
+  @Test
+  public void canNackFirst() {
+    String ackId = UUID.randomUUID().toString();
+    pubsub.withModifyAckDeadline();
+    CompletableFuture<Void> renewTimer = new CompletableFuture<>();
+    long expiration = System.nanoTime() + ackDeadline.toNanos();
+    leaseManager.lease(ackId, expiration, renewTimer).nack(); // immediately nack
+    leaseManager.flush(); // wait for batch to complete
+    renewTimer.complete(null);
+    assertEquals(ImmutableList.of(ImmutableList.of(ackId)),
+        pubsub.modifyAckDeadlineCallable.requests.stream()
+            .map(ModifyAckDeadlineRequest::getAckIdsList).collect(Collectors.toList()));
+    assertEquals(ImmutableList.of(0), pubsub.modifyAckDeadlineCallable.requests.stream()
+        .map(ModifyAckDeadlineRequest::getAckDeadlineSeconds).collect(Collectors.toList()));
+    assertEquals(ImmutableList.of(), leaseManager.batches.entrySet().stream()
+        .filter(e -> !e.getValue().result.isDone()).collect(Collectors.toList()));
+  }
+
+  @Test
+  public void canRenewTwice() {
+    int ackDeadlineSeconds = 10;
+    Duration ackDeadline = Duration.ofSeconds(ackDeadlineSeconds);
+    leaseManager = new LeaseManager(pubsub.client, "subscription", ackDeadline, Duration.ZERO,
+        Duration.ZERO, ForkJoinPool.commonPool());
+    String ackId = UUID.randomUUID().toString();
+    pubsub.withModifyAckDeadline();
+    // use completed future to ensure first renew is immediately queued
+    CompletableFuture<Void> renewTimer = CompletableFuture.completedFuture(null);
+    long expiration = System.nanoTime() + ackDeadline.toNanos();
+    leaseManager.lease(ackId, expiration, renewTimer);
+    leaseManager.flush(); // wait for batch to complete
+    // check that first renew has occurred
+    assertEquals(Collections.nCopies(1, ImmutableList.of(ackId)),
+        pubsub.modifyAckDeadlineCallable.requests.stream()
+            .map(ModifyAckDeadlineRequest::getAckIdsList).collect(Collectors.toList()));
+    assertEquals(Collections.nCopies(1, ackDeadlineSeconds),
+        pubsub.modifyAckDeadlineCallable.requests.stream()
+            .map(ModifyAckDeadlineRequest::getAckDeadlineSeconds).collect(Collectors.toList()));
+    // prepare to renew again
+    pubsub.withModifyAckDeadline();
+    // wait 1.5 renew cycles, and ensure we've renewed once.
+    Duration renewFrequency = Duration.ofSeconds(ackDeadlineSeconds).dividedBy(2);
+    new TimedFuture(renewFrequency.dividedBy(2).multipliedBy(3)).join();
+    assertEquals(Collections.nCopies(2, ImmutableList.of(ackId)),
+        pubsub.modifyAckDeadlineCallable.requests.stream()
+            .map(ModifyAckDeadlineRequest::getAckIdsList).collect(Collectors.toList()));
+    assertEquals(Collections.nCopies(2, ackDeadlineSeconds),
+        pubsub.modifyAckDeadlineCallable.requests.stream()
+            .map(ModifyAckDeadlineRequest::getAckDeadlineSeconds).collect(Collectors.toList()));
+    // no pending batches means all leases are on hold
+    assertEquals(ImmutableList.of(), leaseManager.batches.entrySet().stream()
+        .filter(e -> !e.getValue().result.isDone()).collect(Collectors.toList()));
+  }
+}

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/MockPubsub.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/MockPubsub.java
@@ -1,0 +1,94 @@
+package com.mozilla.telemetry.ingestion.sink.util;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.protobuf.Empty;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.GetSubscriptionRequest;
+import com.google.pubsub.v1.ModifyAckDeadlineRequest;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
+import com.google.pubsub.v1.Subscription;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+
+public class MockPubsub {
+
+  public SubscriberStub client = mock(SubscriberStub.class);
+  public MockCallable<ModifyAckDeadlineRequest, Empty> modifyAckDeadlineCallable = //
+      new MockCallable<>();
+  public MockCallable<AcknowledgeRequest, Empty> acknowledgeCallable = new MockCallable<>();
+  public MockCallable<GetSubscriptionRequest, Subscription> getSubscriptionCallable = //
+      new MockCallable<>();
+  public MockCallable<PullRequest, PullResponse> pullCallable = new MockCallable<>();
+
+  /** Constructor. */
+  public MockPubsub() {
+    when(client.modifyAckDeadlineCallable()).thenReturn(modifyAckDeadlineCallable);
+    when(client.acknowledgeCallable()).thenReturn(acknowledgeCallable);
+    when(client.getSubscriptionCallable()).thenReturn(getSubscriptionCallable);
+    when(client.pullCallable()).thenReturn(pullCallable);
+  }
+
+  public MockPubsub withAcknowledge() {
+    acknowledgeCallable.responses.add(Empty.getDefaultInstance());
+    return this;
+  }
+
+  public MockPubsub withModifyAckDeadline() {
+    modifyAckDeadlineCallable.responses.add(Empty.getDefaultInstance());
+    return this;
+  }
+
+  public MockPubsub withSubscription(Subscription response) {
+    getSubscriptionCallable.responses.add(response);
+    return this;
+  }
+
+  public MockPubsub withSubscription(String subscription, int ackDeadlineSeconds) {
+    return withSubscription(Subscription.newBuilder().setName(subscription)
+        .setAckDeadlineSeconds(ackDeadlineSeconds).build());
+  }
+
+  public MockPubsub withPullResponse(PullResponse response) {
+    pullCallable.responses.add(response);
+    return this;
+  }
+
+  public MockPubsub withPullResponse(PubsubMessage message, String ackId) {
+    return withPullResponse(PullResponse.newBuilder().addReceivedMessages(
+        ReceivedMessage.newBuilder().setAckId(ackId).setMessage(message).build()).build());
+  }
+
+  public static class MockCallable<RequestT, ResponseT> extends UnaryCallable<RequestT, ResponseT> {
+
+    public List<ApiCallContext> contexts = new LinkedList<>();
+    public List<RequestT> requests = new LinkedList<>();
+    public Queue<ResponseT> responses = new LinkedList<>();
+
+    private MockCallable() {
+    }
+
+    @Override
+    public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
+      this.requests.add(request);
+      this.contexts.add(context);
+      try {
+        return ApiFutures.immediateFuture(responses.remove());
+      } catch (NoSuchElementException e) {
+        throw new NoSuchElementException(String.format("not enough responses for %s #%d",
+            request.getClass().getSimpleName(), requests.size()));
+      }
+    }
+  }
+}


### PR DESCRIPTION
which will replace `com.google.cloud.pubsub.v1.Subscriber` which uses the StreamingPull API. `Subscriber` isn't able to handle 2 million messages, each in flight for upwards of 10 minutes, because it eats unnecessary amounts of ram and eventually stalls. Somewhere around 200K messages was the upper limit in python, which closely follows the java implementation.