### PR TITLE
Redact syncs.engines.outgoing for versions 26 or older

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -242,6 +242,6 @@ public class MessageScrubber {
     return ParseUri.TELEMETRY.equals(attributes.get(Attribute.DOCUMENT_NAMESPACE))
         && attributes.get(Attribute.DOCUMENT_TYPE).equals("sync")
         && attributes.get(Attribute.APP_VERSION) != null
-        && attributes.get(Attribute.APP_VERSION).matches("^(25|26)\\..*"); // 25 or 26
+        && attributes.get(Attribute.APP_VERSION).matches("^([0-9]|[0-2][0-6])\\..*"); // <= 26
   }
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -280,11 +280,17 @@ public class MessageScrubberTest {
     assertFalse(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "60.6.1").build()));
     assertFalse(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
-        .putAll(baseAttributes).put(Attribute.APP_VERSION, "10.25.1").build()));
+        .putAll(baseAttributes).put(Attribute.APP_VERSION, "27.1").build()));
     assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "25.0.1").build()));
     assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "26.1").build()));
+    assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
+        .putAll(baseAttributes).put(Attribute.APP_VERSION, "14.1").build()));
+    assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
+        .putAll(baseAttributes).put(Attribute.APP_VERSION, "8.0.2").build()));
+    assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
+        .putAll(baseAttributes).put(Attribute.APP_VERSION, "10.0.2").build()));
   }
 
   @Test

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -281,6 +281,8 @@ public class MessageScrubberTest {
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "60.6.1").build()));
     assertFalse(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "27.1").build()));
+    assertFalse(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
+        .putAll(baseAttributes).put(Attribute.APP_VERSION, "100.0").build()));
     assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "25.0.1").build()));
     assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/gcp-ingestion/pull/1310