### PR TITLE
[1754044] Add support for expiration_policy.collect_through_date

### DIFF
--- a/ingestion-beam/bin/download-schemas
+++ b/ingestion-beam/bin/download-schemas
@@ -115,6 +115,20 @@ EOF
   "type" : "object"
 }
 EOF
+    mkdir -p schemas/test/expiration-policy
+    cat > schemas/test/expiration-policy/expiration-policy.1.schema.json << 'EOF'
+{
+  "mozPipelineMetadata": {
+    "bq_dataset_family": "test",
+    "bq_metadata_format": "structured",
+    "bq_table": "expiration_policy_v1",
+    "expiration_policy": {
+      "collect_through_date": "2022-03-01"
+    }
+  },
+  "type" : "object"
+}
+EOF
     mkdir -p schemas/my-namespace/my-test
     cat > schemas/my-namespace/my-test/my-test.1.bq << 'EOF'
 [

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/schema/PipelineMetadataStore.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/schema/PipelineMetadataStore.java
@@ -75,6 +75,34 @@ public class PipelineMetadataStore extends SchemaStore<PipelineMetadataStore.Pip
   }
 
   @AutoValue
+  @JsonDeserialize(builder = AutoValue_PipelineMetadataStore_ExpirationPolicy.Builder.class)
+  public abstract static class ExpirationPolicy {
+
+    public static Builder builder() {
+      return new AutoValue_PipelineMetadataStore_ExpirationPolicy.Builder();
+    }
+
+    @Nullable
+    public abstract Integer delete_after_days();
+
+    @Nullable
+    public abstract String collect_through_date();
+
+    @AutoValue.Builder
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public abstract static class Builder {
+
+      public abstract Builder delete_after_days(Integer value);
+
+      public abstract Builder collect_through_date(String value);
+
+      public abstract ExpirationPolicy build();
+    }
+
+  }
+
+  @AutoValue
   @JsonDeserialize(builder = AutoValue_PipelineMetadataStore_PipelineMetadata.Builder.class)
   public abstract static class PipelineMetadata {
 
@@ -97,6 +125,9 @@ public class PipelineMetadataStore extends SchemaStore<PipelineMetadataStore.Pip
     @Nullable
     public abstract List<JweMapping> jwe_mappings();
 
+    @Nullable
+    public abstract ExpirationPolicy expiration_policy();
+
     @AutoValue.Builder
     @JsonPOJOBuilder(withPrefix = "")
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -113,6 +144,8 @@ public class PipelineMetadataStore extends SchemaStore<PipelineMetadataStore.Pip
       public abstract Builder override_attributes(List<AttributeOverride> value);
 
       public abstract Builder jwe_mappings(List<JweMapping> value);
+
+      public abstract Builder expiration_policy(ExpirationPolicy value);
 
       public abstract PipelineMetadata build();
     }

--- a/ingestion-core/src/test/java/com/mozilla/telemetry/ingestion/core/schema/PipelineMetadataStoreTest.java
+++ b/ingestion-core/src/test/java/com/mozilla/telemetry/ingestion/core/schema/PipelineMetadataStoreTest.java
@@ -17,4 +17,10 @@ public class PipelineMetadataStoreTest {
     assertEquals("/test_string", meta.jwe_mappings().get(0).decrypted_field_path().toString());
   }
 
+  @Test
+  public void testExpirationMetadata() throws SchemaNotFoundException {
+    PipelineMetadata meta = store.getSchema("namespace_0/bar/bar.1.schema.json");
+    assertEquals("2022/03/01", meta.expiration_policy().collect_through_date());
+  }
+
 }

--- a/ingestion-core/src/test/resources/schema/test-schemas/schemas/namespace_0/bar/bar.1.schema.json
+++ b/ingestion-core/src/test/resources/schema/test-schemas/schemas/namespace_0/bar/bar.1.schema.json
@@ -10,7 +10,10 @@
         "source_field_path": "/test_jwe",
         "decrypted_field_path": "/test_string"
       }
-    ]
+    ],
+    "expiration_policy": {
+      "collect_through_date": "2022/03/01"
+    }
   },
   "properties" : {
     "payload": {


### PR DESCRIPTION
This is support work to be able to mark schemas as deprecated via the
`expiration_policy.collect_through_date` property in the `mozPipelineMetadata` object.

* Added support for expiration_policy in the PipelineMetadataStore object.
* Created a deprecation check in the ParsePayload pipeline.

side note: my java is pretty rusty and i tried to err on the side of saftey. so please let me know if you see something that would be more idiomatic.