### PR TITLE
Revert "Bug 1737861 Tag pings from BrowserStack ISP as automation"

### DIFF
--- a/docs/architecture/edge_service_specification.md
+++ b/docs/architecture/edge_service_specification.md
@@ -51,7 +51,7 @@ required group attributes {
   optional string x_debug_id           // example: "my_debug_session_1"
   optional string x_pipeline_proxy     // time that the AWS->GCP tee received the message, example: "2018-03-12T21:02:18.123456Z"
   optional string x_telemetry_agent    // example: "Glean/0.40.0 (Kotlin on Android)"
-  optional string x_source_tags        // example: "Automation, Other"
+  optional string x_source_tags        // example: "automation, other"
   optional string x_foxsec_ip_reputation // example: "95"
   optional string x_lb_tags            // example: "TLSv1.3, 009C"
 }

--- a/docs/architecture/edge_service_specification.md
+++ b/docs/architecture/edge_service_specification.md
@@ -51,7 +51,7 @@ required group attributes {
   optional string x_debug_id           // example: "my_debug_session_1"
   optional string x_pipeline_proxy     // time that the AWS->GCP tee received the message, example: "2018-03-12T21:02:18.123456Z"
   optional string x_telemetry_agent    // example: "Glean/0.40.0 (Kotlin on Android)"
-  optional string x_source_tags        // example: "automation, other"
+  optional string x_source_tags        // example: "Automation, Other"
   optional string x_foxsec_ip_reputation // example: "95"
   optional string x_lb_tags            // example: "TLSv1.3, 009C"
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -11,9 +11,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -296,20 +293,6 @@ public class MessageScrubber {
     if ("metrics".equals(docType) && namespace != null
         && BUG_1751955_AFFECTED_NAMESPACES.contains(namespace)) {
       processForBug1751955(json);
-    }
-
-    if ("BrowserStack".equals(attributes.get(Attribute.ISP_NAME))) {
-      String tags = Strings.nullToEmpty(attributes.get(Attribute.X_SOURCE_TAGS));
-      List<String> tagList = Arrays.stream(tags.trim().split("\\s*,\\s*"))
-          .filter(s -> s.length() > 0).collect(Collectors.toList());
-      if (!tagList.contains("automation")) {
-        // We add the "automation" tag to all pings coming from BrowserStack to cause
-        // them to be filtered out of stable tables.
-        tagList = new ArrayList<>(tagList);
-        tagList.add("automation");
-        attributes.put(Attribute.X_SOURCE_TAGS, String.join(", ", tagList));
-        markBugCounter("1757216");
-      }
     }
 
     // Data collected prior to glean.js 0.17.0 is effectively useless.

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -2,7 +2,6 @@ package com.mozilla.telemetry.decoder;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -565,44 +564,6 @@ public class MessageScrubberTest {
         + "}\n").getBytes(StandardCharsets.UTF_8));
     MessageScrubber.scrub(attributes, json);
     assertEquals(expected, json);
-  }
-
-  @Test
-  public void testShouldTagBrowserStackBug1757216() throws Exception {
-    final ObjectNode emptyNode = Json.createObjectNode();
-    final Map<String, String> baseAttributes = ImmutableMap.<String, String>builder() //
-        .put(Attribute.DOCUMENT_NAMESPACE, "org-mozilla-firefox") //
-        .put(Attribute.DOCUMENT_TYPE, "baseline") //
-        .put(Attribute.DOCUMENT_VERSION, "1") //
-        .put(Attribute.ISP_NAME, "BrowserStack").build();
-
-    Map<String, String> noTags = new HashMap<>(baseAttributes);
-    MessageScrubber.scrub(noTags, emptyNode);
-    assertEquals("automation", noTags.get(Attribute.X_SOURCE_TAGS));
-
-    Map<String, String> twoTags = new HashMap<>(baseAttributes);
-    twoTags.put(Attribute.X_SOURCE_TAGS, "foo ,  bar");
-    MessageScrubber.scrub(twoTags, emptyNode);
-    assertEquals("foo, bar, automation", twoTags.get(Attribute.X_SOURCE_TAGS));
-
-    Map<String, String> existingAutomationTags = new HashMap<>(baseAttributes);
-    existingAutomationTags.put(Attribute.X_SOURCE_TAGS, "automation,  foo");
-    MessageScrubber.scrub(existingAutomationTags, emptyNode);
-    assertEquals("automation,  foo", existingAutomationTags.get(Attribute.X_SOURCE_TAGS));
-  }
-
-  @Test
-  public void testShouldNotTagBrowserStackBug1757216() throws Exception {
-    final ObjectNode emptyNode = Json.createObjectNode();
-    final Map<String, String> baseAttributes = ImmutableMap.<String, String>builder() //
-        .put(Attribute.DOCUMENT_NAMESPACE, "org-mozilla-firefox") //
-        .put(Attribute.DOCUMENT_TYPE, "baseline") //
-        .put(Attribute.DOCUMENT_VERSION, "1") //
-        .put(Attribute.ISP_NAME, "Your Fave ISP").build();
-
-    Map<String, String> noTags = new HashMap<>(baseAttributes);
-    MessageScrubber.scrub(noTags, emptyNode);
-    assertNull(noTags.get(Attribute.X_SOURCE_TAGS));
   }
 
   @Test


### PR DESCRIPTION
Reverts mozilla/gcp-ingestion#2031

I announced this change in the related incident channel, and it turns out there's not yet consensus around dropping this data, so backing out for now.