### PR TITLE
Bug 1684980 - Ignore non-Glean user agents from firefox-desktop

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -79,6 +79,7 @@ public class MessageScrubber {
     final String appVersion = attributes.get(Attribute.APP_VERSION);
     final String appUpdateChannel = attributes.get(Attribute.APP_UPDATE_CHANNEL);
     final String appBuildId = attributes.get(Attribute.APP_BUILD_ID);
+    final String userAgent = attributes.get(Attribute.USER_AGENT);
 
     // Check for toxic data that should be dropped without sending to error output.
     if (ParseUri.TELEMETRY.equals(namespace) && "crash".equals(docType)
@@ -132,8 +133,7 @@ public class MessageScrubber {
 
     // Glean enforces a particular user-agent string that a rogue fuzzer is not abiding by
     // https://searchfox.org/mozilla-central/source/third_party/rust/glean-core/src/upload/request.rs#35,72-75
-    if (attributes.get(Attribute.DOCUMENT_NAMESPACE).equals("firefox-desktop")
-        && !attributes.get(Attribute.USER_AGENT).startsWith("Glean")) {
+    if ("firefox-desktop".equals(namespace) && !userAgent.startsWith("Glean")) {
       throw new UnwantedDataException("1684980");
     }
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -130,6 +130,13 @@ public class MessageScrubber {
       throw new UnwantedDataException("1592010");
     }
 
+    // Glean enforces a particular user-agent string that a rogue fuzzer is not abiding by
+    // https://searchfox.org/mozilla-central/source/third_party/rust/glean-core/src/upload/request.rs#35,72-75
+    if (attributes.get(Attribute.DOCUMENT_NAMESPACE).equals("firefox-desktop")
+        && !attributes.get(Attribute.USER_AGENT).startsWith("Glean")) {
+      throw new UnwantedDataException("1684980");
+    }
+
     // Check for other signatures that we want to send to error output, but which should appear
     // in normal pipeline monitoring.
     if (bug1489560Affected(attributes, json)) {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -534,4 +534,32 @@ public class MessageScrubberTest {
     assertThrows(UnwantedDataException.class,
         () -> MessageScrubber.scrubByUri("/submit/sslreports/"));
   }
+
+  @Test
+  public void testUnwantedData1684980GleanUserAgent() {
+    Map<String, String> mozAttributes = ImmutableMap.<String, String>builder()
+        .put(Attribute.DOCUMENT_NAMESPACE, "firefox-desktop") //
+        .put(Attribute.USER_AGENT,
+            "Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0")
+        .build();
+
+    assertThrows(UnwantedDataException.class,
+        () -> MessageScrubber.scrub(mozAttributes, Json.createObjectNode()));
+
+    // empty agent strings are also scrubbed
+    Map<String, String> emptyAtrributes = ImmutableMap.<String, String>builder()
+        .put(Attribute.DOCUMENT_NAMESPACE, "firefox-desktop") //
+        .put(Attribute.USER_AGENT, "") //
+        .build();
+
+    assertThrows(UnwantedDataException.class,
+        () -> MessageScrubber.scrub(emptyAtrributes, Json.createObjectNode()));
+
+    Map<String, String> gleanAtrributes = ImmutableMap.<String, String>builder()
+        .put(Attribute.DOCUMENT_NAMESPACE, "firefox-desktop") //
+        .put(Attribute.USER_AGENT, "Glean/33.9.1 (Rust on Windows)") //
+        .build();
+
+    MessageScrubber.scrub(gleanAtrributes, Json.createObjectNode());
+  }
 }


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1684980)