### PR TITLE
Add dataflow template build script support for decoder options

### DIFF
--- a/ingestion-beam/bin/build-template
+++ b/ingestion-beam/bin/build-template
@@ -29,6 +29,8 @@ WORKER_OPTS="--numWorkers=1 \
 --maxNumWorkers=${MAX_NUM_WORKERS} \
 --autoscalingAlgorithm=THROUGHPUT_BASED"
 
+DECODER_OPTS="${DECODER_OPTS}"
+
 SINK_OPTS="--workerMachineType=${SINK_WORKER_MACHINE_TYPE} \
 --workerDiskType='compute.googleapis.com/projects//zones//diskTypes/pd-ssd' \
 --diskSizeGb=${SINK_DISK_SIZE} \
@@ -52,7 +54,8 @@ ${SINK_OPTS}"
 elif [[ $JOB_TYPE == "decoder" ]] ; then
   JOB_CLASS="com.mozilla.telemetry.Decoder"
   OUTPUT_OPTS="--outputType=pubsub \
---outputFileFormat=json"
+--outputFileFormat=json \
+${DECODER_OPTS}"
   ERROR_OUTPUT_OPTS="--errorOutputType=pubsub"
 elif [[ $JOB_TYPE =~ ^republisher_.*$ ]] ; then
   JOB_CLASS="com.mozilla.telemetry.Republisher"


### PR DESCRIPTION
This is for pioneer build automation to set `--pioneerEnabled=true` at template compile time. Previously we didn't have any compile-time decoder options.