### PR TITLE
Ignore beam-synchronous deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: /
   ignore:
   - dependency-name: com.google.cloud:libraries-bom
+  - dependency-name: com.fasterxml.jackson:jackson-bom
+  - dependency-name: org.apache.avro:avro
   schedule:
     interval: daily
   reviewers:


### PR DESCRIPTION
prevents PRs like #1804 and #1656