### PR TITLE
Downgrade beam from 2.36.0 to 2.35.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <argLine>-Xmx1024m -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
 
         <auto-value.version>1.9</auto-value.version>
-        <beam.version>2.36.0</beam.version>
+        <beam.version>2.35.0</beam.version>
 
         <!-- Keep these dependency versions in sync with what is pulled in by beam;
              check https://mvnrepository.com/artifact/org.apache.beam -->


### PR DESCRIPTION
We are experiencing a production issue and it seems like 2.35.0 is working. /cc @whd 

<pending JIRA ticket>
