### PR TITLE
Bug 1697602 Drop AET messages

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -112,6 +112,9 @@ public class MessageScrubber {
             .anyMatch(j -> j.textValue().startsWith("webIsolated="))) {
       throw new MessageShouldBeDroppedException("1562011");
     }
+    if ("account-ecosystem".equals(docType)) {
+      throw new MessageShouldBeDroppedException("1697602");
+    }
 
     // Check for unwanted data; these messages aren't thrown out, but this class of errors will be
     // ignored for most pipeline monitoring.

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -220,6 +220,20 @@ public class MessageScrubberTest {
   }
 
   @Test
+  public void testShouldScrubBug1697602() throws Exception {
+    final Map<String, String> attributes1 = ImmutableMap.<String, String>builder()
+        .put(Attribute.DOCUMENT_NAMESPACE, "telemetry")
+        .put(Attribute.DOCUMENT_TYPE, "account-ecosystem").build();
+    assertThrows(MessageShouldBeDroppedException.class,
+        () -> MessageScrubber.scrub(attributes1, Json.createObjectNode()));
+    final Map<String, String> attributes2 = ImmutableMap.<String, String>builder()
+        .put(Attribute.DOCUMENT_NAMESPACE, "firefox-accounts")
+        .put(Attribute.DOCUMENT_TYPE, "account-ecosystem").build();
+    assertThrows(MessageShouldBeDroppedException.class,
+        () -> MessageScrubber.scrub(attributes2, Json.createObjectNode()));
+  }
+
+  @Test
   public void testBug1602844Affected() throws Exception {
     Map<String, String> baseAttributes = ImmutableMap.<String, String>builder()
         .put(Attribute.DOCUMENT_NAMESPACE, ParseUri.TELEMETRY)


### PR DESCRIPTION
Prerequisite for https://github.com/mozilla/gcp-ingestion/pull/1599 so we make sure that we drop any messages that might contain `ecosystem_anon_id` which was considered sensitive under the deployed AET design.

This is a first preventative step we can take right now for tearing down AET. Further steps will require some coordination with SRE.