### PR TITLE
Update docs about deduplication

### DIFF
--- a/docs/architecture/decoder_service_specification.md
+++ b/docs/architecture/decoder_service_specification.md
@@ -77,7 +77,7 @@ required group attributes {
   optional string geo_subdivision2           // from geoip lookup
   optional string geo_city                   // from geoip lookup
   required string submission_timestamp       // from edge metadata
-g  optional string date                       // header from client
+  optional string date                       // header from client
   optional string dnt                        // header from client
   optional string x_pingsender_version       // header from client
   optional string x_debug_id                 // header from client
@@ -124,4 +124,4 @@ the document.
 BigQuery, and GroupByKey in Beam and Spark.
 
 Note that deduplication is only provided with a "best effort" quality of service
-using a 10-minute window.
+using a 10 minute window.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -15,8 +15,6 @@ This document specifies the architecture for GCP Ingestion as a whole.
   `BigQuery`
 - The Dataflow `Decoder` job decodes messages from the PubSub `Raw Topic` to
   the PubSub `Decoded Topic`
-  - Also checks for existence of `document_id`s in
-    `Cloud Memorystore` in order to deduplicate messages
 - The Dataflow `AET Decoder` job provides all the functionality of the `Decoder`
   with additional decryption handling for Account Ecosystem Telemetry pings
 - The Dataflow `Republisher` job reads messages from the PubSub `Decoded Topic`,
@@ -70,12 +68,8 @@ This document specifies the architecture for GCP Ingestion as a whole.
   1. Produce `normalized_` variants of select attributes
   1. Inject `normalized_` attributes at the top level and other select
      attributes into a nested `metadata` top level key in `payload`
-- Should deduplicate messages based on the `document_id` attribute using
-  `Cloud MemoryStore`
+- Should deduplicate messages based on the `uri` attribute
   - Must ensure at least once delivery, so deduplication is only "best effort"
-  - Should delay deduplication to the latest possible stage of the pipeline
-    to minimize the time window between an ID being marked as seen in
-    `Republisher` and it being checked in `Decoder`
 - Must send messages rejected by transforms to a configurable error destination
   - Must allow error destination in BigQuery
 

--- a/docs/architecture/pain_points.md
+++ b/docs/architecture/pain_points.md
@@ -45,8 +45,8 @@ is to specify mapping at template creation time.
 Does not use standard client library.
 
 Does not expose an output of delivered messages, which is needed for at least
-once delivery with deduplication. Current workaround is to get delivered
-messages from a subscription to the output PubSub topic.
+once delivery with deduplication. Current workaround is to use the deduplication
+available via `PubsubIO.read()`.
 
 Uses HTTPS JSON API, which increases message payload size vs protobuf by 25%
 for base64 encoding and causes some messages to exceed the 10MB request size

--- a/docs/ingestion-beam/republisher-job.md
+++ b/docs/ingestion-beam/republisher-job.md
@@ -6,18 +6,7 @@ The primary intention is to produce smaller derived Pub/Sub topics so
 that consumers that only need a specific subset of messages don't incur
 the cost of reading the entire stream of decoded messages.
 
-The Republisher has the additional responsibility of marking messages as seen
-in `Cloud MemoryStore` for deduplication purposes. That functionality exists
-here to avoid the expense of an additional separate consumer of the full
-decoded topic.
-
 ## Capabilities
-
-### Marking Messages As Seen
-
-The job needs to connect to Redis in order to mark `document_id`s of consumed
-messages as seen. The Decoder is able to use that information to drop duplicate
-messages flowing through the pipeline.
 
 ### Debug Republishing
 


### PR DESCRIPTION
To match reality of https://bugzilla.mozilla.org/show_bug.cgi?id=1694764
and allow for clear communication to data users about the change.

A separate follow-up will be to remove code from the repository that handles interaction with Redis.