### PR TITLE
[Bug 1642386] Handle sync pings from Firefox for iOS < v28

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -242,6 +242,6 @@ public class MessageScrubber {
     return ParseUri.TELEMETRY.equals(attributes.get(Attribute.DOCUMENT_NAMESPACE))
         && attributes.get(Attribute.DOCUMENT_TYPE).equals("sync")
         && attributes.get(Attribute.APP_VERSION) != null
-        && attributes.get(Attribute.APP_VERSION).matches("^([0-9]|[0-2][0-6])\\..*"); // <= 26
+        && attributes.get(Attribute.APP_VERSION).matches("^([0-9]|[0-2][0-7])\\..*"); // <= 27
   }
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -280,6 +280,8 @@ public class MessageScrubberTest {
     assertFalse(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "60.6.1").build()));
     assertFalse(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
+        .putAll(baseAttributes).put(Attribute.APP_VERSION, "28.1").build()));
+    assertTrue(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "27.1").build()));
     assertFalse(MessageScrubber.bug1642386Affected(ImmutableMap.<String, String>builder()
         .putAll(baseAttributes).put(Attribute.APP_VERSION, "100.0").build()));


### PR DESCRIPTION
The sync ping issue will be resolved with FF for iOS version 28. So we should scrub the affected fields for version 27 to make sure they are not written to payload_bytes_error.

