### PR TITLE
Support workload identity in flush manager service

### DIFF
--- a/ingestion-edge/tests/unit/flush_manager/test_create_job.py
+++ b/ingestion-edge/tests/unit/flush_manager/test_create_job.py
@@ -131,7 +131,9 @@ def test_flush_released_pvs(api: MagicMock, batch_api: MagicMock):
 
     batch_api.create_namespaced_job.side_effect = create_job
 
-    flush_released_pvs(api, batch_api, "command", "env", "image", "namespace")
+    flush_released_pvs(
+        api, batch_api, "command", "env", "image", "namespace", "service-account-name"
+    )
 
     api.list_persistent_volume.assert_called_once_with()
     batch_api.list_namespaced_job.assert_called_once_with("namespace")
@@ -179,7 +181,15 @@ def test_create_flush_job_raises_server_error(api: MagicMock, batch_api: MagicMo
     batch_api.create_namespaced_job.side_effect = create_job
 
     with pytest.raises(ApiException):
-        flush_released_pvs(api, batch_api, "command", "env", "image", "namespace")
+        flush_released_pvs(
+            api,
+            batch_api,
+            "command",
+            "env",
+            "image",
+            "namespace",
+            "service-account-name",
+        )
 
     api.list_persistent_volume.assert_called_once_with()
     batch_api.list_namespaced_job.called_once_with("namespace")
@@ -207,7 +217,15 @@ def test_create_pvc_raises_server_error(api: MagicMock, batch_api: MagicMock):
     api.create_namespaced_persistent_volume_claim.side_effect = create_pvc
 
     with pytest.raises(ApiException):
-        flush_released_pvs(api, batch_api, "command", "env", "image", "namespace")
+        flush_released_pvs(
+            api,
+            batch_api,
+            "command",
+            "env",
+            "image",
+            "namespace",
+            "service-account-name",
+        )
 
     api.list_persistent_volume.assert_called_once_with()
     batch_api.list_namespaced_job.called_once_with("namespace")

--- a/ingestion-edge/tests/unit/flush_manager/test_main.py
+++ b/ingestion-edge/tests/unit/flush_manager/test_main.py
@@ -28,7 +28,7 @@ def test_run_task():
 
 def test_flush_and_delete(api: MagicMock, batch_api: MagicMock):
     flush_released_pvs_and_delete_complete_jobs(
-        api, batch_api, "command", "env", "image", "namespace"
+        api, batch_api, "command", "env", "image", "namespace", "service-account-name"
     )
     api.list_persistent_volume.assert_called_once_with()
     assert [


### PR DESCRIPTION
We use [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) in newer GKE deployments. In order to actually flush queued messages to pubsub, flush jobs spawned by flush manager need to be annotated with the appropriate k8s service account information (mapped to a GCP SA by workload identity).

In the old stack that flush manager was developed on, we used `GOOGLE_APPLICATION_CREDENTIALS` via env var and mounted secret volume to pass credentials to containers. In point of fact, I'm not sure if the flush manager config ever worked in old stage either since the current code passes neither GCP SA nor K8s SA information. I vaguely recall discussing this with :relud so it might have been known and I simply didn't catch that flushes always failed until doing some more exhaustive testing (flushes of empty disks do succeed however which is the common case).

See [service_account_name](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1PodSpec.md#v1podspec). The behavior of k8s when leaving this unspecified is to use [default](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server) so this shouldn't be a change in behavior. In ops logic we generally prefer not to use the `default` k8s SA in annotations and annotate explicit service accounts within namespaces instead.

Tested with https://github.com/mozilla-services/cloudops-infra/pull/2695/commits/b92de758dbb751a77dda8d25146b93ddf56a7d4e in stage.

Separately while testing this I was able to induce data loss by simply deleting a pod associated with a flush job while in an induced error state (flush manager would delete the `pv` even though the flush job did not succeed, or at least should not have [returned a successful status](https://github.com/mozilla/gcp-ingestion/blob/master/ingestion-edge/ingestion_edge/flush_manager.py#L65)). This is mildly concerning but I may be misunderstanding the expectation here (`kubectl delete pod` is not going to happen on production stacks in practice). I will double check on this with :relud next week.