### PR TITLE
Refactor error handling for AET

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/aet/AetProcessing.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/aet/AetProcessing.java
@@ -1,0 +1,59 @@
+package com.mozilla.telemetry.aet;
+
+import com.mozilla.telemetry.decoder.DecoderOptions;
+import com.mozilla.telemetry.decoder.ParseLogEntry;
+import com.mozilla.telemetry.decoder.ParseUri;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.WithFailures;
+import org.apache.beam.sdk.transforms.WithFailures.Result;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+
+/**
+ * Composite transform that handles decrypting AET identifiers and surrounding logic.
+ *
+ * <p>In particular, this transform provides special error handling such that payloads
+ * are sanitized of identifiers before being included in the error collection to avoid
+ * spilling sensitive ecosystem_anon_id values to error output.
+ */
+public class AetProcessing extends PTransform<PCollection<PubsubMessage>, //
+    WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage>> {
+
+  public static AetProcessing of(DecoderOptions options) {
+    return new AetProcessing(options);
+  }
+
+  private AetProcessing(DecoderOptions options) {
+    this.options = options;
+  }
+
+  private final DecoderOptions options;
+
+  @Override
+  public Result<PCollection<PubsubMessage>, PubsubMessage> expand(
+      PCollection<PubsubMessage> input) {
+    final List<PCollection<PubsubMessage>> failureCollections = new ArrayList<>();
+
+    PCollection<PubsubMessage> output = input //
+        .apply(ParseLogEntry.of()).failuresTo(failureCollections) //
+        // ParseUri also appears in the Decoder after AET decryption,
+        // but we have a redundant step here so that if there's a failure, we're able to
+        // sanitize the payload before sending to error output.
+        .apply("AetParseUri", ParseUri.of()).failuresTo(failureCollections) //
+        .apply(DecryptAetIdentifiers //
+            .of(options.getAetMetadataLocation(), options.getAetKmsEnabled())) //
+        .failuresTo(failureCollections);
+
+    // Flatten and sanitize error collections.
+    PCollection<PubsubMessage> errors = PCollectionList.of(failureCollections) //
+        .apply("FlattenAetFailureCollections", Flatten.pCollections()) //
+        .apply("SanitizeJsonPayload", SanitizeJsonPayload.of());
+
+    return WithFailures.Result.of(output, errors);
+  }
+
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/aet/DecryptAetIdentifiers.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/aet/DecryptAetIdentifiers.java
@@ -76,6 +76,8 @@ public class DecryptAetIdentifiers extends
   private final Counter successStructured = Metrics.counter(DecryptAetIdentifiers.class,
       "success_structured");
 
+  public static final String ACCOUNT_ECOSYSTEM = "account-ecosystem";
+
   public static DecryptAetIdentifiers of(ValueProvider<String> metadataLocation,
       ValueProvider<Boolean> kmsEnabled) {
     return new DecryptAetIdentifiers(metadataLocation, kmsEnabled);
@@ -233,14 +235,14 @@ public class DecryptAetIdentifiers extends
 
       try {
         if (Namespace.TELEMETRY.equals(namespace) && //
-            docType != null && docType.startsWith("account-ecosystem")) {
+            docType != null && docType.startsWith(ACCOUNT_ECOSYSTEM)) {
           processDesktopTelemetryPayload(json);
           successTelemetry.inc();
         } else if (false) {
           // Placeholder condition for handling AET payloads coming from Glean-enabled applications;
           // design is evolving in https://bugzilla.mozilla.org/show_bug.cgi?id=1634468
           successGlean.inc();
-        } else if (docType != null && docType.startsWith("account-ecosystem")) {
+        } else if (docType != null && docType.startsWith(ACCOUNT_ECOSYSTEM)) {
           processStructuredIngestionPayload(json);
           successStructured.inc();
         } else {

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/aet/DecryptAetIdentifiers.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/aet/DecryptAetIdentifiers.java
@@ -90,30 +90,30 @@ public class DecryptAetIdentifiers extends
   /**
    * Base class for all exceptions thrown by this class.
    */
-  abstract static class DecryptAetPayloadException extends RuntimeException {
+  abstract static class DecryptAetIdentifiersException extends RuntimeException {
 
-    private DecryptAetPayloadException() {
+    private DecryptAetIdentifiersException() {
     }
 
-    private DecryptAetPayloadException(Throwable cause) {
+    private DecryptAetIdentifiersException(Throwable cause) {
       super(cause);
     }
   }
 
-  public static class UnparsableAetPayloadException extends DecryptAetPayloadException {
+  public static class UnparsableAetPayloadException extends DecryptAetIdentifiersException {
 
     public UnparsableAetPayloadException(Exception cause) {
       super(cause);
     }
   }
 
-  public static class IllegalAetUriException extends DecryptAetPayloadException {
+  public static class IllegalAetUriException extends DecryptAetIdentifiersException {
 
     public IllegalAetUriException() {
     }
   }
 
-  public static class IllegalAetPayloadException extends DecryptAetPayloadException {
+  public static class IllegalAetPayloadException extends DecryptAetIdentifiersException {
 
     public IllegalAetPayloadException(Exception cause) {
       super(cause);
@@ -129,8 +129,8 @@ public class DecryptAetIdentifiers extends
         .exceptionsVia((WithFailures.ExceptionElement<PubsubMessage> ee) -> {
           try {
             throw ee.exception();
-          } catch (DecryptAetPayloadException e) {
-            return FailureMessage.of(DecryptAetPayloadException.class.getSimpleName(), ee.element(),
+          } catch (DecryptAetIdentifiersException e) {
+            return FailureMessage.of(DecryptAetIdentifiers.class.getSimpleName(), ee.element(),
                 ee.exception());
           }
         }));

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/aet/DecryptAetIdentifiers.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/aet/DecryptAetIdentifiers.java
@@ -231,12 +231,6 @@ public class DecryptAetIdentifiers extends
       String namespace = message.getAttribute(Attribute.DOCUMENT_NAMESPACE);
       String docType = message.getAttribute(Attribute.DOCUMENT_TYPE);
 
-      // This transform comes early in the Decoder job before ParseUri, so we must work with
-      // the raw URI rather than parsed namespace and doctype.
-      // In particular, ParseUri is the first transform that can send messages to error output;
-      // we risk spilling sensitive information if AET payloads get sent to an output before anon_id
-      // values are removed, so we must have this transform come before an error step so that we
-      // can handle sanitizing/dropping the payload before emitting errors.
       try {
         if (Namespace.TELEMETRY.equals(namespace) && //
             docType != null && docType.startsWith("account-ecosystem")) {

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/aet/SanitizeJsonPayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/aet/SanitizeJsonPayload.java
@@ -1,0 +1,80 @@
+package com.mozilla.telemetry.aet;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.mozilla.telemetry.util.Json;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+public class SanitizeJsonPayload {
+
+  /**
+   * Return a redacted value if the given node represents a long string.
+   *
+   * <p>Strings longer than 32 characters might be ecosystem_anon_id values, so we want to make
+   * sure they are not propagated to error output.
+   */
+  private static JsonNode redactedNode(JsonNode node) {
+    String value = node.textValue();
+    if (value != null && value.length() > 32) {
+      return TextNode.valueOf(
+          String.format("%s<%d characters redacted>", value.substring(0, 4), value.length() - 4));
+    } else {
+      return node;
+    }
+  }
+
+  /**
+   * Recursively walk a JSON tree, redacting long string values.
+   */
+  @VisibleForTesting
+  static void sanitizeJsonNode(JsonNode node) {
+    if (node.isObject()) {
+      List<Entry<String, JsonNode>> fields = Lists.newArrayList(node.fields());
+      for (Map.Entry<String, JsonNode> entry : fields) {
+        String fieldName = entry.getKey();
+        JsonNode value = entry.getValue();
+        ((ObjectNode) node).set(fieldName, redactedNode(value));
+      }
+    }
+    if (node.isArray()) {
+      List<JsonNode> elements = Lists.newArrayList(node.elements());
+      for (int i = 0; i < elements.size(); i++) {
+        JsonNode value = elements.get(i);
+        if (value.isTextual() && value.asText().length() > 32) {
+          ((ArrayNode) node).set(i, redactedNode(value));
+        }
+      }
+    }
+
+    // Recursively sanitize objects and arrays.
+    if (node.isContainerNode()) {
+      node.elements().forEachRemaining(SanitizeJsonPayload::sanitizeJsonNode);
+    }
+  }
+
+  /** Return SantizeJsonPayload transform. */
+  public static MapElements<PubsubMessage, PubsubMessage> of() {
+    return MapElements.into(TypeDescriptor.of(PubsubMessage.class)).via((PubsubMessage message) -> {
+      byte[] sanitizedPayload;
+      try {
+        ObjectNode json = Json.readObjectNode(message.getPayload());
+        sanitizeJsonNode(json);
+        sanitizedPayload = Json.asBytes(json);
+      } catch (IOException ignore) {
+        sanitizedPayload = null;
+      }
+      return new PubsubMessage(sanitizedPayload, message.getAttributeMap());
+    });
+  }
+
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/aet/AetProcessingTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/aet/AetProcessingTest.java
@@ -1,0 +1,79 @@
+package com.mozilla.telemetry.aet;
+
+import static com.mozilla.telemetry.aet.DecryptAetIdentifiersTest.encryptWithTestPublicKey;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import com.mozilla.telemetry.decoder.DecoderOptions;
+import com.mozilla.telemetry.decoder.DecoderOptions.Parsed;
+import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import com.mozilla.telemetry.options.InputFileFormat;
+import com.mozilla.telemetry.options.OutputFileFormat;
+import com.mozilla.telemetry.util.Json;
+import com.mozilla.telemetry.util.TestWithDeterministicJson;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.WithFailures.Result;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AetProcessingTest extends TestWithDeterministicJson {
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testOutputTelemetry() throws Exception {
+    // minimal test for throughput of a single document
+    DecoderOptions decoderOptions = pipeline.getOptions().as(DecoderOptions.class);
+    decoderOptions.setAetEnabled(true);
+    decoderOptions.setAetMetadataLocation(pipeline
+        .newProvider(Resources.getResource("account-ecosystem/metadata-local.json").getPath()));
+    decoderOptions.setAetKmsEnabled(pipeline.newProvider(false));
+    Parsed options = DecoderOptions.parseDecoderOptions(decoderOptions);
+    String userId = "2ef67665ec7369ba0fab7f802a5e1e04";
+    String anonId = encryptWithTestPublicKey(userId);
+    List<String> prevUserIds = ImmutableList.of("3ef67665ec7369ba0fab7f802a5e1e04",
+        "4ef67665ec7369ba0fab7f802a5e1e04");
+    List<String> prevAnonIds = prevUserIds.stream().map(x -> {
+      try {
+        return encryptWithTestPublicKey(x);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }).collect(Collectors.toList());
+    String input = Json.asString(ImmutableMap.of("payload",
+        ImmutableMap.builder().put("ecosystemAnonId", anonId)
+            .put("ecosystemClientId", "3ed15efab7e94757bf9e9ef5e844ada2")
+            .put("ecosystemDeviceId", "7ab4e373ce434b848a9d0946e388fee9")
+            .put("previousEcosystemAnonIds", prevAnonIds).build()));
+    String expected = Json.asString(ImmutableMap.of("payload",
+        ImmutableMap.builder().put("ecosystemUserId", userId)
+            .put("ecosystemClientId", "3ed15efab7e94757bf9e9ef5e844ada2")
+            .put("ecosystemDeviceId", "7ab4e373ce434b848a9d0946e388fee9")
+            .put("previousEcosystemUserIds", prevUserIds).build()));
+    Result<PCollection<PubsubMessage>, PubsubMessage> result = pipeline.apply(Create.of(input))
+        .apply(InputFileFormat.text.decode())
+        .apply("AddAttributes",
+            MapElements.into(TypeDescriptor.of(PubsubMessage.class))
+                .via(element -> new PubsubMessage(element.getPayload(),
+                    ImmutableMap.of(Attribute.SUBMISSION_TIMESTAMP, "2020-01-01 12:00:00",
+                        Attribute.URI,
+                        "/submit/telemetry/ce39b608-f595-4c69-b6a6-f7a436604648"
+                            + "/account-ecosystem/Firefox/61.0a1/nightly/20180328030202"))))
+        .apply(AetProcessing.of(options));
+    PAssert.that(result.failures()).empty();
+    PAssert.that(result.output().apply(OutputFileFormat.text.encode()))
+        .containsInAnyOrder(ImmutableList.of(expected));
+    pipeline.run();
+  }
+
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/aet/DecryptAetIdentifiersTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/aet/DecryptAetIdentifiersTest.java
@@ -46,7 +46,8 @@ public class DecryptAetIdentifiersTest extends TestWithDeterministicJson {
     return PublicJsonWebKey.Factory.newPublicJwk(new String(data));
   }
 
-  private static String encryptWithTestPublicKey(String payload) throws Exception {
+  /** Encrypt a string using a key stored in test resources. */
+  static String encryptWithTestPublicKey(String payload) throws Exception {
     PublicJsonWebKey key = loadPublicKey("account-ecosystem/testkey1.public.json");
     JsonWebEncryption jwe = new JsonWebEncryption();
     jwe.setKey(key.getKey());

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/aet/DecryptAetIdentifiersTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/aet/DecryptAetIdentifiersTest.java
@@ -68,18 +68,6 @@ public class DecryptAetIdentifiersTest extends TestWithDeterministicJson {
     assertEquals(expected, actual);
   }
 
-  @Test
-  public void testSanitizeJsonNode() throws Exception {
-    String userId = "2ef67665ec7369ba0fab7f802a5e1e04";
-    String anonId = encryptWithTestPublicKey(userId);
-    ObjectNode json = Json.asObjectNode(
-        ImmutableMap.of("payload", ImmutableMap.of("myList", ImmutableList.of("foo", anonId))));
-    ObjectNode expected = Json.asObjectNode(ImmutableMap.of("payload",
-        ImmutableMap.of("myList", ImmutableList.of("foo", "eyJr<435 characters redacted>"))));
-    DecryptAetIdentifiers.sanitizeJsonNode(json);
-    assertEquals(Json.asString(expected), Json.asString(json));
-  }
-
   @Test(expected = ValidationException.class)
   public void testForbiddenFieldsStructured() throws Exception {
     JsonValidator validator = new JsonValidator();
@@ -124,9 +112,8 @@ public class DecryptAetIdentifiersTest extends TestWithDeterministicJson {
         .apply("AddAttributes",
             MapElements.into(TypeDescriptor.of(PubsubMessage.class))
                 .via(element -> new PubsubMessage(element.getPayload(),
-                    ImmutableMap.of(Attribute.URI,
-                        "/submit/firefox-accounts/account-ecosystem/1/"
-                            + "8299c050-6be8-4197-8a0b-fd1062a11da4"))))
+                    ImmutableMap.of(Attribute.DOCUMENT_NAMESPACE, "firefox-accounts",
+                        Attribute.DOCUMENT_TYPE, "account-ecosystem"))))
         .apply(DecryptAetIdentifiers.of(metadataLocation, kmsEnabled));
     PAssert.that(result.failures()).empty();
     PAssert.that(result.output().apply(OutputFileFormat.text.encode()))
@@ -167,9 +154,8 @@ public class DecryptAetIdentifiersTest extends TestWithDeterministicJson {
         .apply("AddAttributes",
             MapElements.into(TypeDescriptor.of(PubsubMessage.class))
                 .via(element -> new PubsubMessage(element.getPayload(),
-                    ImmutableMap.of(Attribute.URI,
-                        "/submit/telemetry/ce39b608-f595-4c69-b6a6-f7a436604648"
-                            + "/account-ecosystem/Firefox/61.0a1/nightly/20180328030202"))))
+                    ImmutableMap.of(Attribute.DOCUMENT_NAMESPACE, "telemetry",
+                        Attribute.DOCUMENT_TYPE, "account-ecosystem"))))
         .apply(DecryptAetIdentifiers.of(metadataLocation, kmsEnabled));
     PAssert.that(result.failures()).empty();
     PAssert.that(result.output().apply(OutputFileFormat.text.encode()))
@@ -211,13 +197,12 @@ public class DecryptAetIdentifiersTest extends TestWithDeterministicJson {
         .apply("AddAttributes",
             MapElements.into(TypeDescriptor.of(PubsubMessage.class))
                 .via(element -> new PubsubMessage(element.getPayload(),
-                    ImmutableMap.of(Attribute.URI,
-                        "/submit/firefox-accounts/account-ecosystem/1/"
-                            + "8299c050-6be8-4197-8a0b-fd1062a11da4"))))
+                    ImmutableMap.of(Attribute.DOCUMENT_NAMESPACE, "firefox-accounts",
+                        Attribute.DOCUMENT_TYPE, "account-ecosystem"))))
         .apply(DecryptAetIdentifiers.of(metadataLocation, kmsEnabled));
     PAssert.that(result.output()).empty();
-    PAssert.that(result.failures().apply(OutputFileFormat.text.encode()))
-        .containsInAnyOrder(ImmutableList.of(expected));
+    PAssert.that(result.failures().apply("Sanitize", SanitizeJsonPayload.of())
+        .apply(OutputFileFormat.text.encode())).containsInAnyOrder(ImmutableList.of(expected));
     pipeline.run();
   }
 
@@ -260,14 +245,13 @@ public class DecryptAetIdentifiersTest extends TestWithDeterministicJson {
         .apply("AddAttributes",
             MapElements.into(TypeDescriptor.of(PubsubMessage.class))
                 .via(element -> new PubsubMessage(element.getPayload(),
-                    ImmutableMap.of(Attribute.URI,
-                        "/submit/telemetry/ce39b608-f595-4c69-b6a6-f7a436604648"
-                            + "/account-ecosystem/Firefox/61.0a1/nightly/20180328030202"))))
+                    ImmutableMap.of(Attribute.DOCUMENT_NAMESPACE, "telemetry",
+                        Attribute.DOCUMENT_TYPE, "account-ecosystem"))))
         .apply(DecryptAetIdentifiers.of(metadataLocation, kmsEnabled));
     PAssert.that(result.output().apply("EncodeOutput", OutputFileFormat.text.encode()))
         .containsInAnyOrder(expectedOutput);
-    PAssert.that(result.failures().apply("EncodeErrors", OutputFileFormat.text.encode()))
-        .containsInAnyOrder(expectedError);
+    PAssert.that(result.failures().apply("Sanitize", SanitizeJsonPayload.of()).apply("EncodeErrors",
+        OutputFileFormat.text.encode())).containsInAnyOrder(expectedError);
     pipeline.run();
   }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/aet/SanitizeJsonPayloadTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/aet/SanitizeJsonPayloadTest.java
@@ -1,0 +1,24 @@
+package com.mozilla.telemetry.aet;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.mozilla.telemetry.util.Json;
+import org.junit.Test;
+
+public class SanitizeJsonPayloadTest {
+
+  @Test
+  public void testSanitizeJsonNode() {
+    String anonId = "eyJrbGciOiJFQ0RILUVTK0EyNTZLVyIsImVuYyI6IkEyNTZHQ00iLCJlc0EyNTZLVyIsImVuYyI6I";
+    ObjectNode json = Json.asObjectNode(
+        ImmutableMap.of("payload", ImmutableMap.of("myList", ImmutableList.of("foo", anonId))));
+    ObjectNode expected = Json.asObjectNode(ImmutableMap.of("payload",
+        ImmutableMap.of("myList", ImmutableList.of("foo", "eyJr<73 characters redacted>"))));
+    SanitizeJsonPayload.sanitizeJsonNode(json);
+    assertEquals(Json.asString(expected), Json.asString(json));
+  }
+
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseLogEntryTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseLogEntryTest.java
@@ -33,7 +33,7 @@ public class ParseLogEntryTest extends TestWithDeterministicJson {
 
     PCollection<PubsubMessage> output = pipeline
         .apply(new FileInput(StaticValueProvider.of(input), InputFileFormat.json))
-        .apply(ParseLogEntry.of());
+        .apply(ParseLogEntry.of()).output();
 
     PAssert.that(output.apply(OutputFileFormat.text.encode()))
         .containsInAnyOrder(ImmutableList.of(expected));


### PR DESCRIPTION
Currently, the DecryptAetIdentifiers transform has responsibility for parsing
URIs and sanitizing errors before passing them to error output.

This change refactors the error handling logic so that we can properly use the
ParseUri transform, allowing its errors and DecryptAetIdentifiers' errors to
all flow through sanitization logic before heading to error output.

This also sets the stage for us to be able to look up decryption mappings in
JSON schemas since we'll have the parsed doctype info ready to go.