### PR TITLE
Update google-api-core to 1.31.0

### DIFF
--- a/ingestion-edge/requirements.in
+++ b/ingestion-edge/requirements.in
@@ -1,6 +1,6 @@
 aiohttp==3.7.4.post0
 dockerflow==2021.7.0
-google-api-core==1.28.0  # transitive dep that needs dependabot updates
+google-api-core==1.31.0  # transitive dep that needs dependabot updates
 google-cloud-container==2.5.0
 google-cloud-monitoring==2.4.0
 google-cloud-pubsub==1.0.2

--- a/ingestion-edge/requirements.txt
+++ b/ingestion-edge/requirements.txt
@@ -157,9 +157,9 @@ flake8==3.8.3 \
     --hash=sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c \
     --hash=sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208
     # via pytest-flake8
-google-api-core[grpc]==1.28.0 \
-    --hash=sha256:02646803bd728e12dd1f45ee1dcc31c12614c9a1ac451b9a1ce26aa65df9b957 \
-    --hash=sha256:a658a4e367511a444c7daf2c58855ff6fd7f7d138c154e5b17186c1f8154c8cb
+google-api-core[grpc]==1.31.0 \
+    --hash=sha256:7c8ba88e2b893ef4f67d67e229aade51a2db5053023b73b1394a5ee3dcdb561c \
+    --hash=sha256:a9f979b5c6a9cad31a4120ca6be712df76adc32336a7bf4bc2f4331a1b527fe7
     # via
     #   -r requirements.in
     #   google-cloud-container


### PR DESCRIPTION
fixes docker builds
dependabot isn't posting an update for this because `No update possible`:

```
updater | INFO <job_170347332> Checking if google-api-core 1.28.0 needs updating
  proxy | 2021/07/09 21:03:13 [146] GET https://pypi.org:443/simple/google-api-core/
  proxy | 2021/07/09 21:03:13 [146] 200 https://pypi.org:443/simple/google-api-core/
updater | INFO <job_170347332> Latest version is 1.31.0
  proxy | 2021/07/09 21:03:17 [148] GET https://pypi.org:443/simple/pip/
  proxy | 2021/07/09 21:03:17 [148] 200 https://pypi.org:443/simple/pip/
  proxy | 2021/07/09 21:03:19 [150] GET https://pypi.org:443/simple/google-api-core/
  proxy | 2021/07/09 21:03:19 [150] 304 https://pypi.org:443/simple/google-api-core/
  proxy | 2021/07/09 21:03:19 [152] GET https://files.pythonhosted.org:443/packages/aa/51/629a31d4e7db2bbc0b0b789ac4034108c68647bea9cf5b54c8366df47b8e/google_api_core-1.31.0-py2.py3-none-any.whl
  proxy | 2021/07/09 21:03:19 [152] 200 https://files.pythonhosted.org:443/packages/aa/51/629a31d4e7db2bbc0b0b789ac4034108c68647bea9cf5b54c8366df47b8e/google_api_core-1.31.0-py2.py3-none-any.whl
updater | INFO <job_170347332> Requirements to unlock update_not_possible
updater | INFO <job_170347332> Requirements update strategy bump_versions
updater | INFO <job_170347332> No update possible for google-api-core 1.28.0
```