### PR TITLE
Update Snappy dep for Apple Silicon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,9 @@
         <jackson.version>2.12.4</jackson.version>
         <avro.version>1.8.2</avro.version>
 
+        <!-- The version pulled in by avro does not support Apple Silicon as of Jan 2022 -->
+        <snappy.version>1.1.8.3</snappy.version>
+
         <!-- Set empty default. -->
         <exec.mainClass></exec.mainClass>
     </properties>
@@ -130,6 +133,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>1.21</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${snappy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -133,11 +138,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>1.21</version>
-        </dependency>
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <version>${snappy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
The snappy-java library supports M1 processors as of 1.1.8.2; see
https://github.com/xerial/snappy-java/blob/master/Milestone.md#snappy-java-1182-2020-11-28

This change should be relatively safe, as snappy pulls in no transitive deps and we do not actually rely on snappy compression in production currently.

With this change, I was able to run `mvn clean test` successfully in this repo on an M1 Mac.