### PR TITLE
Bug 1784911 - Drop firefox-desktop.background-update pings

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -218,6 +218,9 @@ public class MessageScrubber {
     if ("account-ecosystem".equals(docType)) {
       throw new MessageShouldBeDroppedException("1697602");
     }
+    if ("firefox-desktop".equals(namespace) && "background-update".equals(docType)) {
+      throw new MessageShouldBeDroppedException("1784911");
+    }
 
     // Check for unwanted data; these messages aren't thrown out, but this class of errors will be
     // ignored for most pipeline monitoring.


### PR DESCRIPTION
Per discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1784911#c15, `firefox-desktop.background-update` pings are sent due to a bug in Glean SDK. This PR makes Decoder drop these pings so they're not showing up in monitoring queries. When this is deployed, a counter with a bug number label will start to be collected in the pipeline. As a follow up note should be added in the bug with a link to a dashboard to monitor this counter. This will allow for monitoring the effect of the future fix.