### PR TITLE
Remove fixed list of query params for impression aggregation

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/AggregateImpressions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/AggregateImpressions.java
@@ -1,7 +1,6 @@
 package com.mozilla.telemetry.contextualservices;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
 import com.mozilla.telemetry.transforms.PubsubConstraints;
@@ -10,6 +9,7 @@ import com.mozilla.telemetry.util.Time;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
@@ -33,11 +33,6 @@ import org.joda.time.Instant;
  */
 public class AggregateImpressions
     extends PTransform<PCollection<PubsubMessage>, PCollection<PubsubMessage>> {
-
-  private static final List<String> aggregationFields = ImmutableList.of(
-      ParsedReportingUrl.PARAM_COUNTRY_CODE, ParsedReportingUrl.PARAM_REGION_CODE,
-      ParsedReportingUrl.PARAM_FORM_FACTOR, ParsedReportingUrl.PARAM_OS_FAMILY,
-      ParsedReportingUrl.PARAM_ID, ParsedReportingUrl.PARAM_DMA_CODE);
 
   private final String aggregationWindowDuration;
 
@@ -75,10 +70,12 @@ public class AggregateImpressions
 
     ParsedReportingUrl urlParser = new ParsedReportingUrl(reportingUrl);
 
-    // Rebuild url filtering out unneeded parameters
+    // Rebuild url, sorting query params for consistency across urls
+    List<Map.Entry<String, String>> keyValues = urlParser.getQueryParams().entrySet().stream()
+        .sorted(Map.Entry.comparingByKey()).collect(Collectors.toList());
     ParsedReportingUrl aggregationUrl = new ParsedReportingUrl(urlParser.getBaseUrl());
-    for (String name : aggregationFields) {
-      aggregationUrl.addQueryParam(name, urlParser.getQueryParam(name));
+    for (Map.Entry<String, String> kv : keyValues) {
+      aggregationUrl.addQueryParam(kv.getKey(), kv.getValue());
     }
 
     return aggregationUrl.toString();

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/AggregateImpressions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/AggregateImpressions.java
@@ -37,7 +37,7 @@ public class AggregateImpressions
   private static final List<String> aggregationFields = ImmutableList.of(
       ParsedReportingUrl.PARAM_COUNTRY_CODE, ParsedReportingUrl.PARAM_REGION_CODE,
       ParsedReportingUrl.PARAM_FORM_FACTOR, ParsedReportingUrl.PARAM_OS_FAMILY,
-      ParsedReportingUrl.PARAM_ID);
+      ParsedReportingUrl.PARAM_ID, ParsedReportingUrl.PARAM_DMA_CODE);
 
   private final String aggregationWindowDuration;
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParsedReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParsedReportingUrl.java
@@ -67,6 +67,10 @@ public class ParsedReportingUrl {
     return queryParams.get(paramName);
   }
 
+  public Map<String, String> getQueryParams() {
+    return queryParams;
+  }
+
   public String getBaseUrl() {
     return reportingUrl.toString().split("\\?")[0];
   }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
@@ -57,26 +57,24 @@ public class AggregateImpressionsTest {
 
   @Test
   public void testGetAggregationKey() {
-    String url = String.format("http://test.com?%s=US&unwanted=abc",
-        ParsedReportingUrl.PARAM_COUNTRY_CODE);
+    String url = "http://test.com?country-code=US&abc=abc&def=a";
     Map<String, String> attributes = Collections.singletonMap(Attribute.REPORTING_URL, url);
     PubsubMessage message = new PubsubMessage(new byte[] {}, attributes);
 
     String aggKey = AggregateImpressions.getAggregationKey(message);
 
-    // Should remove unwanted params and add missing ones
-    Assert.assertTrue(aggKey.startsWith("http://test.com?"));
-    Assert.assertTrue(aggKey.contains(ParsedReportingUrl.PARAM_COUNTRY_CODE + "=US"));
-    Assert.assertTrue(aggKey.contains(ParsedReportingUrl.PARAM_REGION_CODE));
-    Assert.assertFalse(aggKey.contains("unwanted=abc"));
+    // Should return url with sorted query params
+    Assert.assertEquals(aggKey, "http://test.com?abc=abc&country-code=US&def=a");
   }
 
   @Test
   public void testAggregation() {
     Map<String, String> attributesUrl1 = Collections.singletonMap(Attribute.REPORTING_URL,
-        String.format("https://test.com?%s=US", ParsedReportingUrl.PARAM_COUNTRY_CODE));
+        String.format("https://test.com?%s=US&%s=", ParsedReportingUrl.PARAM_COUNTRY_CODE,
+            ParsedReportingUrl.PARAM_REGION_CODE));
     Map<String, String> attributesUrl2 = Collections.singletonMap(Attribute.REPORTING_URL,
-        String.format("https://test.com?%s=DE", ParsedReportingUrl.PARAM_COUNTRY_CODE));
+        String.format("https://test.com?%s=DE&%s=", ParsedReportingUrl.PARAM_COUNTRY_CODE,
+            ParsedReportingUrl.PARAM_REGION_CODE));
 
     List<PubsubMessage> input = ImmutableList.of(new PubsubMessage(new byte[0], attributesUrl1),
         new PubsubMessage(new byte[0], attributesUrl2),


### PR DESCRIPTION
This should fix it but this seems like this can easily happen again and it might be tricky to catch in unit tests.  I think the aggregation fields was used to reduce the number of keys to group by but I'm not sure if it's useful.  I can look at the query params that we're actually receiving and see if this is needed.