### PR TITLE
Fix missing image builds in edge docker-compose

### DIFF
--- a/ingestion-edge/docker-compose.yml
+++ b/ingestion-edge/docker-compose.yml
@@ -33,11 +33,13 @@ services:
         ]
       ]
   pubsub:
+    build: .
     image: *image
     command: python -m pubsub_emulator
     environment:
       PORT: 8085
   test:
+    build: .
     image: *image
     command:
     - bin/pytest-all


### PR DESCRIPTION
services don't depend on `web` by default, so they all need to be able to build the docker image to prevent [`ERROR: manifest for ******** not found`](https://app.circleci.com/pipelines/github/mozilla/gcp-ingestion/537/workflows/2677f6fa-f859-4ed1-8b1f-8214975c659f/jobs/28089) on `docker-compose up --build` without a preceding `docker-compose build`.

This fixes broken `ingestion-edge-release` CI.