### PR TITLE
Use java 11 for dataflow flex templates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,16 @@
-version: 2
+version: 2.1
+executors:
+  java-8:
+    docker:
+    # Pin the maven image due to observed VM aborts on CircleCI 2018-01-08.
+    - image: maven@sha256:955e28c9a64b439591adfd43da77586c8bcd45f51627bf9144e297386c6a6be3
+    environment:
+      JAVA_COMPILER_RELEASE_FLAG: ""
+  java-11:
+    docker:
+    - image: maven:3-jdk-11
+    environment:
+      JAVA_COMPILER_RELEASE_FLAG: "-Dmaven.compiler.release=11"
 jobs:
   spelling:
     docker:
@@ -160,9 +172,11 @@ jobs:
 
   ingestion-beam: &ingestion_beam
     working_directory: /root/project/ingestion-beam
-    docker:
-    # Pin the maven image due to observed VM aborts on CircleCI 2018-01-08.
-    - image: maven@sha256:955e28c9a64b439591adfd43da77586c8bcd45f51627bf9144e297386c6a6be3
+    parameters:
+      java-version:
+        default: java-8
+        type: executor
+    executor: << parameters.java-version >>
     steps:
     - *checkout
     - *skip_unmodified
@@ -187,7 +201,7 @@ jobs:
       run:
         name: Maven Test
         command: |
-          mvn clean test
+          mvn clean test $JAVA_COMPILER_RELEASE_FLAG
     - &store_maven_test_results
       store_test_results:
         path: target/surefire-reports
@@ -223,7 +237,7 @@ jobs:
         command: |
           export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
           echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-          mvn clean test -Dtest=*IntegrationTest -DfailIfNoTests=false
+          mvn clean test -Dtest=*IntegrationTest -DfailIfNoTests=false $JAVA_COMPILER_RELEASE_FLAG
     - *store_maven_test_results
     - *report_code_coverage
     # We don't save_cache here; we let the ingestion-beam job cover that.
@@ -308,6 +322,14 @@ workflows:
     - ingestion-beam-integration
     - ingestion-sink
     - ingestion-sink-integration
+    - ingestion-beam:
+        java-version: java-11
+    - ingestion-beam-integration:
+        java-version: java-11
+    - ingestion-sink:
+        java-version: java-11
+    - ingestion-sink-integration:
+        java-version: java-11
     - ingestion-sink-release:
         filters:
           branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ executors:
     - image: maven:3-jdk-11
     environment:
       JAVA_COMPILER_RELEASE_FLAG: "-Dmaven.compiler.release=11"
+  docker-compose:
+    docker:
+    - image: docker/compose:1.22.0
 jobs:
   spelling:
     docker:
@@ -173,10 +176,9 @@ jobs:
   ingestion-beam: &ingestion_beam
     working_directory: /root/project/ingestion-beam
     parameters:
-      java-version:
-        default: java-8
+      executor:
         type: executor
-    executor: << parameters.java-version >>
+    executor: << parameters.executor >>
     steps:
     - *checkout
     - *skip_unmodified
@@ -281,8 +283,6 @@ jobs:
 
   ingestion-sink-release:
     <<: *ingestion_sink
-    docker:
-      - image: docker/compose:1.22.0
     steps:
       - *setup_remote_docker
       - *checkout
@@ -318,19 +318,15 @@ workflows:
             only: main
           tags:
             only: /.*/
-    - ingestion-beam
-    - ingestion-beam-integration
-    - ingestion-sink
-    - ingestion-sink-integration
-    - ingestion-beam:
-        java-version: java-11
-    - ingestion-beam-integration:
-        java-version: java-11
-    - ingestion-sink:
-        java-version: java-11
-    - ingestion-sink-integration:
-        java-version: java-11
+    - ingestion-beam: &java_matrix
+        matrix:
+          parameters:
+            executor: [java-8, java-11]
+    - ingestion-beam-integration: *java_matrix
+    - ingestion-sink: *java_matrix
+    - ingestion-sink-integration: *java_matrix
     - ingestion-sink-release:
+        executor: docker-compose
         filters:
           branches:
             only: main

--- a/ingestion-beam/Dockerfile
+++ b/ingestion-beam/Dockerfile
@@ -15,7 +15,7 @@ RUN mvn package -Dmaven.test.skip=true
 # https://cloud.google.com/dataflow/docs/guides/templates/configuring-flex-templates#changing_the_base_image
 # and the versions available are defined here:
 # https://cloud.google.com/dataflow/docs/reference/flex-templates-base-images
-FROM gcr.io/dataflow-templates-base/java11-template-launcher-base:20210120_RC00
+FROM gcr.io/dataflow-templates-base/java11-template-launcher-base:20210419_RC00
 ARG PACKAGE_VERSION=0.1-SNAPSHOT
 COPY --from=build /app/ingestion-beam/target/ingestion-beam-$PACKAGE_VERSION.lib/ /template/ingestion-beam-$PACKAGE_VERSION.lib/
 # copy jar after dependencies to maximize docker caching and reduce upload size

--- a/ingestion-beam/Dockerfile
+++ b/ingestion-beam/Dockerfile
@@ -1,5 +1,5 @@
 # Use maven image to build the jars that will be included via COPY later.
-FROM maven:3-jdk-8 AS build
+FROM maven:3-jdk-11 AS build
 WORKDIR /app/ingestion-beam
 COPY pom.xml /app/pom.xml
 COPY ingestion-beam/pom.xml /app/ingestion-beam/pom.xml
@@ -15,7 +15,7 @@ RUN mvn package -Dmaven.test.skip=true
 # https://cloud.google.com/dataflow/docs/guides/templates/configuring-flex-templates#changing_the_base_image
 # and the versions available are defined here:
 # https://cloud.google.com/dataflow/docs/reference/flex-templates-base-images
-FROM gcr.io/dataflow-templates-base/java8-template-launcher-base:20210120_RC00
+FROM gcr.io/dataflow-templates-base/java11-template-launcher-base:20210120_RC00
 ARG PACKAGE_VERSION=0.1-SNAPSHOT
 COPY --from=build /app/ingestion-beam/target/ingestion-beam-$PACKAGE_VERSION.lib/ /template/ingestion-beam-$PACKAGE_VERSION.lib/
 # copy jar after dependencies to maximize docker caching and reduce upload size

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/metrics/KeyedCounter.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/metrics/KeyedCounter.java
@@ -1,8 +1,8 @@
 package com.mozilla.telemetry.metrics;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 
@@ -11,7 +11,7 @@ import org.apache.beam.sdk.metrics.Metrics;
  */
 public class KeyedCounter {
 
-  static final Map<String, Counter> counters = new HashMap<>();
+  static final Map<String, Counter> counters = new ConcurrentHashMap<>();
 
   /**
    * Increment the counter associated with the given key by 1.


### PR DESCRIPTION
per https://github.com/mozilla/gcp-ingestion/issues/1534#issuecomment-893478454

also run beam and sink tests in both java 8 and 11 until we are fully off java 8