### PR TITLE
Fix redact quicksuggest search query

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -190,9 +190,9 @@ public class MessageScrubber {
     }
 
     if (bug1712850Affected(attributes)) {
-      JsonNode payload = json.path("payload");
-      if (payload.hasNonNull("search_query")) {
-        ((ObjectNode) payload).put("search_query", "");
+      if (json.hasNonNull("search_query") || json.hasNonNull("matched_keywords")) {
+        json.put("search_query", "");
+        json.put("matched_keywords", "");
         markBugCounter("1712850");
       }
     }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -449,18 +449,19 @@ public class MessageScrubberTest {
   @Test
   public void testRedactForBug1712850() throws Exception {
     ObjectNode json = Json.readObjectNode(("{\n" //
-        + "\"payload\": {\n" //
-        + "  \"search_query\": \"abc\"\n" //
-        + "  }\n}").getBytes(StandardCharsets.UTF_8));
+        + "  \"search_query\": \"abc\",\n" //
+        + "  \"matched_keywords\": \"abc\"\n" //
+        + "}").getBytes(StandardCharsets.UTF_8));
 
     final Map<String, String> attributes = ImmutableMap.<String, String>builder()
         .put(Attribute.DOCUMENT_NAMESPACE, "contextual-services")
         .put(Attribute.DOCUMENT_TYPE, "quicksuggest-impression").build();
 
-    assertTrue(json.path("payload").hasNonNull("search_query"));
+    assertTrue(json.hasNonNull("search_query"));
+    assertTrue(json.hasNonNull("matched_keywords"));
     MessageScrubber.scrub(attributes, json);
-    assertTrue(json.path("payload").hasNonNull("search_query"));
-    assertEquals("", json.path("payload").path("search_query").asText());
+    assertEquals("", json.path("search_query").asText());
+    assertEquals("", json.path("matched_keywords").asText());
   }
 
   @Test


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1712850

- Values aren't nested in a `payload` field, see [schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/main/templates/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json)
- `matched_keywords` is identical to `search_query` and needs to be scrubbed