### PR TITLE
Bug 1711706 Support X-Telemetry-Agent header

### DIFF
--- a/docs/architecture/edge_service_specification.md
+++ b/docs/architecture/edge_service_specification.md
@@ -50,6 +50,7 @@ required group attributes {
   optional string x_pingsender_version // example: "1.0"
   optional string x_debug_id           // example: "my_debug_session_1"
   optional string x_pipeline_proxy     // time that the AWS->GCP tee received the message, example: "2018-03-12T21:02:18.123456Z"
+  optional string x_telemetry_agent    // example: "Glean/0.40.0 (Kotlin on Android)"
 }
 ```
 

--- a/docs/ingestion-edge/index.md
+++ b/docs/ingestion-edge/index.md
@@ -57,7 +57,7 @@ environment variables:
   on the filesystem where `QUEUE_PATH` is mounted below which `/__heartbeat__`
   will fail, defaults to `0` which disables the check
 - `METADATA_HEADERS`: a JSON list of headers to preserve as PubSub message
-  attributes, defaults to `["Content-Length", "Date", "DNT", "User-Agent", "X-Forwarded-For", "X-Pingsender-Version", "X-Pipeline-Proxy", "X-Debug-ID"]`;
+  attributes, defaults to `["Content-Length", "Date", "DNT", "User-Agent", "X-Forwarded-For", "X-Pingsender-Version", "X-Pipeline-Proxy", "X-Debug-ID", "X-Telemetry-Agent"]`;
   the message attribute name will be the header name in lowercase and with `-`
   converted to `_`
 - `PUBLISH_TIMEOUT_SECONDS`: a float indicating the maximum number of seconds

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/Constant.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/Constant.java
@@ -54,6 +54,7 @@ public class Constant {
     public static final String X_PINGSENDER_VERSION = "x_pingsender_version";
     public static final String X_PIPELINE_PROXY = "x_pipeline_proxy";
     public static final String X_SOURCE_TAGS = "x_source_tags";
+    public static final String X_TELEMETRY_AGENT = "x_telemetry_agent";
   }
 
   public static class FieldName {

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/transform/NestedMetadata.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/transform/NestedMetadata.java
@@ -40,7 +40,7 @@ public class NestedMetadata {
   private static final String HEADER = "header";
   private static final List<String> HEADER_ATTRIBUTES = ImmutableList //
       .of(Attribute.DATE, Attribute.DNT, Attribute.X_DEBUG_ID, Attribute.X_PINGSENDER_VERSION,
-          Attribute.X_SOURCE_TAGS);
+          Attribute.X_SOURCE_TAGS, Attribute.X_TELEMETRY_AGENT);
 
   private static final List<String> URI_ATTRIBUTES = ImmutableList //
       .of(Attribute.URI, Attribute.APP_NAME, Attribute.APP_VERSION, Attribute.APP_UPDATE_CHANNEL,

--- a/ingestion-core/src/test/java/com/mozilla/telemetry/ingestion/core/transform/NestedMetadataTest.java
+++ b/ingestion-core/src/test/java/com/mozilla/telemetry/ingestion/core/transform/NestedMetadataTest.java
@@ -70,19 +70,27 @@ public class NestedMetadataTest {
     Map<String, String> attributes = ImmutableMap.of("dnt", "1", //
         "sample_id", "18", //
         "x_source_tags", "automation, perf", //
-        "x_debug_id", "mysession");
+        "x_debug_id", "mysession", //
+        "x_telemetry_agent", "Glean/0.40.0 (Kotlin on Android)"
+        );
     ObjectNode headers = NestedMetadata.headersFromAttributes(attributes);
-    ObjectNode expected = mapToObjectNode(ImmutableMap.of("dnt", "1", "x_debug_id", "mysession",
-        "x_source_tags", "automation, perf"));
+    ObjectNode expected = mapToObjectNode(ImmutableMap.of("dnt", "1", //
+        "x_debug_id", "mysession", //
+        "x_source_tags", "automation, perf", //
+        "x_telemetry_agent", "Glean/0.40.0 (Kotlin on Android)"));
     assertEquals(expected, headers);
   }
 
   @Test
   public void testPutHeaderAttributes() throws Exception {
-    ObjectNode metadata = mapToObjectNode(ImmutableMap.of("header", ImmutableMap.of("dnt", "1",
-        "x_debug_id", "mysession", "x_source_tags", "automation, perf")));
+    ObjectNode metadata = mapToObjectNode(ImmutableMap.of("header", ImmutableMap.of("dnt", "1", //
+        "x_debug_id", "mysession", //
+        "x_source_tags", "automation, perf", //
+        "x_telemetry_agent", "Glean/0.40.0 (Kotlin on Android)")));
     Map<String, String> expected = ImmutableMap.of("dnt", "1", //
-        "x_debug_id", "mysession", "x_source_tags", "automation, perf");
+        "x_debug_id", "mysession", //
+        "x_source_tags", "automation, perf", //
+        "x_telemetry_agent", "Glean/0.40.0 (Kotlin on Android)");
     Map<String, String> attributes = new HashMap<>();
     NestedMetadata.putHeaderAttributes(attributes, (metadata));
     assertEquals(expected, attributes);

--- a/ingestion-edge/ingestion_edge/config.py
+++ b/ingestion-edge/ingestion_edge/config.py
@@ -62,6 +62,7 @@ DEFAULT_METADATA_HEADERS = [
     "X-Pipeline-Proxy",
     "X-Debug-ID",
     "X-Source-Tags",
+    "X-Telemetry-Agent",
 ]
 
 METADATA_HEADERS = {


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1711706

This will require changing config for ingestion-edge and redeploying to allow `X-Telemetry-Agent` to be passed to pubsub.

The relevant fields are added to schemas in https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/676

I don't _think_ the order in which these are merged/applied particularly matters. We should be tolerant at each step of the new field existing or not. If we start processing the field before schemas have a relevant field, the value for the new field will simply get dropped until the schemas are updated.