### PR TITLE
CONSVC 1872: Share quicksuggest pings for all scenarios

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
@@ -243,15 +243,6 @@ public class ParseReportingUrl extends
                 message.getAttribute(Attribute.GEO_DMA_CODE));
           }
 
-          // Specific validation for quicksuggest
-          if (SponsoredInteraction.SOURCE_SUGGEST.equals(interaction.getSource())) {
-            // See https://mozilla-hub.atlassian.net/browse/CONSVC-1777
-            if (!"online".equals(payload.path("scenario").asText())) {
-              throw new RejectedMessageException(
-                  "We send quicksuggest pings only for the online scenario");
-            }
-          }
-
           // We only add these dimensions for topsites clicks, not quicksuggest per
           // https://bugzilla.mozilla.org/show_bug.cgi?id=1738974
           // We are also limiting this to desktop.

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
@@ -167,42 +167,6 @@ public class ParseReportingUrlTest {
   }
 
   @Test
-  public void testSuggestOnlineScenarioFilter() {
-    Map<String, String> attributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE,
-        "quicksuggest-impression", Attribute.DOCUMENT_NAMESPACE, "contextual-services",
-        Attribute.USER_AGENT_OS, "Windows");
-
-    ObjectNode basePayload = Json.createObjectNode();
-    basePayload.put(Attribute.NORMALIZED_COUNTRY_CODE, "US");
-    basePayload.put(Attribute.VERSION, "87.0");
-    basePayload.put(Attribute.REPORTING_URL,
-        "https://moz.impression.com/?partner=1&custom-data=foo&sub1=bar&sub2=baz&adv-id=eggs&v=5");
-
-    List<PubsubMessage> input = Stream.of("online", "offline", "")
-        .map(scenario -> basePayload.deepCopy().put("scenario", scenario))
-        .map(payload -> new PubsubMessage(Json.asBytes(payload), attributes))
-        .collect(Collectors.toList());
-
-    Result<PCollection<SponsoredInteraction>, PubsubMessage> result = pipeline //
-        .apply(Create.of(input)) //
-        .apply(ParseReportingUrl.of(URL_ALLOW_LIST));
-
-    PAssert.that(result.failures()).satisfies(messagesIter -> {
-      ArrayList<PubsubMessage> messages = Lists.newArrayList(messagesIter.iterator());
-      Assert.assertEquals(2, messages.size());
-      return null;
-    });
-
-    PAssert.that(result.output()).satisfies(messagesIter -> {
-      ArrayList<SponsoredInteraction> messages = Lists.newArrayList(messagesIter.iterator());
-      Assert.assertEquals(1, messages.size());
-      return null;
-    });
-
-    pipeline.run();
-  }
-
-  @Test
   public void testDmaCode() {
     ObjectNode inputPayload = Json.createObjectNode();
     inputPayload.put(Attribute.NORMALIZED_COUNTRY_CODE, "US");

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
 import com.mozilla.telemetry.util.Json;
 import java.io.IOException;


### PR DESCRIPTION
This reverts the change of https://github.com/mozilla/gcp-ingestion/pull/2075/ and closes [CONSVC-1872](https://mozilla-hub.atlassian.net/browse/CONSVC-1872).

r? @quiiver 