### PR TITLE
Depend on beam bom for GCP instead of libraries-bom

### DIFF
--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/BeamDependenciesIntegrationTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/integration/BeamDependenciesIntegrationTest.java
@@ -20,19 +20,14 @@ public class BeamDependenciesIntegrationTest {
   public void checkVersions() throws Exception {
     final String beamVersion = System.getProperty("beam.version");
     final Pom beamCore = getPom("org.apache.beam", "beam-sdks-java-core", beamVersion);
-    final Pom beamGcpIO = getPom("org.apache.beam", "beam-sdks-java-io-google-cloud-platform",
-        beamVersion);
 
     final Map<String, Optional<String>> expectedVersions = ImmutableMap.of(//
         "avro.version", beamCore.getVersion("org.apache.avro", "avro"), //
-        "jackson.version", beamCore.getVersion("com.fasterxml.jackson.core", "jackson-core"), //
-        "googleCloudLibraries.version", beamGcpIO.getVersion("com.google.cloud", "libraries-bom"));
+        "jackson.version", beamCore.getVersion("com.fasterxml.jackson.core", "jackson-core"));
 
     final Map<String, Optional<String>> actualVersions = ImmutableMap.of(//
         "avro.version", Optional.of(System.getProperty("avro.version")), //
-        "jackson.version", Optional.of(System.getProperty("jackson.version")), //
-        "googleCloudLibraries.version",
-        Optional.of(System.getProperty("googleCloudLibraries.version")));
+        "jackson.version", Optional.of(System.getProperty("jackson.version")));
 
     assertEquals(expectedVersions, actualVersions);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
              check https://mvnrepository.com/artifact/org.apache.beam -->
         <jackson.version>2.10.2</jackson.version>
         <avro.version>1.8.2</avro.version>
-        <googleCloudLibraries.version>13.2.0</googleCloudLibraries.version>
 
         <!-- Set empty default. -->
         <exec.mainClass></exec.mainClass>
@@ -85,7 +84,7 @@
         <dependencies>
             <dependency>
                 <groupId>org.apache.beam</groupId>
-                <artifactId>beam-sdks-java-bom</artifactId>
+                <artifactId>beam-sdks-java-google-cloud-platform-bom</artifactId>
                 <version>${beam.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -96,13 +95,6 @@
                 <version>${jackson.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>libraries-bom</artifactId>
-                <version>${googleCloudLibraries.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -306,7 +298,6 @@
                         <beam.version>${beam.version}</beam.version>
                         <jackson.version>${jackson.version}</jackson.version>
                         <avro.version>${avro.version}</avro.version>
-                        <googleCloudLibraries.version>${googleCloudLibraries.version}</googleCloudLibraries.version>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
this portion of #1712 doesn't need to wait until beam 2.31