### PR TITLE
Add per-doctype counter to ParseReportingUrl

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
@@ -97,7 +97,7 @@ public class ParseReportingUrl extends
           ParsedReportingUrl urlParser = new ParsedReportingUrl(reportingUrl);
 
           if (!isUrlValid(urlParser.getReportingUrl(), attributes.get(Attribute.DOCUMENT_TYPE))) {
-            PerDocTypeCounter.inc(attributes, "RejectedNonNullUrl");
+            PerDocTypeCounter.inc(attributes, "rejected_nonnull_url");
             throw new ParsedReportingUrl.InvalidUrlException(
                 "Reporting URL host not found in allow list: " + reportingUrl);
           }


### PR DESCRIPTION
This is the last point in the ContextualServicesReporter at which we filter
out individual pings before aggregation, so is the best place to emit a metric
about submissions we'll be making per-doctype.

This will provide a slightly more reliable measure for our operational dashboards.