### PR TITLE
Update transitive dependencies to fix ingestion-edge-release

### DIFF
--- a/ingestion-edge/requirements.txt
+++ b/ingestion-edge/requirements.txt
@@ -182,9 +182,9 @@ google-cloud-pubsub==1.0.2 \
     --hash=sha256:12ff565ef00e4ca19d2ae26ae4515070094ba857d7c7024370dbed81fc7d58ab \
     --hash=sha256:afb08eb558f3e4d836e6f77443f81555d6921ffc888c7c3085acd1205fba6e8c
     # via -r requirements.in
-googleapis-common-protos[grpc]==1.52.0 \
-    --hash=sha256:560716c807117394da12cecb0a54da5a451b5cf9866f1d37e9a5e2329a665351 \
-    --hash=sha256:c8961760f5aad9a711d37b675be103e0cc4e9a39327e0d6d857872f698403e24
+googleapis-common-protos[grpc]==1.53.0 \
+    --hash=sha256:a88ee8903aa0a81f6c3cec2d5cf62d3c8aa67c06439b0496b49048fb1854ebf4 \
+    --hash=sha256:f6d561ab8fb16b30020b940e2dd01cd80082f4762fa9f3ee670f4419b4b8dbd0
     # via
     #   google-api-core
     #   grpc-google-iam-v1
@@ -731,13 +731,13 @@ yarl==1.4.2 \
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3.3 \
-    --hash=sha256:79c1ac8a9dccbec8752761cb5a2df833224263ca661477a2a9ed03ddf4e0e3ba \
-    --hash=sha256:fab098c8a1758295dd9f57413c199f23571e8fde6cc39c22c78c961b4ac6286d
+pip==21.0.1 \
+    --hash=sha256:37fd50e056e2aed635dec96594606f0286640489b0db0ce7607f7e51890372d5 \
+    --hash=sha256:99bbde183ec5ec037318e774b0d8ae0a64352fe53b2c7fd630be1d07e94f41e5
     # via pip-tools
-setuptools==51.1.1 \
-    --hash=sha256:0b43d1e0e0ac1467185581c2ceaf86b5c1a1bc408f8f6407687b0856302d1850 \
-    --hash=sha256:6d119767443a0f770bab9738b86ce9c0a699a7759ff4f61af583ee73d2e528a0
+setuptools==54.0.0 \
+    --hash=sha256:34efee89c4c879204f5739ec6d9d3635195b0b7d2b51e25c9261a327367ec5ff \
+    --hash=sha256:d85b57c41e88b69ab87065c964134ec85b7573cbab0fdaa7ef32330ed764600a
     # via
     #   google-api-core
     #   google-auth


### PR DESCRIPTION
which is failing because pip >= 20.3.4 has a dependency resolution issue with googleapis-common-protos 1.52.0, and the `python:3.8-slim` docker container now comes with pip 21.0.1.