### PR TITLE
Relax decoder job type match to accommodate pioneer

### DIFF
--- a/ingestion-beam/bin/build-template
+++ b/ingestion-beam/bin/build-template
@@ -51,7 +51,7 @@ elif [[ $JOB_TYPE == "gcssink" ]] ; then
 ${SINK_OPTS}"
   ERROR_OUTPUT_OPTS="--errorOutputType=file \
 --errorOutputNumShards=${ERROR_NUM_SHARDS}"
-elif [[ $JOB_TYPE == "decoder" ]] ; then
+elif [[ $JOB_TYPE =~ ^decoder.*$ ]] ; then
   JOB_CLASS="com.mozilla.telemetry.Decoder"
   OUTPUT_OPTS="--outputType=pubsub \
 --outputFileFormat=json \


### PR DESCRIPTION
Similar to the [republisher](https://github.com/mozilla/gcp-ingestion/blob/master/ingestion-beam/bin/build-template#L60), we need to be able to write a separate template per pipeline family. Unlike the republisher, we can share a single template between pipeline families except for pioneer, so the regular expression is slightly more relaxed.