### PR TITLE
Fix yaml type of ssh key fingerprints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
         command: sudo pip install mkdocs markdown-include
     - add_ssh_keys:
         fingerprints:
-          "84:b0:66:dd:ec:68:b1:45:9d:5d:66:fd:4a:4f:1b:57"
+        - "84:b0:66:dd:ec:68:b1:45:9d:5d:66:fd:4a:4f:1b:57"
     - run:
         name: Build and deploy docs
         command: |


### PR DESCRIPTION
the docs indicate that `fingerprints` is supposed to be an array: https://circleci.com/docs/2.0/configuration-reference/#add_ssh_keys