### PR TITLE
Add X-Source-Tags to core AddMetadata headers list

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/AddMetadata.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/AddMetadata.java
@@ -42,7 +42,7 @@ public class AddMetadata {
 
   private static final String HEADER = "header";
   private static final List<String> HEADER_ATTRIBUTES = ImmutableList //
-      .of(Attribute.DATE, Attribute.DNT, Attribute.X_PINGSENDER_VERSION, Attribute.X_DEBUG_ID,
+      .of(Attribute.DATE, Attribute.DNT, Attribute.X_DEBUG_ID, Attribute.X_PINGSENDER_VERSION,
           Attribute.X_SOURCE_TAGS);
 
   private static final List<String> URI_ATTRIBUTES = ImmutableList //

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/transform/AddMetadata.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/transform/AddMetadata.java
@@ -31,7 +31,8 @@ public class AddMetadata {
 
   private static final String HEADER = "header";
   private static final List<String> HEADER_ATTRIBUTES = ImmutableList //
-      .of(Attribute.DATE, Attribute.DNT, Attribute.X_DEBUG_ID, Attribute.X_PINGSENDER_VERSION);
+      .of(Attribute.DATE, Attribute.DNT, Attribute.X_DEBUG_ID, Attribute.X_PINGSENDER_VERSION,
+          Attribute.X_SOURCE_TAGS);
 
   private static final List<String> URI_ATTRIBUTES = ImmutableList //
       .of(Attribute.URI, Attribute.APP_NAME, Attribute.APP_VERSION, Attribute.APP_UPDATE_CHANNEL,


### PR DESCRIPTION
Fixup to #1328 since it looks like we have this logic duplicated in core and in beam.