### PR TITLE
Add transitive google deps for dependabot updates

### DIFF
--- a/ingestion-edge/requirements.in
+++ b/ingestion-edge/requirements.in
@@ -1,8 +1,10 @@
 aiohttp==3.7.4.post0
 dockerflow==2020.10.0
+google-api-core==1.28.0  # transitive dep that needs dependabot updates
 google-cloud-container==2.4.1
 google-cloud-monitoring==2.2.1
 google-cloud-pubsub==1.0.2
+googleapis-common-protos==1.53.0  # transitive dep that needs dependabot updates
 gunicorn==20.1.0
 kubernetes==17.17.0
 persist-queue==0.6.0

--- a/ingestion-edge/requirements.txt
+++ b/ingestion-edge/requirements.txt
@@ -157,16 +157,17 @@ flake8==3.8.3 \
     --hash=sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c \
     --hash=sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208
     # via pytest-flake8
-google-api-core[grpc]==1.22.4 \
-    --hash=sha256:15e00ceb7e6dc44159e2a41a222830744e9ebcb3a553c580b61cb5a66572f2f0 \
-    --hash=sha256:4a9d7ac2527a9e298eebb580a5e24e7e41d6afd97010848dd0f306cae198ec1a
+google-api-core[grpc]==1.28.0 \
+    --hash=sha256:02646803bd728e12dd1f45ee1dcc31c12614c9a1ac451b9a1ce26aa65df9b957 \
+    --hash=sha256:a658a4e367511a444c7daf2c58855ff6fd7f7d138c154e5b17186c1f8154c8cb
     # via
+    #   -r requirements.in
     #   google-cloud-container
     #   google-cloud-monitoring
     #   google-cloud-pubsub
-google-auth==1.22.1 \
-    --hash=sha256:712dd7d140a9a1ea218e5688c7fcb04af71b431a29ec9ce433e384c60e387b98 \
-    --hash=sha256:9c0f71789438d703f77b94aad4ea545afaec9a65f10e6cc1bc8b89ce242244bb
+google-auth==1.30.0 \
+    --hash=sha256:588bdb03a41ecb4978472b847881e5518b5d9ec6153d3d679aa127a55e13b39f \
+    --hash=sha256:9ad25fba07f46a628ad4d0ca09f38dcb262830df2ac95b217f9b0129c9e42206
     # via
     #   google-api-core
     #   kubernetes
@@ -186,6 +187,7 @@ googleapis-common-protos[grpc]==1.53.0 \
     --hash=sha256:a88ee8903aa0a81f6c3cec2d5cf62d3c8aa67c06439b0496b49048fb1854ebf4 \
     --hash=sha256:f6d561ab8fb16b30020b940e2dd01cd80082f4762fa9f3ee670f4419b4b8dbd0
     # via
+    #   -r requirements.in
     #   google-api-core
     #   grpc-google-iam-v1
 grpc-google-iam-v1==0.12.3 \
@@ -351,6 +353,7 @@ packaging==20.4 \
     --hash=sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8 \
     --hash=sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181
     # via
+    #   google-api-core
     #   google-cloud-container
     #   pytest
 pathspec==0.8.0 \


### PR DESCRIPTION
workaround for pypa/pip#9644

similar to https://github.com/mozilla/bigquery-etl/pull/2064