### PR TITLE
Remove explicit versioning of google-cloud-pubsublite

### DIFF
--- a/ingestion-sink/pom.xml
+++ b/ingestion-sink/pom.xml
@@ -51,12 +51,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- explicitly version PubSub Lite until it is included in libraries-bom. -->
-            <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-pubsublite</artifactId>
-                <version>1.5.3</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>


### PR DESCRIPTION
because it is now included in `libraries-bom`