### PR TITLE
Work around bug that was breaking q.empty()

### DIFF
--- a/ingestion-edge/ingestion_edge/publish.py
+++ b/ingestion-edge/ingestion_edge/publish.py
@@ -106,7 +106,11 @@ def get_queue(config: dict) -> SQLiteAckQueue:
         for key, value in config.items()
         if key.startswith("QUEUE_")
     }
-    return SQLiteAckQueue(**queue_config)
+    q: SQLiteAckQueue = SQLiteAckQueue(**queue_config, auto_resume=False)
+    q.resume_unack_tasks()
+    # work around https://github.com/peter-wangxu/persist-queue/pull/154
+    q.total = q._count()
+    return q
 
 
 def init_app(app: Sanic) -> Tuple[PublisherClient, SQLiteAckQueue]:


### PR DESCRIPTION
https://github.com/peter-wangxu/persist-queue/pull/154 can cause `q.empty()` to return inaccurate results, which in turn can cause the flush manager to incorrectly think that disks were flushed because this loop wouldn't drain the queue:
https://github.com/mozilla/gcp-ingestion/blob/70b89609350f941d4e5b606e4b8558fe9550fc89/ingestion-edge/ingestion_edge/flush.py#L134