### PR TITLE
[Bug 1642386] Redact payload.syncs.engines.outgoing for old sync pings

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -221,7 +221,7 @@ public class MessageScrubber {
         && "Lockbox".equals(attributes.get(Attribute.APP_NAME))
         && attributes.get(Attribute.APP_VERSION) != null
         && ("1.7.0".equals(attributes.get(Attribute.APP_VERSION))
-            || attributes.get(Attribute.APP_VERSION).matches("1\\.[0-6][0-9.]*"));
+            || attributes.get(Attribute.APP_VERSION).matches("^1\\.[0-6][0-9.]*"));
   }
 
   // See bug 1162183 for discussion of affected versions, etc.
@@ -233,14 +233,15 @@ public class MessageScrubber {
     return ParseUri.TELEMETRY.equals(attributes.get(Attribute.DOCUMENT_NAMESPACE))
         && affectedDocumentTypes.contains(attributes.get(Attribute.DOCUMENT_TYPE))
         && attributes.get(Attribute.APP_VERSION) != null
-        && attributes.get(Attribute.APP_VERSION).matches("([0-3][0-9]|4[0-1])\\..*"); // 41 or older
+        && attributes.get(Attribute.APP_VERSION).matches("^([0-3][0-9]|4[0-1])\\..*"); // >= 41
   }
 
   // See bug 1642386 for discussion of affected versions, etc.
+  @VisibleForTesting
   static boolean bug1642386Affected(Map<String, String> attributes) {
     return ParseUri.TELEMETRY.equals(attributes.get(Attribute.DOCUMENT_NAMESPACE))
         && attributes.get(Attribute.DOCUMENT_TYPE).equals("sync")
         && attributes.get(Attribute.APP_VERSION) != null
-        && attributes.get(Attribute.APP_VERSION).matches("(25|26)\\..*"); // 25 or 26
+        && attributes.get(Attribute.APP_VERSION).matches("^(25|26)\\..*"); // 25 or 26
   }
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -137,6 +137,15 @@ public class MessageScrubber {
         markBugCounter("1162183");
       }
     }
+
+    if (bug1642386Affected(attributes)) {
+      json.path("payload").path("syncs").elements().forEachRemaining(syncItem -> {
+        syncItem.path("engines").elements().forEachRemaining(engine -> {
+          ((ObjectNode) engine).remove("outgoing");
+          markBugCounter("1642386");
+        });
+      });
+    }
   }
 
   private static void markBugCounter(String bugNumber) {
@@ -225,5 +234,13 @@ public class MessageScrubber {
         && affectedDocumentTypes.contains(attributes.get(Attribute.DOCUMENT_TYPE))
         && attributes.get(Attribute.APP_VERSION) != null
         && attributes.get(Attribute.APP_VERSION).matches("([0-3][0-9]|4[0-1])\\..*"); // 41 or older
+  }
+
+  // See bug 1642386 for discussion of affected versions, etc.
+  static boolean bug1642386Affected(Map<String, String> attributes) {
+    return ParseUri.TELEMETRY.equals(attributes.get(Attribute.DOCUMENT_NAMESPACE))
+        && attributes.get(Attribute.DOCUMENT_TYPE).equals("sync")
+        && attributes.get(Attribute.APP_VERSION) != null
+        && attributes.get(Attribute.APP_VERSION).matches("(25|26)\\..*"); // 25 or 26
   }
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -272,6 +272,20 @@ public class MessageScrubberTest {
   }
 
   @Test
+  public void testBug1642386Affected() throws Exception {
+    Map<String, String> baseAttributes = ImmutableMap.<String, String>builder()
+        .put(Attribute.DOCUMENT_NAMESPACE, ParseUri.TELEMETRY).put(Attribute.DOCUMENT_TYPE, "sync")
+        .build();
+
+    assertFalse(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
+        .putAll(baseAttributes).put(Attribute.APP_VERSION, "60.6.1").build()));
+    assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
+        .putAll(baseAttributes).put(Attribute.APP_VERSION, "25.0.1").build()));
+    assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
+        .putAll(baseAttributes).put(Attribute.APP_VERSION, "26.1").build()));
+  }
+
+  @Test
   public void testRedactForBug1602844() throws Exception {
     Map<String, String> attributes = ImmutableMap.<String, String>builder()
         .put(Attribute.DOCUMENT_NAMESPACE, ParseUri.TELEMETRY)
@@ -332,6 +346,63 @@ public class MessageScrubberTest {
     MessageScrubber.scrub(attributes, json);
     assertFalse(json.path("payload").has("slowSQL"));
     assertTrue(json.path("payload").path("slowSQL").isMissingNode());
+  }
+
+  @Test
+  public void testRedactForBug1642386() throws Exception {
+    ObjectNode json = Json.readObjectNode(("{\n" //
+        + "  \"payload\": {\n" //
+        + "    \"syncs\": [{\n" //
+        + "      \"engines\": [" //
+        + "        {\n" //
+        + "          \"outgoing\": {\n" //
+        + "            \"failed\": 10,\n" //
+        + "            \"sent\": 23\n" //
+        + "          }\n" //
+        + "        },{\n" //
+        + "          \"outgoing\": {\n" //
+        + "            \"failed\": 2,\n" //
+        + "            \"sent\": 0\n" //
+        + "          }\n" //
+        + "        }\n" //
+        + "      ]}, {\n" //
+        + "      \"engines\": [" //
+        + "        {\n" //
+        + "          \"outgoing\": {\n" //
+        + "            \"failed\": 1,\n" //
+        + "            \"sent\": 3\n" //
+        + "          }\n" //
+        + "        },{\n" //
+        + "          \"outgoing\": {\n" //
+        + "            \"failed\": 28,\n" //
+        + "            \"sent\": 70\n" //
+        + "          }\n" //
+        + "        }\n" //
+        + "      ]}\n" //
+        + "    ]\n" //
+        + "  },\n" //
+        + "  \"client_id\": null\n" + "}").getBytes(StandardCharsets.UTF_8));
+    final Map<String, String> attributes = ImmutableMap.<String, String>builder()
+        .put(Attribute.DOCUMENT_NAMESPACE, ParseUri.TELEMETRY).put(Attribute.DOCUMENT_TYPE, "sync")
+        .put(Attribute.APP_VERSION, "25.1").build();
+
+    assertFalse(json.path("payload").path("syncs").path(0).path("engines").path(0).path("outgoing")
+        .isNull());
+    assertFalse(json.path("payload").path("syncs").path(0).path("engines").path(1).path("outgoing")
+        .isNull());
+    assertFalse(json.path("payload").path("syncs").path(1).path("engines").path(0).path("outgoing")
+        .isNull());
+    assertFalse(json.path("payload").path("syncs").path(1).path("engines").path(1).path("outgoing")
+        .isNull());
+    MessageScrubber.scrub(attributes, json);
+    assertTrue(json.path("payload").path("syncs").path(0).path("engines").path(0).path("outgoing")
+        .isMissingNode());
+    assertTrue(json.path("payload").path("syncs").path(0).path("engines").path(1).path("outgoing")
+        .isMissingNode());
+    assertFalse(json.path("payload").path("syncs").path(0).path("engines").path(0).has("outgoing"));
+    assertFalse(json.path("payload").path("syncs").path(0).path("engines").path(1).has("outgoing"));
+    assertFalse(json.path("payload").path("syncs").path(1).path("engines").path(0).has("outgoing"));
+    assertFalse(json.path("payload").path("syncs").path(1).path("engines").path(1).has("outgoing"));
   }
 
   @Test

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -279,6 +279,8 @@ public class MessageScrubberTest {
 
     assertFalse(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "60.6.1").build()));
+    assertFalse(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
+        .putAll(baseAttributes).put(Attribute.APP_VERSION, "10.25.1").build()));
     assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "25.0.1").build()));
     assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1642386

To reduce the number of validation errors, this adds an additional redaction case to the MessageScrubber. The fields `syncs[...].engines[...].outgoing` get removed from the payload from sync v4 pings sent from clients with FF versions 25 and 26 since they are incompatible with the current schema.