### PR TITLE
Require "payload" in AET telemetry json schema

### DIFF
--- a/ingestion-beam/src/main/resources/account-ecosystem/telemetry.schema.json
+++ b/ingestion-beam/src/main/resources/account-ecosystem/telemetry.schema.json
@@ -22,18 +22,18 @@
             "type": "string"
           },
           "type": "array"
-        }
+        },
+        "ecosystemUserId": false,
+        "previousEcosystemUserIds": false,
+        "ecosystem_user_id": false,
+        "previous_ecosystem_user_ids": false,
+        "ecosystem_anon_id": false,
+        "previous_ecosystem_anon_ids": false
       },
       "required": [
         "ecosystemClientId",
         "ecosystemDeviceId"
-      ],
-      "ecosystemUserId": false,
-      "previousEcosystemUserIds": false,
-      "ecosystem_user_id": false,
-      "previous_ecosystem_user_ids": false,
-      "ecosystem_anon_id": false,
-      "previous_ecosystem_anon_ids": false
+      ]
     },
     "ecosystemAnonId": false,
     "previousEcosystemAnonIds": false,

--- a/ingestion-beam/src/main/resources/account-ecosystem/telemetry.schema.json
+++ b/ingestion-beam/src/main/resources/account-ecosystem/telemetry.schema.json
@@ -43,5 +43,8 @@
     "previous_ecosystem_user_ids": false,
     "ecosystem_anon_id": false,
     "previous_ecosystem_anon_ids": false
-  }
+  },
+  "required": [
+    "payload"
+  ]
 }


### PR DESCRIPTION
This will avoid a pipeline error that @whd reported when sending a message with content `{}`.

Was:
```
Error message from worker: java.lang.ClassCastException: com.fasterxml.jackson.databind.node.MissingNode cannot be cast to com.fasterxml.jackson.databind.node.ObjectNode com.mozilla.telemetry.aet.DecryptAetIdentifiers$Fn.processDesktopTelemetryPayload(DecryptAetIdentifiers.java:241)
```