### PR TITLE
Bug 1691807 - Allow decryption of objects in rally meta pings

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/DecryptPioneerPayloads.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/DecryptPioneerPayloads.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.FlatMapElements;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -130,6 +131,9 @@ public class DecryptPioneerPayloads extends
       ObjectNode json = Json.readObjectNode(message.getPayload());
       validator.validate(envelopeSchema, json);
       JsonNode payload = json.get(FieldName.PAYLOAD);
+      final String namespace = payload.get(SCHEMA_NAMESPACE).asText();
+      final String schemaName = payload.get(SCHEMA_NAME).asText();
+      final String schemaVersion = payload.get(SCHEMA_VERSION).asText();
 
       byte[] payloadData;
       try {
@@ -149,8 +153,13 @@ public class DecryptPioneerPayloads extends
           payloadData = decrypted;
         }
       } catch (IOException | JoseException e) {
-        if (payload.get(SCHEMA_NAME).asText().equals(DELETION_REQUEST_SCHEMA_NAME)
-            || payload.get(SCHEMA_NAME).asText().equals(ENROLLMENT_SCHEMA_NAME)) {
+        if (schemaName.equals(DELETION_REQUEST_SCHEMA_NAME)
+            || schemaName.equals(ENROLLMENT_SCHEMA_NAME)) {
+          // keep track of these exceptions, which are the cases where we
+          // were unable to decrypt the content and push it through anyways
+          // to ensure delivery of requests.
+          String label = String.format("%s.%s.%s", namespace, schemaName, schemaVersion);
+          Metrics.counter(DecryptPioneerPayloads.class, label).inc();
           // The deletion-request and enrollment pings are special cased within
           // the decryption pipeline. The Pioneer client requires a JWE payload to
           // exist before it can be sent. The encrypted data is the empty string
@@ -177,10 +186,9 @@ public class DecryptPioneerPayloads extends
 
       // Redirect messages via attributes
       Map<String, String> attributes = new HashMap<String, String>(message.getAttributeMap());
-      attributes.put(Attribute.DOCUMENT_NAMESPACE,
-          resolveInvalidNamespace(payload.get(SCHEMA_NAMESPACE).asText()));
-      attributes.put(Attribute.DOCUMENT_TYPE, payload.get(SCHEMA_NAME).asText());
-      attributes.put(Attribute.DOCUMENT_VERSION, payload.get(SCHEMA_VERSION).asText());
+      attributes.put(Attribute.DOCUMENT_NAMESPACE, resolveInvalidNamespace(namespace));
+      attributes.put(Attribute.DOCUMENT_TYPE, schemaName);
+      attributes.put(Attribute.DOCUMENT_VERSION, schemaVersion);
       return Collections.singletonList(new PubsubMessage(merged, attributes));
     }
   }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DecryptPioneerPayloadsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DecryptPioneerPayloadsTest.java
@@ -270,4 +270,65 @@ public class DecryptPioneerPayloadsTest extends TestWithDeterministicJson {
     PAssert.that(output).containsInAnyOrder(expectedNamespaces);
     pipeline.run();
   }
+
+  @Test
+  public void testBug1691807EnrollmentDeletionPayloadsSuccess() throws Exception {
+    // test valid payloads within the enrollment and deletion request
+    ValueProvider<String> metadataLocation = pipeline
+        .newProvider(Resources.getResource("pioneer/metadata-local.json").getPath());
+    ValueProvider<Boolean> kmsEnabled = pipeline.newProvider(false);
+    ValueProvider<Boolean> decompressPayload = pipeline.newProvider(true);
+
+    final List<String> input = readTestFiles(
+        Arrays.asList("pioneer/bug-1691807.pioneer-enrollment.valid.study-bar.ciphertext.json",
+            "pioneer/bug-1691807.deletion-request.valid.study-bar.ciphertext.json"));
+
+    Result<PCollection<PubsubMessage>, PubsubMessage> result = pipeline.apply(Create.of(input))
+        .apply(InputFileFormat.text.decode())
+        .apply("AddAttributes", MapElements.into(TypeDescriptor.of(PubsubMessage.class))
+            .via(element -> new PubsubMessage(element.getPayload(),
+                ImmutableMap.of(Attribute.DOCUMENT_NAMESPACE, "telemetry", Attribute.DOCUMENT_TYPE,
+                    "pioneer-study", Attribute.DOCUMENT_VERSION, "4"))))
+        .apply(DecryptPioneerPayloads.of(metadataLocation, kmsEnabled, decompressPayload));
+
+    PAssert.that(result.failures()).empty();
+    pipeline.run();
+
+    PCollection<String> output = result.output().apply(OutputFileFormat.text.encode())
+        .apply(ReformatJson.of());
+    final List<String> expectedMain = readTestFiles(
+        Arrays.asList("pioneer/sample.plaintext.json", "pioneer/sample.plaintext.json"));
+    PAssert.that(output).containsInAnyOrder(expectedMain);
+    pipeline.run();
+  }
+
+  @Test
+  public void testBug1691807EnrollmentDeletionPayloadsFailures() throws Exception {
+    // test valid payloads within the enrollment and deletion request
+    ValueProvider<String> metadataLocation = pipeline
+        .newProvider(Resources.getResource("pioneer/metadata-local.json").getPath());
+    ValueProvider<Boolean> kmsEnabled = pipeline.newProvider(false);
+    ValueProvider<Boolean> decompressPayload = pipeline.newProvider(true);
+
+    final List<String> input = readTestFiles(
+        Arrays.asList("pioneer/bug-1691807.pioneer-enrollment.invalid.study-bar.ciphertext.json",
+            "pioneer/bug-1691807.deletion-request.invalid.study-bar.ciphertext.json"));
+
+    Result<PCollection<PubsubMessage>, PubsubMessage> result = pipeline.apply(Create.of(input))
+        .apply(InputFileFormat.text.decode())
+        .apply("AddAttributes", MapElements.into(TypeDescriptor.of(PubsubMessage.class))
+            .via(element -> new PubsubMessage(element.getPayload(),
+                ImmutableMap.of(Attribute.DOCUMENT_NAMESPACE, "telemetry", Attribute.DOCUMENT_TYPE,
+                    "pioneer-study", Attribute.DOCUMENT_VERSION, "4"))))
+        .apply(DecryptPioneerPayloads.of(metadataLocation, kmsEnabled, decompressPayload));
+
+    PAssert.that(result.output()).empty();
+    pipeline.run();
+
+    PCollection<String> exceptions = result.failures().apply(MapElements
+        .into(TypeDescriptors.strings()).via(message -> message.getAttribute("exception_class")));
+    // IntegrityException extends JoseException
+    PAssert.that(exceptions).containsInAnyOrder("org.jose4j.lang.JoseException",
+        "org.jose4j.lang.JoseException");
+  }
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DecryptPioneerPayloadsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/DecryptPioneerPayloadsTest.java
@@ -322,13 +322,13 @@ public class DecryptPioneerPayloadsTest extends TestWithDeterministicJson {
                     "pioneer-study", Attribute.DOCUMENT_VERSION, "4"))))
         .apply(DecryptPioneerPayloads.of(metadataLocation, kmsEnabled, decompressPayload));
 
-    PAssert.that(result.output()).empty();
+    PAssert.that(result.failures()).empty();
     pipeline.run();
 
-    PCollection<String> exceptions = result.failures().apply(MapElements
-        .into(TypeDescriptors.strings()).via(message -> message.getAttribute("exception_class")));
-    // IntegrityException extends JoseException
-    PAssert.that(exceptions).containsInAnyOrder("org.jose4j.lang.JoseException",
-        "org.jose4j.lang.JoseException");
+    PCollection<String> output = result.output().apply(OutputFileFormat.text.encode())
+        .apply(ReformatJson.of());
+    final List<String> expectedMain = Arrays.asList("{}", "{}");
+    PAssert.that(output).containsInAnyOrder(expectedMain);
+    pipeline.run();
   }
 }

--- a/ingestion-beam/src/test/resources/pioneer/bug-1691807.deletion-request.invalid.study-bar.ciphertext.json
+++ b/ingestion-beam/src/test/resources/pioneer/bug-1691807.deletion-request.invalid.study-bar.ciphertext.json
@@ -1,0 +1,26 @@
+{
+  "type": "pioneer-study",
+  "id": "9af045aa-80ca-e743-92de-b31431abc547",
+  "creationDate": "2020-04-24T20:04:10.285Z",
+  "version": 4,
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20200415104457",
+    "name": "Firefox",
+    "version": "77.0a1",
+    "displayVersion": "77.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "77.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "default"
+  },
+  "payload": {
+    "encryptedData": "eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSIsImVwayI6eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6IlZuTllQN29BbTBMb0xTM3FDQWFiN3ItOVQyT2hUR0hhRnA1YmVFR3hiNXMiLCJ5IjoiQzFtRFk3VDNWb2p5RWNvVWJ2YzU3U2Y4Xzk4NXVGWHNZbmVlUHo1dzI3SSJ9LCJraWQiOiJJRGh0VmtTOURFaHUtVEVZR1ZqX0ZxMmRpUEdDdkt3bFEwZW14aTFFWWV3IiwidHlwIjoiSldFIn0..sqS5vgbScAInfqdZ.YhkQn9VoMdc5hKdF2twY72jX0bAq8UmBf_LGRfWkcKBbv9VIMnykRKGJ50bAaxOW8V_Mhd-W5Ynwsgh6W3UvMwVSOZkJFJgss7cZlkGfDg.nWsJBryP1QSkJp5DH-SS6g",
+    "encryptionKeyId": "study-bar",
+    "schemaNamespace": "study-bar",
+    "schemaName": "deletion-request",
+    "schemaVersion": 1,
+    "pioneerId": "9af045aa-80ca-e743-92de-b31431abc547",
+    "studyName": "pioneer-v2-example@example.com"
+  }
+}

--- a/ingestion-beam/src/test/resources/pioneer/bug-1691807.deletion-request.valid.study-bar.ciphertext.json
+++ b/ingestion-beam/src/test/resources/pioneer/bug-1691807.deletion-request.valid.study-bar.ciphertext.json
@@ -1,0 +1,26 @@
+{
+  "type": "pioneer-study",
+  "id": "9af045aa-80ca-e743-92de-b31431abc547",
+  "creationDate": "2020-04-24T20:04:10.285Z",
+  "version": 4,
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20200415104457",
+    "name": "Firefox",
+    "version": "77.0a1",
+    "displayVersion": "77.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "77.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "default"
+  },
+  "payload": {
+    "encryptedData": "eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSIsImVwayI6eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImhXUWdlTTVWOXZid2ZfZFV4V3hwWFMxdmVIb2g3dHlmVUdhN3NBOFRzWnciLCJ5IjoiMVR0MXRqVDYxdzRyWm9sSllGd0djYnlQNkcxRjUtM0pMd2pfam1Ua1JKSSJ9LCJraWQiOiIzcDhTQ3R5cmEwdV9CLWhMRTdaTm5GcjNFZDBjMTVLdkNEcUxrN2Rpblc4IiwidHlwIjoiSldFIn0..tOiU2P5Fc3ER1U1Y.rrOuQai8iSTIcTT_OrvdGKNBj06Eu9KdM_ewjWZ8st0iEjT8Jsby1lsIjSQkwJsfWOoACZ2um-OBAAiFesIbesdWz0ldD9UTeSGcJQ6Uyw.-obDckIMilQ4WHYjeXUU9g",
+    "encryptionKeyId": "study-bar",
+    "schemaNamespace": "study-bar",
+    "schemaName": "deletion-request",
+    "schemaVersion": 1,
+    "pioneerId": "9af045aa-80ca-e743-92de-b31431abc547",
+    "studyName": "pioneer-v2-example@example.com"
+  }
+}

--- a/ingestion-beam/src/test/resources/pioneer/bug-1691807.pioneer-enrollment.invalid.study-bar.ciphertext.json
+++ b/ingestion-beam/src/test/resources/pioneer/bug-1691807.pioneer-enrollment.invalid.study-bar.ciphertext.json
@@ -1,0 +1,26 @@
+{
+  "type": "pioneer-study",
+  "id": "9af045aa-80ca-e743-92de-b31431abc547",
+  "creationDate": "2020-04-24T20:04:10.285Z",
+  "version": 4,
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20200415104457",
+    "name": "Firefox",
+    "version": "77.0a1",
+    "displayVersion": "77.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "77.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "default"
+  },
+  "payload": {
+    "encryptedData": "eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSIsImVwayI6eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6IlZuTllQN29BbTBMb0xTM3FDQWFiN3ItOVQyT2hUR0hhRnA1YmVFR3hiNXMiLCJ5IjoiQzFtRFk3VDNWb2p5RWNvVWJ2YzU3U2Y4Xzk4NXVGWHNZbmVlUHo1dzI3SSJ9LCJraWQiOiJJRGh0VmtTOURFaHUtVEVZR1ZqX0ZxMmRpUEdDdkt3bFEwZW14aTFFWWV3IiwidHlwIjoiSldFIn0..sqS5vgbScAInfqdZ.YhkQn9VoMdc5hKdF2twY72jX0bAq8UmBf_LGRfWkcKBbv9VIMnykRKGJ50bAaxOW8V_Mhd-W5Ynwsgh6W3UvMwVSOZkJFJgss7cZlkGfDg.nWsJBryP1QSkJp5DH-SS6g",
+    "encryptionKeyId": "study-bar",
+    "schemaNamespace": "study-bar",
+    "schemaName": "pioneer-enrollment",
+    "schemaVersion": 1,
+    "pioneerId": "9af045aa-80ca-e743-92de-b31431abc547",
+    "studyName": "pioneer-v2-example@example.com"
+  }
+}

--- a/ingestion-beam/src/test/resources/pioneer/bug-1691807.pioneer-enrollment.valid.study-bar.ciphertext.json
+++ b/ingestion-beam/src/test/resources/pioneer/bug-1691807.pioneer-enrollment.valid.study-bar.ciphertext.json
@@ -1,0 +1,26 @@
+{
+  "type": "pioneer-study",
+  "id": "9af045aa-80ca-e743-92de-b31431abc547",
+  "creationDate": "2020-04-24T20:04:10.285Z",
+  "version": 4,
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20200415104457",
+    "name": "Firefox",
+    "version": "77.0a1",
+    "displayVersion": "77.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "77.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "default"
+  },
+  "payload": {
+    "encryptedData": "eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSIsImVwayI6eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImhXUWdlTTVWOXZid2ZfZFV4V3hwWFMxdmVIb2g3dHlmVUdhN3NBOFRzWnciLCJ5IjoiMVR0MXRqVDYxdzRyWm9sSllGd0djYnlQNkcxRjUtM0pMd2pfam1Ua1JKSSJ9LCJraWQiOiIzcDhTQ3R5cmEwdV9CLWhMRTdaTm5GcjNFZDBjMTVLdkNEcUxrN2Rpblc4IiwidHlwIjoiSldFIn0..tOiU2P5Fc3ER1U1Y.rrOuQai8iSTIcTT_OrvdGKNBj06Eu9KdM_ewjWZ8st0iEjT8Jsby1lsIjSQkwJsfWOoACZ2um-OBAAiFesIbesdWz0ldD9UTeSGcJQ6Uyw.-obDckIMilQ4WHYjeXUU9g",
+    "encryptionKeyId": "study-bar",
+    "schemaNamespace": "study-bar",
+    "schemaName": "pioneer-enrollment",
+    "schemaVersion": 1,
+    "pioneerId": "9af045aa-80ca-e743-92de-b31431abc547",
+    "studyName": "pioneer-v2-example@example.com"
+  }
+}


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1691807)

This allows for schema evolution of the pioneer-rally and deletion-request pings. Because we always forward the envelope metadata, we add a dataflow counter to keep track of the instances where there we receive a corrupt message because the content is dropped.