### PR TITLE
Allow user-provided durations to be zero in ingestion-sink

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/Time.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/Time.java
@@ -1,6 +1,6 @@
 package com.mozilla.telemetry.util;
 
-import static com.mozilla.telemetry.ingestion.core.util.Time.parseJavaDuration;
+import static com.mozilla.telemetry.ingestion.core.util.Time.parsePositiveJavaDuration;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
@@ -52,7 +52,7 @@ public class Time {
    * Like {@link #parseDuration(String)}, but returns the number of seconds in the parsed duration.
    */
   public static long parseSeconds(String value) {
-    return parseJavaDuration(value).getSeconds();
+    return parsePositiveJavaDuration(value).getSeconds();
   }
 
   /**
@@ -110,7 +110,7 @@ public class Time {
   }
 
   private static org.joda.time.Duration parseJodaDuration(String value) {
-    return toJoda(parseJavaDuration(value));
+    return toJoda(parsePositiveJavaDuration(value));
   }
 
 }

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/util/Time.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/util/Time.java
@@ -3,20 +3,23 @@ package com.mozilla.telemetry.ingestion.core.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+
 public class Time {
 
   /**
    * Return a {@code java.time.Duration} from an ISO-8601 duration or from simple formats
    * such as "5 seconds", "5sec", or "5s".
    */
-  public static java.time.Duration parseJavaDuration(String value) {
+  public static Duration parseJavaDuration(String value) {
     checkNotNull(value, "The specified duration must be a non-null value!");
-    java.time.Duration duration;
+    Duration duration;
 
     try {
       // This is already an ISO-8601 duration.
-      duration = java.time.Duration.parse(value);
-    } catch (java.time.format.DateTimeParseException outer) {
+      duration = Duration.parse(value);
+    } catch (DateTimeParseException outer) {
       String modifiedValue = value.toLowerCase().replaceAll("seconds", "s")
           .replaceAll("second", "s").replaceAll("sec", "s").replaceAll("minutes", "m")
           .replaceAll("minute", "m").replaceAll("mins", "m").replaceAll("min", "m")
@@ -32,7 +35,7 @@ public class Time {
         modifiedValue += "0s";
       }
       try {
-        duration = java.time.Duration.parse(modifiedValue);
+        duration = Duration.parse(modifiedValue);
       } catch (java.time.format.DateTimeParseException e) {
         throw new IllegalArgumentException(
             "User-provided duration '" + value + "' was transformed to '" + modifiedValue
@@ -41,8 +44,15 @@ public class Time {
       }
     }
 
-    checkArgument(duration.toMillis() > 0, "The window duration must be greater than 0!");
+    return duration;
+  }
 
+  /**
+   * Perform {@code Time::parseJavaDuration} and require the result to be greater than 0.
+   */
+  public static Duration parsePositiveJavaDuration(String value) {
+    Duration duration = parseJavaDuration(value);
+    checkArgument(duration.toMillis() > 0, "The window duration must be greater than 0!");
     return duration;
   }
 }

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/SinkBigQueryIntegrationTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/SinkBigQueryIntegrationTest.java
@@ -124,7 +124,7 @@ public class SinkBigQueryIntegrationTest {
   public void canStream() throws Exception {
     createTablesAndPublishInputs(ImmutableList.of(SIMPLE_MESSAGE));
 
-    environmentVariables.set("BATCH_MAX_DELAY", "0.001s");
+    environmentVariables.set("BATCH_MAX_DELAY", "0s");
     environmentVariables.set("INPUT_SUBSCRIPTION", pubsub.getSubscription(0));
     environmentVariables.set("OUTPUT_TABLE",
         bq.project + "." + bq.dataset + ".${document_type}_v${document_version}");
@@ -137,7 +137,7 @@ public class SinkBigQueryIntegrationTest {
     createTablesAndPublishInputs(ImmutableList.of(SIMPLE_MESSAGE));
 
     Map<String, String> sinkEnv = ImmutableMap.<String, String>builder()
-        .put("BATCH_MAX_DELAY", "0.001s") //
+        .put("BATCH_MAX_DELAY", "0s") //
         .put("BIG_QUERY_OUTPUT_MODE", "file_loads") //
         .put("INPUT_SUBSCRIPTION", pubsub.getSubscription(0)) //
         .put("OUTPUT_BUCKET", gcs.bucket) //
@@ -151,7 +151,7 @@ public class SinkBigQueryIntegrationTest {
 
     sinkEnv.keySet().forEach(environmentVariables::clear);
     environmentVariables.set("INPUT_SUBSCRIPTION", pubsub.getSubscription(1));
-    environmentVariables.set("LOAD_MAX_DELAY", "0.001s");
+    environmentVariables.set("LOAD_MAX_DELAY", "0s");
     // unregister stackdriver stats exporter so BoundedSink can register another one
     StackdriverStatsExporter.unregister();
     BoundedSink.run(1, 30);
@@ -169,14 +169,14 @@ public class SinkBigQueryIntegrationTest {
         SIMPLE_MESSAGE.toBuilder().setData(ByteString.copyFromUtf8(OVERSIZE_REQUEST_DATA)).build());
     createTablesAndPublishInputs(input);
 
-    environmentVariables.set("BATCH_MAX_DELAY", "0.001s");
+    environmentVariables.set("BATCH_MAX_DELAY", "0s");
     environmentVariables.set("BIG_QUERY_OUTPUT_MODE", "mixed");
     environmentVariables.set("INPUT_SUBSCRIPTION", pubsub.getSubscription(0));
-    environmentVariables.set("LOAD_MAX_DELAY", "0.001s");
+    environmentVariables.set("LOAD_MAX_DELAY", "0s");
     environmentVariables.set("OUTPUT_BUCKET", gcs.bucket);
     environmentVariables.set("OUTPUT_TABLE",
         bq.project + "." + bq.dataset + ".${document_type}_v${document_version}");
-    environmentVariables.set("STREAMING_BATCH_MAX_DELAY", "0.001s");
+    environmentVariables.set("STREAMING_BATCH_MAX_DELAY", "0s");
     BoundedSink.run(input.size(), 30);
     checkResult(ImmutableList.of(
         ImmutableList.of("bar", "1", SUBMISSION_TIMESTAMP, OVERSIZE_ROW_DATA, "bar_v1"),
@@ -211,14 +211,14 @@ public class SinkBigQueryIntegrationTest {
     createTablesAndPublishInputs(nonStreamingInput);
 
     Map<String, String> sinkEnv = ImmutableMap.<String, String>builder()
-        .put("BATCH_MAX_DELAY", "0.001s") //
+        .put("BATCH_MAX_DELAY", "0s") //
         .put("BIG_QUERY_OUTPUT_MODE", "mixed") //
         .put("INPUT_SUBSCRIPTION", pubsub.getSubscription(0)) //
         .put("OUTPUT_BUCKET", gcs.bucket) //
         .put("OUTPUT_TABLE",
             bq.project + "." + bq.dataset + ".${document_type}_v${document_version}") //
         .put("OUTPUT_TOPIC", pubsub.getTopic(1)) //
-        .put("STREAMING_BATCH_MAX_DELAY", "0.001s") //
+        .put("STREAMING_BATCH_MAX_DELAY", "0s") //
         .put("STREAMING_DOCTYPES", "namespace-0/.*|namespace-1/foo") //
         .build();
     sinkEnv.forEach(environmentVariables::set);
@@ -227,7 +227,7 @@ public class SinkBigQueryIntegrationTest {
 
     sinkEnv.keySet().forEach(environmentVariables::clear);
     environmentVariables.set("INPUT_SUBSCRIPTION", pubsub.getSubscription(1));
-    environmentVariables.set("LOAD_MAX_DELAY", "0.001s");
+    environmentVariables.set("LOAD_MAX_DELAY", "0s");
     // unregister stackdriver stats exporter so BoundedSink can register another one
     StackdriverStatsExporter.unregister();
     BoundedSink.run(nonStreamingInput.size(), 30);

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/SinkGcsIntegrationTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/SinkGcsIntegrationTest.java
@@ -57,7 +57,7 @@ public class SinkGcsIntegrationTest {
         .putAttributes("submission_timestamp", submissionTimestamp).build()));
 
     environmentVariables.set("INPUT_SUBSCRIPTION", pubsub.getSubscription());
-    environmentVariables.set("BATCH_MAX_DELAY", "0.001s");
+    environmentVariables.set("BATCH_MAX_DELAY", "0s");
     environmentVariables.set("OUTPUT_BUCKET",
         gcs.bucket + "/${document_namespace}/${document_type}_"
             + "v${document_version}/${submission_date}/${submission_hour}/");


### PR DESCRIPTION
In ingestion-sink a delay of `0s` causes each message to be sent separately and immediately.