### PR TITLE
Set docker version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
     - &setup_remote_docker
       setup_remote_docker:
         docker_layer_caching: true
+        version: 19.03.13
     - &create_version_json
       run:
         name: Create version.json


### PR DESCRIPTION
This explicitly sets the Docker version. If we don't set the version,
CircleCI defaults to using 17.03.0 which is a version that CircleCI is
deprecating.

https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572