### PR TITLE
Fix dependabot config causing duplicate PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,24 +10,6 @@ updates:
   labels:
   - dependencies
   - java
-- package-ecosystem: maven
-  directory: /ingestion-beam
-  schedule:
-    interval: daily
-  reviewers:
-  - jklukas
-  labels:
-  - dependencies
-  - java
-- package-ecosystem: maven
-  directory: /ingestion-sink
-  schedule:
-    interval: daily
-  reviewers:
-  - relud
-  labels:
-  - dependencies
-  - java
 - package-ecosystem: pip
   directory: /ingestion-edge
   schedule:


### PR DESCRIPTION
dependabot scans maven dependencies, so configuring ingestion-{beam,sink} separately was causing duplicates