### PR TITLE
Fix #1280 -  Fail early on empty metadataLocation when Pioneer is enabled

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/DecoderOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/DecoderOptions.java
@@ -46,7 +46,7 @@ public interface DecoderOptions extends SinkOptions, PipelineOptions {
 
   @Description("Path (local or gs://) to JSON array of metadata entries enumerating encrypted"
       + " private keys, Cloud KMS resource ids for decrypting those keys, and their corresponding"
-      + " document namespaces; leave null to disable.")
+      + " document namespaces; this must be set if Pioneer is enabled.")
   ValueProvider<String> getPioneerMetadataLocation();
 
   void setPioneerMetadataLocation(ValueProvider<String> value);

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/KeyStore.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/KeyStore.java
@@ -49,6 +49,11 @@ public class KeyStore {
   private KeyStore(String metadataLocation, boolean kmsEnabled) {
     this.metadataLocation = metadataLocation;
     this.kmsEnabled = kmsEnabled;
+
+    // throw immediately if the keyStore is misconfigured
+    if (metadataLocation == null) {
+      throw new IllegalArgumentException("Metadata location is missing.");
+    }
   }
 
   @VisibleForTesting

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/KeyStore.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/KeyStore.java
@@ -47,13 +47,12 @@ public class KeyStore {
   }
 
   private KeyStore(String metadataLocation, boolean kmsEnabled) {
-    this.metadataLocation = metadataLocation;
-    this.kmsEnabled = kmsEnabled;
-
     // throw immediately if the keyStore is misconfigured
     if (metadataLocation == null) {
       throw new IllegalArgumentException("Metadata location is missing.");
     }
+    this.metadataLocation = metadataLocation;
+    this.kmsEnabled = kmsEnabled;
   }
 
   @VisibleForTesting

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/util/KeyStoreTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/util/KeyStoreTest.java
@@ -9,6 +9,11 @@ import org.junit.Test;
 
 public class KeyStoreTest {
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullMetadataLocation() {
+    KeyStore.of(null, false);
+  }
+
   @Test(expected = ValidationException.class)
   public void testMetadataInvalidFormat() {
     String metadataLocation = Resources.getResource("pioneer/metadata-invalid.json").getPath();


### PR DESCRIPTION
This fixes #1280 by throwing an `IllegalArgumentException` when the metadataLocation is not properly.