### PR TITLE
Bug 1752178 Allow DDG organic codes

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -112,6 +112,10 @@ public class MessageScrubber {
   private static final Set<String> ALLOWED_DESKTOP_SEARCH_CODES = ImmutableSet.of("none",
       // Client-side sanitization will produce "other"
       "other",
+      // Additional DDG-specific codes; ideally these would be marked as "none" for organic,
+      // but to avoid additional pipeline complexity, we add them as allowed codes here;
+      // see bug 1752239.
+      "hz", "h_",
       // Values below are pulled from search-telemetry-v2.json as defined in
       // https://phabricator.services.mozilla.com/D136768
       // Longer-term, they will be available in RemoteSettings at:

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -498,7 +498,8 @@ public class MessageScrubberTest {
         + "        \"google.in-content.sap-follow-on.none\": 1,\n" //
         + "        \"google.in-content.sap-follow-on.blahblah\": 2,\n" //
         + "        \"google.in-content.sap-follow-on._1000969a\": 3,\n" //
-        + "        \"google.in-content.sap-follow-on.ubuntu.ts\": 4\n" //
+        + "        \"google.in-content.sap-follow-on.ubuntu.ts\": 4,\n" //
+        + "        \"duckduckgo.in-content.organic.h_\": 5\n" //
         + "      },\n" //
         + "      \"browser.search.ad_clicks\": {\n" //
         + "        \"google.in-content.sap-follow-on.none\": 6,\n" //
@@ -516,7 +517,8 @@ public class MessageScrubberTest {
         + "        \"google.in-content.sap-follow-on.none\": 1,\n" //
         + "        \"google.in-content.sap-follow-on.other-scrubbed\": 2,\n" //
         + "        \"google.in-content.sap-follow-on._1000969a\": 3,\n" //
-        + "        \"google.in-content.sap-follow-on.ubuntu.ts\": 4\n" //
+        + "        \"google.in-content.sap-follow-on.ubuntu.ts\": 4,\n" //
+        + "        \"duckduckgo.in-content.organic.h_\": 5\n" //
         + "      },\n" //
         + "      \"browser.search.ad_clicks\": {\n" //
         + "        \"google.in-content.sap-follow-on.none\": 6,\n" //


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1752239

In particular, see discussion about choosing to allow these codes through rather than replacing values with "none" as is done on the client.