### PR TITLE
Allow structured AET pings to be missing ecosystem_client_id

### DIFF
--- a/ingestion-beam/src/main/resources/account-ecosystem/structured.schema.json
+++ b/ingestion-beam/src/main/resources/account-ecosystem/structured.schema.json
@@ -23,7 +23,16 @@
     "previous_ecosystem_user_ids": false,
     "previousEcosystemUserIds": false
   },
-  "required": [
-    "ecosystem_client_id"
+  "anyOf": [
+    {
+      "required": [
+        "ecosystem_client_id"
+      ]
+    },
+    {
+      "required": [
+        "ecosystem_anon_id"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
This matches the schema change introduced in https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/572