### PR TITLE
Bug 1732313 - Marking com-apple-dt-xctest-tool and org-mozilla-feniy as unwanted namespaces

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -64,6 +64,8 @@ public class MessageScrubber {
       .put("artistscope-ios-artisbrowser", "1719343") //
       .put("com-luxxle-ios-fennec", "1719341") //
       .put("com-etiantian-pclass", "1719338") //
+      .put("com-apple-dt-xctest-tool", "1732313") //
+      .put("org-mozilla-feniy", "1732313") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap


### PR DESCRIPTION
See title and https://bugzilla.mozilla.org/show_bug.cgi?id=1732313