### PR TITLE
Switch exception class from AffectedByBug to UnwantedDataException

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -244,7 +244,7 @@ public class MessageScrubber {
 
     // No such docType: default-browser-agent/1
     if ("default-browser-agent".equals(namespace) && "1".equals(docType)) {
-      throw new AffectedByBugException("1626020");
+      throw new UnwantedDataException("1626020");
     }
 
     // Redactions (message is altered, but allowed through).

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -597,7 +597,7 @@ public class MessageScrubberTest {
   }
 
   @Test
-  public void testBug1626020Affected() throws Exception {
+  public void testBug1626020() throws Exception {
     ObjectNode pingToBeScrubbed = Json.readObjectNode(("{\n" //
         + "  \"client_info\": {\n" //
         + "    \"client_id\": null" //
@@ -607,7 +607,7 @@ public class MessageScrubberTest {
         .put(Attribute.DOCUMENT_NAMESPACE, "default-browser-agent")
         .put(Attribute.DOCUMENT_TYPE, "1").build();
 
-    assertThrows(AffectedByBugException.class,
+    assertThrows(UnwantedDataException.class,
         () -> MessageScrubber.scrub(attributes, pingToBeScrubbed));
   }
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1749356

This change will prevent these error messages from showing
up in our monitoring dashboard.

https://mozilla.cloud.looker.com/dashboards/387?Submission+Date=90+day