### PR TITLE
[Bug 1644200] Mark pings sent from com-granitamalta-cloudbrowser as unwatend data

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -30,6 +30,7 @@ public class MessageScrubber {
       .put("org-mozilla-fogotype", "1635592") //
       .put("com-pumabrowser-pumabrowser", "1637055") //
       .put("org-mozilla-fenix-debug", "1614409") //
+      .put("com-granitamalta-cloudbrowser", "1644200") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -97,6 +97,16 @@ public class MessageScrubberTest {
   }
 
   @Test
+  public void testUnwantedDataBug1644200() {
+    Map<String, String> attributes = ImmutableMap.<String, String>builder()
+        .put(Attribute.DOCUMENT_NAMESPACE, "com-granitamalta-cloudbrowser")
+        .put(Attribute.DOCUMENT_TYPE, "baseline").build();
+
+    assertThrows(UnwantedDataException.class,
+        () -> MessageScrubber.scrub(attributes, Json.createObjectNode()));
+  }
+
+  @Test
   public void testUnwantedDataBug1618684() {
     Map<String, String> attributes = ImmutableMap.<String, String>builder()
         .put(Attribute.APP_NAME, "FirefoxOS").build();


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1644200