### PR TITLE
Use maven.compiler.release to build for java 8 from jdk 9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ There are currently four components:
 For more information, see [the documentation](https://mozilla.github.io/gcp-ingestion).
 
 Java 11 support is a work in progress for the Beam Java SDK, so this project requires
-Java 8 and will likely fail to compile using newer versions of the JDK.
+Java 8. Maven has been configured to compile for Java 8 when using newer versions of the
+JDK, but support is only guaranteed for JDK 8.
 To manage multiple local JDKs, consider [jenv](https://www.jenv.be/) and the
 `jenv enable-plugin maven` command.

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,15 @@
                 <module>ingestion-sink</module>
             </modules>
         </profile>
+        <profile>
+            <id>java-8-api</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
     </profiles>
 
     <properties>
@@ -158,6 +167,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
+                    <!-- For JDK 9+ the java-8-api profile is automatically activated, which sets
+                         maven.compiler.release=8, causing source and target to be ignored -->
                     <source>1.8</source>
                     <target>1.8</target>
                     <showWarnings>true</showWarnings>


### PR DESCRIPTION
per https://www.baeldung.com/maven-java-version#java9
> To cross-compile correctly, the new `-release` option replaces three flags: `-source`, `-target` and `-bootclasspath`.

Note that `maven.compiler.release` is only valid for jdk 9+, and when set causes maven-compiler-plugin to ignore `source` and `target`.