### PR TITLE
Update docs edit uri to main branch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: Mozilla Telemetry ingestion on Google Cloud Platform
 site_author: Mozilla Data Platform Team
 
 repo_url: https://github.com/mozilla/gcp-ingestion/
-edit_uri: blob/main/docs/
+edit_uri: edit/main/docs/
 
 theme:
   name: material


### PR DESCRIPTION
See: https://www.mkdocs.org/user-guide/configuration/#edit_uri
The default edit link goes to edit in the master branch which gives a 404.  

An additional option is to point to the read-only view of the file instead of going directly to the edit page which I would prefer but it's probably inconsequential.