### PR TITLE
Update known bad versions of google-cloud-pubsub

### DIFF
--- a/ingestion-sink/pom.xml
+++ b/ingestion-sink/pom.xml
@@ -61,8 +61,8 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-pubsub</artifactId>
-                <!-- Versions 1.116.0 to 1.116.4 (at least) produce the following error in stage and
-                  prod, likely from calling ModifyAckDeadline with too many ack ids at once:
+                <!-- Versions 1.116.0 to 1.117.0 (at least) produce the following error under load,
+                  likely from calling ModifyAckDeadline with too many ack ids at once:
                   com.google.api.gax.rpc.InvalidArgumentException: io.grpc.StatusRuntimeException:
                   INVALID_ARGUMENT: Request payload size exceeds the limit: 524288 bytes. -->
                 <version>1.115.5</version>


### PR DESCRIPTION
upstream issue: https://github.com/googleapis/java-pubsub/issues/1126