### PR TITLE
Don't have pip resolve and install dependencies

### DIFF
--- a/ingestion-edge/bin/build
+++ b/ingestion-edge/bin/build
@@ -4,4 +4,4 @@
 
 if ${VENV:-true}; then python3.8 -m venv "$VENV_DIR"; source "$VENV_ACTIVATE"; fi
 
-python3.8 -m pip install --no-cache-dir -r requirements.txt
+python3.8 -m pip install --no-cache-dir --no-deps -r requirements.txt


### PR DESCRIPTION
The dependencies are already precalculated by pip-compile and frozen in `requirements.txt`, and pip's own dependency resolution has issues.

- The [pip docs about repeatable installs](https://pip.pypa.io/en/stable/topics/repeatable-installs/#pinning-the-package-versions) specifically suggests using `--no-deps`.
- I successfully tested the build locally using `--no-deps`.
- I'm unsure whether pip will still [install dependencies before their dependents](https://pip.pypa.io/en/stable/cli/pip_install/#installation-order) when `--no-deps` is specified.