### PR TITLE
Contextual services docs fix

### DIFF
--- a/docs/ingestion-beam/contextual-services-job.md
+++ b/docs/ingestion-beam/contextual-services-job.md
@@ -13,7 +13,7 @@ The input of this job is all `contextual-services` namespace messages, which inc
 
 The following diagram shows the steps in the Beam pipeline. This is up to date as of 2021-08-23.
 
-![diagrams/ctxtsvc-sender.mmd](../diagrams/ctxtsvc-sender.svg)
+![diagrams/ctxt-sender.mmd](../diagrams/ctxt-sender.svg)
 **Figure**: _An overview of the execution graph for the `ContextualServicesReporter`._
 
 ### Pub/Sub republished topic


### PR DESCRIPTION
Follow-up to #1825 and #1824. I actually ran `mkdocs` locally this time to verify the diagram is getting pulled in.