### PR TITLE
Bug 1614409 - Ignore fenix-debug namespace

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -29,6 +29,7 @@ public class MessageScrubber {
       .put("org-mozilla-vrbrowser-wavevr", "1614411") //
       .put("org-mozilla-fogotype", "1635592") //
       .put("com-pumabrowser-pumabrowser", "1637055") //
+      .put("org-mozilla-fenix-debug", "1614409") //
       .build();
 
   private static final ImmutableSet<String> FIREFOX_ONLY_DOCTYPES = ImmutableSet.of("event", "main",


### PR DESCRIPTION
I'm wondering if we can start not adding tests for all affected namespaces, considering the codepath is definitely "proven". Happy to add one if anyone objects.