### PR TITLE
Ignore apps from health check on 2021-03-15

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -52,6 +52,7 @@ public class MessageScrubber {
       .put("org-privacywall-browser", "1691468") //
       .put("org-mozilla-ios-lockbox-credentialprovider", "1695728") //
       .put("com-zibb-browser", "1698576") //
+      .put("org-mozilla-firefox-betb", "1698579") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -53,6 +53,7 @@ public class MessageScrubber {
       .put("org-mozilla-ios-lockbox-credentialprovider", "1695728") //
       .put("com-zibb-browser", "1698576") //
       .put("org-mozilla-firefox-betb", "1698579") //
+      .put("org-mozilla-allanchain-firefox", "1698574") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -51,6 +51,7 @@ public class MessageScrubber {
       .put("glean-js-tmp", "1689513") //
       .put("org-privacywall-browser", "1691468") //
       .put("org-mozilla-ios-lockbox-credentialprovider", "1695728") //
+      .put("com-zibb-browser", "1698576") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap


### PR DESCRIPTION
This should ignore a couple of namespaces that showed up at the top of the unknown namespaces.

https://bugzilla.mozilla.org/show_bug.cgi?id=1698574
https://bugzilla.mozilla.org/show_bug.cgi?id=1698576
https://bugzilla.mozilla.org/show_bug.cgi?id=1698579