### PR TITLE
Revert "Update beam to 2.29 and jackson to 2.12.1"

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubConstraints.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/PubsubConstraints.java
@@ -38,12 +38,14 @@ public class PubsubConstraints {
     return truncateToFitUtf8ByteLength(value, MAX_ATTRIBUTE_VALUE_BYTES);
   }
 
-  /** Fills out empty attributes if message or attributeMap are null. */
+  /** Fills out empty payload and attributes if the message itself or components are null. */
   public static PubsubMessage ensureNonNull(PubsubMessage message) {
     if (message == null) {
-      return new PubsubMessage(new byte[] {}, new HashMap<>(), null);
+      return new PubsubMessage(new byte[] {}, new HashMap<>());
+    } else if (message.getPayload() == null) {
+      return ensureNonNull(new PubsubMessage(new byte[] {}, message.getAttributeMap()));
     } else if (message.getAttributeMap() == null) {
-      return new PubsubMessage(message.getPayload(), new HashMap<>(), message.getMessageId());
+      return ensureNonNull(new PubsubMessage(message.getPayload(), new HashMap<>()));
     } else {
       return message;
     }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/BeamDependenciesIntegrationTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/BeamDependenciesIntegrationTest.java
@@ -25,11 +25,14 @@ public class BeamDependenciesIntegrationTest {
 
     final Map<String, Optional<String>> expectedVersions = ImmutableMap.of(//
         "avro.version", beamCore.getVersion("org.apache.avro", "avro"), //
-        "jackson.version", beamCore.getVersion("com.fasterxml.jackson.core", "jackson-core"));
+        "jackson.version", beamCore.getVersion("com.fasterxml.jackson.core", "jackson-core"), //
+        "googleCloudLibraries.version", beamGcpIO.getVersion("com.google.cloud", "libraries-bom"));
 
     final Map<String, Optional<String>> actualVersions = ImmutableMap.of(//
         "avro.version", Optional.of(System.getProperty("avro.version")), //
-        "jackson.version", Optional.of(System.getProperty("jackson.version")));
+        "jackson.version", Optional.of(System.getProperty("jackson.version")), //
+        "googleCloudLibraries.version",
+        Optional.of(System.getProperty("googleCloudLibraries.version")));
 
     assertEquals(expectedVersions, actualVersions);
   }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/options/OutputFileFormatTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/options/OutputFileFormatTest.java
@@ -1,7 +1,6 @@
 package com.mozilla.telemetry.options;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 
 import java.io.UncheckedIOException;
 import java.util.HashMap;
@@ -11,13 +10,10 @@ import org.junit.Test;
 
 public class OutputFileFormatTest {
 
-  private static final byte[] emptyBytes = new byte[] {};
-
   @Test
-  public void testEmptyText() {
+  public void testNullText() {
     assertEquals("", OutputFileFormat.text.encodeSingleMessage(null));
-    assertEquals("",
-        OutputFileFormat.text.encodeSingleMessage(new PubsubMessage(emptyBytes, null)));
+    assertEquals("", OutputFileFormat.text.encodeSingleMessage(new PubsubMessage(null, null)));
   }
 
   @Test
@@ -25,11 +21,10 @@ public class OutputFileFormatTest {
     assertEquals("null", OutputFileFormat.json.encodeSingleMessage(null));
   }
 
-  @Test
+  @Test(expected = UncheckedIOException.class)
   public void testInvalidAttributeMapThrows() {
     Map<String, String> attributes = new HashMap<>();
     attributes.put(null, "hi");
-    assertThrows(UncheckedIOException.class,
-        () -> OutputFileFormat.json.encodeSingleMessage(new PubsubMessage(emptyBytes, attributes)));
+    OutputFileFormat.json.encodeSingleMessage(new PubsubMessage(null, attributes));
   }
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubConstraintsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubConstraintsTest.java
@@ -1,13 +1,7 @@
 package com.mozilla.telemetry.transforms;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
 
-import com.google.common.collect.ImmutableMap;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
@@ -19,38 +13,6 @@ public class PubsubConstraintsTest {
 
   // Euro is 3 bytes in UTF-8.
   private static final char EURO = '€';
-
-  private void expectNonNull(PubsubMessage message, boolean expectSameMessage,
-      String expectedPayload, Map<String, String> expectedAttributeMap, String expectedMessageId) {
-    assertEquals(expectedPayload,
-        new String(PubsubConstraints.ensureNonNull(message).getPayload(), StandardCharsets.UTF_8));
-    assertEquals(expectedAttributeMap, PubsubConstraints.ensureNonNull(message).getAttributeMap());
-    assertEquals(expectedMessageId, PubsubConstraints.ensureNonNull(message).getMessageId());
-    if (expectSameMessage) {
-      assertEquals(message, PubsubConstraints.ensureNonNull(message));
-    } else {
-      assertNotEquals(message, PubsubConstraints.ensureNonNull(message));
-    }
-  }
-
-  @Test
-  public void testEnsureNonNull() {
-    final byte[] emptyBytes = new byte[] {};
-    final byte[] testBytes = "test".getBytes(StandardCharsets.UTF_8);
-    final Map<String, String> emptyMap = ImmutableMap.of();
-    final Map<String, String> nonEmptyMap = ImmutableMap.of("k", "v");
-
-    // PubsubMessage enforces non-null payload
-    assertThrows(NullPointerException.class, () -> new PubsubMessage(null, emptyMap, "1"));
-
-    expectNonNull(null, false, "", emptyMap, null);
-    expectNonNull(new PubsubMessage(emptyBytes, null, null), false, "", emptyMap, null);
-    expectNonNull(new PubsubMessage(testBytes, null, "1"), false, "test", emptyMap, "1");
-    expectNonNull(new PubsubMessage(emptyBytes, emptyMap, null), true, "", emptyMap, null);
-    expectNonNull(new PubsubMessage(testBytes, emptyMap, "2"), true, "test", emptyMap, "2");
-    expectNonNull(new PubsubMessage(emptyBytes, nonEmptyMap, null), true, "", nonEmptyMap, null);
-    expectNonNull(new PubsubMessage(testBytes, nonEmptyMap, "3"), true, "test", nonEmptyMap, "3");
-  }
 
   @Test
   public void testTruncatePreservesShortAscii() {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubLiteCompatTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/transforms/PubsubLiteCompatTest.java
@@ -12,6 +12,7 @@ import com.google.protobuf.util.JsonFormat;
 import com.mozilla.telemetry.ingestion.core.util.IOFunction;
 import com.mozilla.telemetry.options.OutputFileFormat;
 import com.mozilla.telemetry.util.Json;
+import com.mozilla.telemetry.util.PubsubWithNullsJsonCoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Function;
@@ -33,7 +34,7 @@ public class PubsubLiteCompatTest {
   public final transient TestPipeline pipeline = TestPipeline.create();
 
   private final List<PubsubMessage> outputToLite = ImmutableList.of(//
-      new PubsubMessage(new byte[] {}, null), //
+      new PubsubMessage(null, null), //
       new PubsubMessage("payload".getBytes(StandardCharsets.UTF_8),
           ImmutableMap.of("meta", "data")));
 
@@ -64,7 +65,7 @@ public class PubsubLiteCompatTest {
   @Test
   public void testToPubsubLiteTransform() throws Exception {
     PCollection<String> result = pipeline //
-        .apply(Create.of(outputToLite)) //
+        .apply(Create.of(outputToLite).withCoder(PubsubWithNullsJsonCoder.of())) //
         .apply(PubsubLiteCompat.toPubsubLite()) //
         .apply("liteToJson",
             MapElements.into(TypeDescriptors.strings()).via(PubsubLiteCompatTest::liteToJson));

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/util/PubsubWithNullsJsonCoder.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/util/PubsubWithNullsJsonCoder.java
@@ -1,0 +1,50 @@
+package com.mozilla.telemetry.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.CustomCoder;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+
+/**
+ * {@link CustomCoder} for {@link PubsubMessage} via JSON that allows null payload and message
+ * values for testing.
+ */
+public class PubsubWithNullsJsonCoder extends CustomCoder<PubsubMessage> {
+
+  private PubsubWithNullsJsonCoder() {
+  }
+
+  private static PubsubWithNullsJsonCoder INSTANCE = new PubsubWithNullsJsonCoder();
+
+  public static PubsubWithNullsJsonCoder of() {
+    return INSTANCE;
+  }
+
+  static class Json extends com.mozilla.telemetry.util.Json {
+
+    static {
+      MAPPER.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false);
+    }
+
+    /**
+     * Read a {@link PubsubMessage} from a string and allow null results.
+     */
+    public static PubsubMessage readPubsubMessage(InputStream data) throws IOException {
+      return MAPPER.readValue(data, PubsubMessage.class);
+    }
+  }
+
+  @Override
+  public void encode(PubsubMessage value, OutputStream outStream)
+      throws CoderException, IOException {
+    outStream.write(Json.asBytes(value));
+  }
+
+  @Override
+  public PubsubMessage decode(InputStream inStream) throws CoderException, IOException {
+    return Json.readPubsubMessage(inStream);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,13 @@
         <!-- The classPath setting is a workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925 -->
         <argLine>-Xmx1024m -XX:MaxPermSize=256m -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
 
-        <beam.version>2.29.0</beam.version>
+        <beam.version>2.28.0</beam.version>
 
         <!-- Keep these dependency versions in sync with what is pulled in by beam;
              check https://mvnrepository.com/artifact/org.apache.beam -->
-        <jackson.version>2.12.1</jackson.version>
+        <jackson.version>2.10.2</jackson.version>
         <avro.version>1.8.2</avro.version>
+        <googleCloudLibraries.version>13.2.0</googleCloudLibraries.version>
 
         <!-- Set empty default. -->
         <exec.mainClass></exec.mainClass>
@@ -84,7 +85,7 @@
         <dependencies>
             <dependency>
                 <groupId>org.apache.beam</groupId>
-                <artifactId>beam-sdks-java-google-cloud-platform-bom</artifactId>
+                <artifactId>beam-sdks-java-bom</artifactId>
                 <version>${beam.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -95,6 +96,13 @@
                 <version>${jackson.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>${googleCloudLibraries.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -298,6 +306,7 @@
                         <beam.version>${beam.version}</beam.version>
                         <jackson.version>${jackson.version}</jackson.version>
                         <avro.version>${avro.version}</avro.version>
+                        <googleCloudLibraries.version>${googleCloudLibraries.version}</googleCloudLibraries.version>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Reverts mozilla/gcp-ingestion#1686

We need to downgrade to beam 2.28 because we are being hit by https://issues.apache.org/jira/browse/BEAM-12356 in the Contextual Services sender job. It sounds like the relevant fix will be included in 2.31, which won't be available for ~5 weeks, at which point we can restore these changes.