### PR TITLE
Allow empty param values in aggregated impression url

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParsedReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParsedReportingUrl.java
@@ -52,8 +52,8 @@ public class ParsedReportingUrl {
       queryParams = new HashMap<>();
     } else {
       queryParams = Arrays.stream(this.reportingUrl.getQuery().split("&"))
-          .map(param -> param.split("=")).filter(param -> param.length > 1)
-          .collect(Collectors.toMap(item -> item[0], item -> item[1]));
+          .map(param -> param.split("="))
+          .collect(Collectors.toMap(item -> item[0], item -> item.length > 1 ? item[1] : ""));
     }
   }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
@@ -100,6 +100,8 @@ public class AggregateImpressionsTest {
           Assert.assertEquals(parsedUrl.getQueryParam(ParsedReportingUrl.PARAM_IMPRESSIONS), "3");
         } else if ("DE".equals(country)) {
           Assert.assertEquals(parsedUrl.getQueryParam(ParsedReportingUrl.PARAM_IMPRESSIONS), "2");
+        } else {
+          throw new IllegalArgumentException("unknown country value");
         }
 
         // Parameters with no values should still be included

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
@@ -95,12 +95,16 @@ public class AggregateImpressionsTest {
         String reportingUrl = message.getAttribute(Attribute.REPORTING_URL);
         ParsedReportingUrl parsedUrl = new ParsedReportingUrl(reportingUrl);
 
-        String queryParam = parsedUrl.getQueryParam(Attribute.REPORTING_URL);
-        if ("US".equals(queryParam)) {
+        String country = parsedUrl.getQueryParam(ParsedReportingUrl.PARAM_COUNTRY_CODE);
+        if ("US".equals(country)) {
           Assert.assertEquals(parsedUrl.getQueryParam(ParsedReportingUrl.PARAM_IMPRESSIONS), "3");
-        } else if ("DE".equals(queryParam)) {
+        } else if ("DE".equals(country)) {
           Assert.assertEquals(parsedUrl.getQueryParam(ParsedReportingUrl.PARAM_IMPRESSIONS), "2");
         }
+
+        // Parameters with no values should still be included
+        Assert.assertTrue(
+            reportingUrl.contains(String.format("%s=", ParsedReportingUrl.PARAM_REGION_CODE)));
 
         long windowSize = Long
             .parseLong(parsedUrl.getQueryParam(ParsedReportingUrl.PARAM_TIMESTAMP_END))

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
@@ -105,6 +105,14 @@ public class ParseReportingUrlTest {
 
       Assert.assertTrue(reportingUrl.startsWith("https://moz.impression.com/?"));
       Assert.assertTrue(reportingUrl.contains("param=1"));
+      Assert.assertTrue(
+          reportingUrl.contains(String.format("%s=", ParsedReportingUrl.PARAM_REGION_CODE)));
+      Assert.assertTrue(reportingUrl
+          .contains(String.format("%s=%s", ParsedReportingUrl.PARAM_OS_FAMILY, "Windows")));
+      Assert.assertTrue(reportingUrl
+          .contains(String.format("%s=%s", ParsedReportingUrl.PARAM_COUNTRY_CODE, "US")));
+      Assert.assertTrue(reportingUrl
+          .contains(String.format("%s=%s", ParsedReportingUrl.PARAM_FORM_FACTOR, "desktop")));
 
       return null;
     });


### PR DESCRIPTION
Empty url query params were being added to unaggregated urls as expected but not aggregated urls.  Should be added to both.

This also adds some stronger checks in the tests