### PR TITLE
Add error output support to ingestion-sink

### DIFF
--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/config/SinkConfig.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/config/SinkConfig.java
@@ -16,6 +16,7 @@ import com.mozilla.telemetry.ingestion.sink.io.Gcs;
 import com.mozilla.telemetry.ingestion.sink.io.Input;
 import com.mozilla.telemetry.ingestion.sink.io.Pipe;
 import com.mozilla.telemetry.ingestion.sink.io.Pubsub;
+import com.mozilla.telemetry.ingestion.sink.io.WriteWithErrors;
 import com.mozilla.telemetry.ingestion.sink.transform.BlobIdToPubsubMessage;
 import com.mozilla.telemetry.ingestion.sink.transform.CompressPayload;
 import com.mozilla.telemetry.ingestion.sink.transform.DecompressPayload;
@@ -39,12 +40,19 @@ import java.util.function.Predicate;
 
 public class SinkConfig {
 
-  public static final String OUTPUT_TABLE = "OUTPUT_TABLE";
-
   private static final String INPUT_COMPRESSION = "INPUT_COMPRESSION";
   private static final String INPUT_PARALLELISM = "INPUT_PARALLELISM";
   private static final String INPUT_PIPE = "INPUT_PIPE";
   private static final String INPUT_SUBSCRIPTION = "INPUT_SUBSCRIPTION";
+  private static final String MAX_OUTSTANDING_ELEMENT_COUNT = "MAX_OUTSTANDING_ELEMENT_COUNT";
+  private static final String MAX_OUTSTANDING_REQUEST_BYTES = "MAX_OUTSTANDING_REQUEST_BYTES";
+
+  private static final Set<String> INPUT_ENV_VARS = ImmutableSet.of(INPUT_COMPRESSION,
+      INPUT_PARALLELISM, INPUT_PIPE, INPUT_SUBSCRIPTION, MAX_OUTSTANDING_ELEMENT_COUNT,
+      MAX_OUTSTANDING_REQUEST_BYTES);
+
+  public static final String OUTPUT_TABLE = "OUTPUT_TABLE";
+
   private static final String BATCH_MAX_BYTES = "BATCH_MAX_BYTES";
   private static final String BATCH_MAX_DELAY = "BATCH_MAX_DELAY";
   private static final String BATCH_MAX_MESSAGES = "BATCH_MAX_MESSAGES";
@@ -56,11 +64,10 @@ public class SinkConfig {
   private static final String OUTPUT_BUCKET = "OUTPUT_BUCKET";
   private static final String OUTPUT_COMPRESSION = "OUTPUT_COMPRESSION";
   private static final String OUTPUT_FORMAT = "OUTPUT_FORMAT";
+  private static final String OUTPUT_MAX_ATTEMPTS = "OUTPUT_MAX_ATTEMPTS";
   private static final String OUTPUT_PARALLELISM = "OUTPUT_PARALLELISM";
   private static final String OUTPUT_PIPE = "OUTPUT_PIPE";
   private static final String OUTPUT_TOPIC = "OUTPUT_TOPIC";
-  private static final String MAX_OUTSTANDING_ELEMENT_COUNT = "MAX_OUTSTANDING_ELEMENT_COUNT";
-  private static final String MAX_OUTSTANDING_REQUEST_BYTES = "MAX_OUTSTANDING_REQUEST_BYTES";
   private static final String SCHEMAS_LOCATION = "SCHEMAS_LOCATION";
   private static final String STREAMING_BATCH_MAX_BYTES = "STREAMING_BATCH_MAX_BYTES";
   private static final String STREAMING_BATCH_MAX_DELAY = "STREAMING_BATCH_MAX_DELAY";
@@ -68,14 +75,12 @@ public class SinkConfig {
   private static final String STREAMING_DOCTYPES = "STREAMING_DOCTYPES";
   private static final String STRICT_SCHEMA_DOCTYPES = "STRICT_SCHEMA_DOCTYPES";
 
-  private static final Set<String> INCLUDE_ENV_VARS = ImmutableSet.of(INPUT_COMPRESSION,
-      INPUT_PARALLELISM, INPUT_PIPE, INPUT_SUBSCRIPTION, BATCH_MAX_BYTES, BATCH_MAX_DELAY,
-      BATCH_MAX_MESSAGES, BIG_QUERY_OUTPUT_MODE, BIG_QUERY_DEFAULT_PROJECT, LOAD_MAX_BYTES,
-      LOAD_MAX_DELAY, LOAD_MAX_FILES, OUTPUT_BUCKET, OUTPUT_COMPRESSION, OUTPUT_FORMAT,
-      OUTPUT_PARALLELISM, OUTPUT_PIPE, OUTPUT_TABLE, OUTPUT_TOPIC, MAX_OUTSTANDING_ELEMENT_COUNT,
-      MAX_OUTSTANDING_REQUEST_BYTES, SCHEMAS_LOCATION, STREAMING_BATCH_MAX_BYTES,
-      STREAMING_BATCH_MAX_DELAY, STREAMING_BATCH_MAX_MESSAGES, STREAMING_DOCTYPES,
-      STRICT_SCHEMA_DOCTYPES);
+  private static final Set<String> OUTPUT_ENV_VARS = ImmutableSet.of(BATCH_MAX_BYTES,
+      BATCH_MAX_DELAY, BATCH_MAX_MESSAGES, BIG_QUERY_OUTPUT_MODE, BIG_QUERY_DEFAULT_PROJECT,
+      LOAD_MAX_BYTES, LOAD_MAX_DELAY, LOAD_MAX_FILES, OUTPUT_BUCKET, OUTPUT_COMPRESSION,
+      OUTPUT_FORMAT, OUTPUT_PARALLELISM, OUTPUT_PIPE, OUTPUT_TABLE, OUTPUT_TOPIC, SCHEMAS_LOCATION,
+      STREAMING_BATCH_MAX_BYTES, STREAMING_BATCH_MAX_DELAY, STREAMING_BATCH_MAX_MESSAGES,
+      STREAMING_DOCTYPES, STRICT_SCHEMA_DOCTYPES);
 
   // BigQuery.Write.Batch.getByteSize reports protobuf size, which can be ~1/3rd more
   // efficient than the JSON that actually gets sent over HTTP, so we use to 60% of the
@@ -116,23 +121,28 @@ public class SinkConfig {
   // BigQuery Load API limits maximum load requests per table per day to 1,000 but mixed mode
   // expects fewer than 1,000 messages per day to need file loads, so use streaming max delay.
   private static final String DEFAULT_STREAMING_LOAD_MAX_DELAY = DEFAULT_STREAMING_BATCH_MAX_DELAY;
+  // BatchExceptions don't count toward this limit. Only used when error output is configured,
+  // otherwise messages will be immediately nacked on failure.
+  private static final int DEFAULT_OUTPUT_MAX_ATTEMPTS = 3;
 
   @VisibleForTesting
   protected static class Output implements Function<PubsubMessage, CompletableFuture<Void>> {
 
-    private final Env env;
     private final OutputType type;
     private final Function<PubsubMessage, CompletableFuture<Void>> write;
 
-    private Output(Env env, OutputType outputType,
-        Function<PubsubMessage, CompletableFuture<Void>> write) {
-      this.env = env;
+    private Output(OutputType outputType, Function<PubsubMessage, CompletableFuture<Void>> write) {
       this.type = outputType;
       this.write = write;
     }
 
     public Output via(Function<PubsubMessage, CompletableFuture<Void>> write) {
-      return new Output(this.env, this.type, write);
+      return new Output(this.type, write);
+    }
+
+    public Output errorsVia(Function<PubsubMessage, CompletableFuture<Void>> errors,
+        int maxAttempts) {
+      return new Output(this.type, new WriteWithErrors(write, errors, maxAttempts));
     }
 
     public CompletableFuture<Void> apply(PubsubMessage message) {
@@ -168,7 +178,7 @@ public class SinkConfig {
               throw new IllegalArgumentException(e);
             }
         }
-        return new Output(env, this, Pipe.Write.of(pipe, env.optString(OUTPUT_TABLE)
+        return new Output(this, Pipe.Write.of(pipe, env.optString(OUTPUT_TABLE)
             .map(PubsubMessageToTemplatedString::forBigQuery).orElse(null), getFormat(env)));
       }
     },
@@ -182,7 +192,7 @@ public class SinkConfig {
 
       @Override
       Output getOutput(Env env, Executor executor) {
-        return new Output(env, this, new Pubsub.Write(env.getString(OUTPUT_TOPIC), executor, b -> b,
+        return new Output(this, new Pubsub.Write(env.getString(OUTPUT_TOPIC), executor, b -> b,
             getOutputCompression(env))::withoutResult);
       }
     },
@@ -191,7 +201,7 @@ public class SinkConfig {
 
       @Override
       Output getOutput(Env env, Executor executor) {
-        return new Output(env, this,
+        return new Output(this,
             new Gcs.Write.Ndjson(getGcsService(env),
                 env.getLong(BATCH_MAX_BYTES, DEFAULT_BATCH_MAX_BYTES),
                 env.getInt(BATCH_MAX_MESSAGES, DEFAULT_BATCH_MAX_MESSAGES),
@@ -218,7 +228,7 @@ public class SinkConfig {
         // to BigQuery. If the blob does not exist, it must have been deleted, because Cloud
         // Storage provides strong global consistency for read-after-write operations.
         // https://cloud.google.com/storage/docs/consistency
-        return new Output(env, this,
+        return new Output(this,
             message -> CompletableFuture.completedFuture(message)
                 .thenApply(BlobIdToPubsubMessage::decode)
                 // ApplyAsync for storage::get because it is a blocking IO operation
@@ -251,7 +261,7 @@ public class SinkConfig {
       @Override
       Output getOutput(Env env, Executor executor) {
         Output pubsubWrite = pubsub.getOutput(env, executor);
-        return new Output(env, this,
+        return new Output(this,
             new Gcs.Write.Ndjson(getGcsService(env),
                 env.getLong(BATCH_MAX_BYTES, DEFAULT_BATCH_MAX_BYTES),
                 env.getInt(BATCH_MAX_MESSAGES, DEFAULT_BATCH_MAX_MESSAGES),
@@ -263,13 +273,18 @@ public class SinkConfig {
                 blobInfo -> pubsubWrite.apply(BlobIdToPubsubMessage.encode(blobInfo.getBlobId())))
                     .withOpenCensusMetrics());
       }
+
+      @Override
+      boolean validErrorOutput() {
+        return false;
+      }
     },
 
     bigQueryStreaming {
 
       @Override
       Output getOutput(Env env, Executor executor) {
-        return new Output(env, this,
+        return new Output(this,
             new BigQuery.Write(getBigQueryService(env),
                 env.getLong(BATCH_MAX_BYTES, DEFAULT_STREAMING_BATCH_MAX_BYTES),
                 env.getInt(BATCH_MAX_MESSAGES, DEFAULT_STREAMING_BATCH_MAX_MESSAGES),
@@ -345,7 +360,7 @@ public class SinkConfig {
         } else {
           mixedOutput = fallbackOutput;
         }
-        return new Output(env, this, mixedOutput);
+        return new Output(this, mixedOutput);
       }
     };
 
@@ -360,6 +375,11 @@ public class SinkConfig {
     // Cases in the enum may override this method set a more appropriate default.
     long getDefaultMaxOutstandingRequestBytes() {
       return 30_000_000L; // 30MB
+    }
+
+    // Cases in the enum override this method to return false when they are not valid error outputs.
+    boolean validErrorOutput() {
+      return true;
     }
 
     static OutputType get(Env env) {
@@ -446,22 +466,43 @@ public class SinkConfig {
 
   /** Return a configured output transform. */
   public static Output getOutput() {
-    Env env = new Env(INCLUDE_ENV_VARS);
+    final Env outputEnv = new Env(OUTPUT_ENV_VARS);
+    final Env errorEnv = new Env(OUTPUT_ENV_VARS, "ERROR_");
     // Executor to use for CompletableFutures in outputs instead of ForkJoinPool.commonPool(),
     // because the default parallelism is 1 in stage and prod. Parallelism should be more than one
     // per batch key (i.e. output table), because this executor is used for batch close operations
     // that may be slow synchronous IO. As of 2020-04-25 there are 89 tables for telemetry and 118
     // tables for structured.
-    Executor executor = new ForkJoinPool(env.getInt(OUTPUT_PARALLELISM, 150));
-    return OutputType.get(env).getOutput(env, executor);
+    final Executor executor = new ForkJoinPool(outputEnv.getInt(OUTPUT_PARALLELISM, 150));
+    final Output output = OutputType.get(outputEnv).getOutput(outputEnv, executor);
+
+    // Handle error output if configured.
+    final Output withErrors;
+    if (outputEnv.containsKey(OUTPUT_MAX_ATTEMPTS) || !errorEnv.isEmpty()) {
+      OutputType errorOutputType = OutputType.get(errorEnv);
+      if (errorOutputType.validErrorOutput()) {
+        withErrors = output.errorsVia(errorOutputType.getOutput(errorEnv, executor).write,
+            outputEnv.getInt(OUTPUT_MAX_ATTEMPTS, DEFAULT_OUTPUT_MAX_ATTEMPTS));
+      } else {
+        throw new IllegalArgumentException(
+            "Invalid error output type detected: " + errorOutputType.name());
+      }
+    } else {
+      withErrors = output;
+    }
+
+    outputEnv.requireAllVarsUsed();
+    errorEnv.requireAllVarsUsed();
+    return withErrors;
   }
 
   /** Return a configured input transform. */
   public static Input getInput(Output output) throws IOException {
-    final DecompressPayload decompress = getInputCompression(output.env);
+    final Env env = new Env(INPUT_ENV_VARS);
+    final DecompressPayload decompress = getInputCompression(env);
     final Input input;
-    if (output.env.containsKey(INPUT_PIPE)) {
-      final String inputPipe = output.env.getString(INPUT_PIPE);
+    if (env.containsKey(INPUT_PIPE)) {
+      final String inputPipe = env.getString(INPUT_PIPE);
       final InputStream pipe;
       switch (inputPipe) {
         case "-":
@@ -472,18 +513,15 @@ public class SinkConfig {
           pipe = System.in;
           break;
         default:
-          pipe = Files.newInputStream(Paths.get(output.env.getString(INPUT_PIPE)));
+          pipe = Files.newInputStream(Paths.get(inputPipe));
       }
       input = Pipe.Read.of(pipe, output.write, decompress);
     } else {
-      // read pubsub messages from INPUT_SUBSCRIPTION
-      input = new Pubsub.Read(output.env.getString(INPUT_SUBSCRIPTION), output,
+      input = new Pubsub.Read(env.getString(INPUT_SUBSCRIPTION), output,
           builder -> builder
               .setFlowControlSettings(FlowControlSettings.newBuilder()
-                  .setMaxOutstandingElementCount(
-                      output.type.getMaxOutstandingElementCount(output.env))
-                  .setMaxOutstandingRequestBytes(
-                      output.type.getMaxOutstandingRequestBytes(output.env))
+                  .setMaxOutstandingElementCount(output.type.getMaxOutstandingElementCount(env))
+                  .setMaxOutstandingRequestBytes(output.type.getMaxOutstandingRequestBytes(env))
                   .build())
               // The number of streaming subscriber connections for reading from Pub/Sub.
               // https://github.com/googleapis/java-pubsub/blob/v1.105.0/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Subscriber.java#L141
@@ -494,13 +532,13 @@ public class SinkConfig {
               // are
               // reached, so parallelism should be no less than the number of available processors.
               .setParallelPullCount(
-                  output.env.getInt(INPUT_PARALLELISM, Runtime.getRuntime().availableProcessors())),
+                  env.getInt(INPUT_PARALLELISM, Runtime.getRuntime().availableProcessors())),
           decompress);
       // Setup OpenCensus stackdriver exporter after all measurement views have been registered,
       // as seen in https://opencensus.io/exporters/supported-exporters/java/stackdriver-stats/
       StackdriverStatsExporter.createAndRegister();
     }
-    output.env.requireAllVarsUsed();
+    env.requireAllVarsUsed();
     return input;
   }
 }

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/WriteWithErrors.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/WriteWithErrors.java
@@ -1,0 +1,44 @@
+package com.mozilla.telemetry.ingestion.sink.io;
+
+import com.google.pubsub.v1.PubsubMessage;
+import com.mozilla.telemetry.ingestion.sink.util.BatchException;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/** Constructor. */
+public class WriteWithErrors implements Function<PubsubMessage, CompletableFuture<Void>> {
+
+  private final Function<PubsubMessage, CompletableFuture<Void>> write;
+  private final Function<PubsubMessage, CompletableFuture<Void>> errors;
+  private final int maxAttempts;
+
+  /** Apply {@code write} until {@code maxAttempts} failures, then apply {@code errors}.
+   */
+  public WriteWithErrors(Function<PubsubMessage, CompletableFuture<Void>> write,
+      Function<PubsubMessage, CompletableFuture<Void>> errors, int maxAttempts) {
+    this.write = write;
+    this.errors = errors;
+    this.maxAttempts = maxAttempts;
+  }
+
+  @Override
+  public CompletableFuture<Void> apply(PubsubMessage message) {
+    return apply(message, 1);
+  }
+
+  private CompletableFuture<Void> apply(PubsubMessage message, int attempt) {
+    return CompletableFuture.completedFuture(message).thenCompose(write)
+        .thenApply(CompletableFuture::completedFuture).exceptionally(t -> {
+          if (t.getCause() instanceof BatchException) {
+            // batch exceptions don't count toward attempt limit
+            return apply(message, attempt);
+          }
+          if (attempt < maxAttempts) {
+            // retry message until maxAttempts is reached
+            return apply(message, attempt + 1);
+          }
+          // deliver to dead letter queue, if provided
+          return errors.apply(message);
+        }).thenCompose(v -> v);
+  }
+}

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/SinkTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/SinkTest.java
@@ -1,18 +1,64 @@
 package com.mozilla.telemetry.ingestion.sink;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.mozilla.telemetry.ingestion.core.schema.TestConstant;
+import com.mozilla.telemetry.ingestion.sink.config.SinkConfig;
 import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.junit.contrib.java.lang.system.TextFromStandardInputStream;
 
 public class SinkTest {
 
   @Rule
   public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
-  @Test(expected = IllegalArgumentException.class)
-  public void failsOnMissingInput() throws IOException {
+  @Rule
+  public final TextFromStandardInputStream systemIn = TextFromStandardInputStream
+      .emptyStandardInputStream();
+
+  @Rule
+  public final SystemOutRule systemOut = new SystemOutRule();
+
+  @Rule
+  public final SystemErrRule systemErr = new SystemErrRule();
+
+  @Test
+  public void failsOnMissingInput() {
     environmentVariables.set("OUTPUT_TABLE", "dataset.table");
+    assertThrows(IllegalArgumentException.class, () -> Sink.main(null));
+  }
+
+  @Test
+  public void failsOnInvalidErrorOutput() {
+    environmentVariables.set("INPUT_PIPE", "-");
+    environmentVariables.set("OUTPUT_PIPE", "-");
+    environmentVariables.set("OUTPUT_MAX_ATTEMPTS", "1");
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+        SinkConfig::getOutput);
+    assertEquals("Invalid error output type detected: bigQueryLoad", thrown.getMessage());
+  }
+
+  @Test
+  public void canDeliverErrors() throws IOException {
+    environmentVariables.set("INPUT_PIPE", "stdin");
+    environmentVariables.set("OUTPUT_PIPE", "stdout");
+    environmentVariables.set("OUTPUT_FORMAT", "payload");
+    environmentVariables.set("SCHEMAS_LOCATION", TestConstant.SCHEMAS_LOCATION);
+    environmentVariables.set("ERROR_OUTPUT_PIPE", "stderr");
+    // one message with no valid payload format, but a valid default format of
+    systemIn.provideLines("{}");
+    systemOut.enableLog();
+    systemOut.mute();
+    systemErr.enableLog();
+    systemErr.mute();
     Sink.main(null);
+    assertEquals("", systemOut.getLog());
+    assertEquals("{}\n", systemErr.getLog());
   }
 }

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/WriteWithErrorsTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/WriteWithErrorsTest.java
@@ -1,0 +1,33 @@
+package com.mozilla.telemetry.ingestion.sink.io;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.pubsub.v1.PubsubMessage;
+import com.mozilla.telemetry.ingestion.sink.util.BatchException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+public class WriteWithErrorsTest {
+
+  @Test
+  public void canRetryBatchException() {
+    final AtomicInteger attempt = new AtomicInteger(0);
+    final List<String> errors = new LinkedList<>();
+
+    new WriteWithErrors(msg -> {
+      if (attempt.incrementAndGet() == 1) {
+        throw BatchException.of(new RuntimeException(), 0);
+      }
+      throw new RuntimeException();
+    }, msg -> {
+      errors.add(msg.getMessageId());
+      return CompletableFuture.completedFuture(null);
+    }, 2).apply(PubsubMessage.newBuilder().setMessageId("1").build()).join();
+    assertEquals(3, attempt.get());
+    assertEquals(ImmutableList.of("1"), errors);
+  }
+}

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/BoundedSink.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/BoundedSink.java
@@ -13,16 +13,16 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Utility for testing an unbounded {@link SinkConfig} with a termination condition.
  */
-public class BoundedSink extends SinkConfig {
+public class BoundedSink {
 
   /**
    * Run async until {@code messageCount} messages have been delivered.
    */
   private static CompletableFuture<Void> runAsync(int messageCount) throws IOException {
-    final Output output = getOutput();
+    final SinkConfig.Output output = SinkConfig.getOutput();
     final AtomicInteger counter = new AtomicInteger(0);
     final AtomicReference<Input> input = new AtomicReference<>();
-    input.set(getInput(output.via(message -> output.apply(message).thenApplyAsync(v -> {
+    input.set(SinkConfig.getInput(output.via(message -> output.apply(message).thenApplyAsync(v -> {
       final int currentMessages = counter.incrementAndGet();
       if (currentMessages >= messageCount) {
         input.get().stopAsync();

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/EnvTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/EnvTest.java
@@ -1,0 +1,46 @@
+package com.mozilla.telemetry.ingestion.sink.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+public class EnvTest {
+
+  @Rule
+  public final EnvironmentVariables envVars = new EnvironmentVariables();
+
+  @Test
+  public void canRemovePrefix() {
+    envVars.set("OUTPUT", "o");
+    envVars.set("ERROR_OUTPUT", "eo");
+    assertEquals("eo", new Env(ImmutableSet.of("OUTPUT"), "ERROR_").getString("OUTPUT"));
+  }
+
+  @Test
+  public void canRestorePrefix() {
+    envVars.set("OUTPUT", "o");
+    envVars.set("ERROR_OUTPUT", "eo");
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+        () -> new Env(ImmutableSet.of("OUTPUT"), "ERROR_").requireAllVarsUsed());
+    assertEquals("Env vars set but not used: [ERROR_OUTPUT]", thrown.getMessage());
+  }
+
+  @Test
+  public void throwsMissingInclude() {
+    envVars.set("OUTPUT", "o");
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+        () -> new Env(ImmutableSet.of()).getString("OUTPUT"));
+    assertEquals("key missing from include: OUTPUT", thrown.getMessage());
+  }
+
+  @Test
+  public void throwsMissingRequired() {
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+        () -> new Env(ImmutableSet.of("OUTPUT")).getString("OUTPUT"));
+    assertEquals("Missing required env var: OUTPUT", thrown.getMessage());
+  }
+}


### PR DESCRIPTION
this enables configuring a dead-letter-queue for undeliverable messages, which is an important feature for working around pubsub lite nack behavior.