### PR TITLE
Bug 1765250 Avoid unroutable messages with missing document_id

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -119,6 +119,14 @@ public class ParseUri {
       // message ID can be removed since it's only used for generating document ID but not used any
       // further
       attributes.remove(Attribute.MESSAGE_ID);
+
+      // Validate attributes
+      try {
+        UUID.fromString(attributes.get(Attribute.DOCUMENT_ID));
+      } catch (IllegalArgumentException e) {
+        throw new InvalidUriException("Entry in document_id place is not a valid UUID");
+      }
+
       return new PubsubMessage(payload, attributes);
     }).exceptionsInto(TypeDescriptor.of(PubsubMessage.class))
         .exceptionsVia((WithFailures.ExceptionElement<PubsubMessage> ee) -> {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
@@ -49,6 +49,9 @@ public class ParseUriTest extends TestWithDeterministicJson {
             + "{\"uri\":\"/nonexistent_prefix/ce39b608-f595-4c69-b6a6-f7a436604648" //
             + "/main/Firefox/61.0a1/nightly/20180328030202\"" //
             + "},\"payload\":\"\"}",
+        "{\"attributeMap\":{\"uri\":\"/submit/telemetry//update/Firefox/61.0a1" //
+            + "/nightly/20180328030202\"" //
+            + "},\"payload\":\"\"}",
         "{\"attributeMap\":" //
             + "{\"uri\":\"/submit/telemetry/ce39b608-f595-4c69-b6a6-f7a436604648"
             + "/Firefox/61.0a1/nightly/20180328030202\"" //
@@ -92,6 +95,7 @@ public class ParseUriTest extends TestWithDeterministicJson {
             .via(message -> message.getAttribute("exception_class")));
     PAssert.that(exceptions).containsInAnyOrder(
         Arrays.asList("com.mozilla.telemetry.decoder.ParseUri$InvalidUriException",
+            "com.mozilla.telemetry.decoder.ParseUri$InvalidUriException",
             "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException",
             "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException"));
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1765250