### PR TITLE
Add build option to ingestion-sink to create standalone jar

### DIFF
--- a/ingestion-sink/pom.xml
+++ b/ingestion-sink/pom.xml
@@ -172,6 +172,26 @@
                     <skip>false</skip>
                 </configuration>
             </plugin>
+            <!-- Create an uber jar for standalone usage. https://stackoverflow.com/a/16222971 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>assemble-all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This generates a standalone jar with all of the dependencies included for use in mozilla-pipeline-schemas for CI. See https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/645.

The jars from each build should get uploaded to a public GCS bucket so it can be fetched the the mps docker container. The jar is ~40mb.

```
% ls -alh target/*.jar
-rw-r--r--  1 amiyaguchi  staff    40M Nov 30 14:20 target/ingestion-sink-0.1-SNAPSHOT-jar-with-dependencies.jar
-rw-r--r--  1 amiyaguchi  staff   151K Nov 30 14:20 target/ingestion-sink-0.1-SNAPSHOT.jar
```