### PR TITLE
[Bug 1695728] Mark `org-mozilla-ios-lockbox-credentialprovider` as UnwantedData

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -50,6 +50,7 @@ public class MessageScrubber {
       .put("com-only4free-activate", "1687350") //
       .put("glean-js-tmp", "1689513") //
       .put("org-privacywall-browser", "1691468") //
+      .put("org-mozilla-ios-lockbox-credentialprovider", "1695728") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1695728