### PR TITLE
Skip flush_manager test in docker-compose

### DIFF
--- a/ingestion-edge/docker-compose.circleci.yml
+++ b/ingestion-edge/docker-compose.circleci.yml
@@ -10,7 +10,7 @@ services:
     env_file:
     - circleci.env
     environment:
-    - PYTEST_ADDOPTS=. tests/integration --ignore tests/load --server=http://web:8000
+    - PYTEST_ADDOPTS=. tests/integration --ignore tests/load --ignore tests/flush_manager --server=http://web:8000
     - &emulator_host PUBSUB_EMULATOR_HOST=pubsub:8085
   web:
     environment:


### PR DESCRIPTION
because the test is meant to run on GKE, not in docker-compose.

this should fix ingestion-edge-release CI on master