### PR TITLE
Fix failing BigQuery integration test

### DIFF
--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/BigQueryIntegrationTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/BigQueryIntegrationTest.java
@@ -111,7 +111,8 @@ public class BigQueryIntegrationTest extends TestWithDeterministicJson {
     String output = String.format("%s:%s", projectId, tableSpec);
 
     PipelineResult result = Sink.run(new String[] { "--inputFileFormat=json", "--inputType=file",
-        "--input=" + input, "--outputType=bigquery", "--bqWriteMethod=streaming",
+        "--input=" + input, "--outputType=bigquery", "--bqWriteMethod=file_loads",
+        "--tempLocation=gs://gcp-ingestion-static-test-bucket/temp/bq-loads",
         "--schemasLocation=schemas.tar.gz", "--output=" + output, "--errorOutputType=stderr" });
 
     result.waitUntilFinish();


### PR DESCRIPTION
The test involves a timestamp that is now just over 1 year old. The test now
throws:

> Value 1561983194123456 for field submission_timestamp of the destination table ******************************:gcloud_test_dataset_temp_2be335db_873f_4dd3_91e3_8b6768430eab.my_test_table is outside the allowed bounds. You can only stream to date range within 365 days in the past and 183 days in the future relative to the current date

We sidestep this problem by using file loads instead of streaming. We still have
other tests that exercise streaming inserts, but this was the only one that
had non-null submission timestamp specified.