### PR TITLE
Optimize schemas loading in the Decoder

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/SanitizeAttributes.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/SanitizeAttributes.java
@@ -3,8 +3,8 @@ package com.mozilla.telemetry.decoder;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
 import com.mozilla.telemetry.ingestion.core.schema.PipelineMetadataStore;
 import com.mozilla.telemetry.ingestion.core.schema.PipelineMetadataStore.PipelineMetadata;
+import com.mozilla.telemetry.schema.SchemaStoreSingletonFactory;
 import com.mozilla.telemetry.transforms.PubsubConstraints;
-import com.mozilla.telemetry.util.BeamFileInputStream;
 import com.mozilla.telemetry.util.Time;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
@@ -12,9 +12,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
-import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 
 /**
@@ -38,7 +38,7 @@ public class SanitizeAttributes
 
   @Override
   public PCollection<PubsubMessage> expand(PCollection<PubsubMessage> input) {
-    return input.apply(MapElements.via(fn));
+    return input.apply(ParDo.of(new Fn()));
   }
 
   ////////
@@ -47,17 +47,17 @@ public class SanitizeAttributes
     this.schemasLocation = schemasLocation;
   }
 
-  private class Fn extends SimpleFunction<PubsubMessage, PubsubMessage> {
+  private class Fn extends DoFn<PubsubMessage, PubsubMessage> {
 
-    @Override
-    public PubsubMessage apply(PubsubMessage message) {
+    @Setup
+    public void setup() {
+      pipelineMetadataStore = SchemaStoreSingletonFactory.getPipelineMetadataStore(schemasLocation);
+    }
+
+    @ProcessElement
+    public void processElement(@Element PubsubMessage message, OutputReceiver<PubsubMessage> out) {
       message = PubsubConstraints.ensureNonNull(message);
       Map<String, String> attributes = new HashMap<>(message.getAttributeMap());
-
-      if (pipelineMetadataStore == null) {
-        pipelineMetadataStore = PipelineMetadataStore.of(schemasLocation,
-            BeamFileInputStream::open);
-      }
 
       final PipelineMetadata meta = pipelineMetadataStore.getSchema(attributes);
 
@@ -82,10 +82,7 @@ public class SanitizeAttributes
         });
       }
 
-      return new PubsubMessage(message.getPayload(), attributes);
+      out.output(new PubsubMessage(message.getPayload(), attributes));
     }
   }
-
-  private final Fn fn = new Fn();
-
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/schema/SchemaStoreSingletonFactory.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/schema/SchemaStoreSingletonFactory.java
@@ -1,0 +1,55 @@
+package com.mozilla.telemetry.schema;
+
+import com.mozilla.telemetry.ingestion.core.schema.JSONSchemaStore;
+import com.mozilla.telemetry.ingestion.core.schema.PipelineMetadataStore;
+import com.mozilla.telemetry.util.BeamFileInputStream;
+
+/**
+ * Factory class for getting singleton instances of SchemaStores.
+ *
+ * <p>Beam can run up to 500 threads per worker
+ * (see https://cloud.google.com/dataflow/docs/guides/troubleshoot-oom#dofn)
+ * By using singleton instances of SchemaStores we can speed up worker startup a bit and
+ * decrease memory utilization.
+ *
+ * <p>`schemasLocation` parameter in the factory methods here is used only during object creation.
+ * This is fine here since the value is not changing during runtime of the job.
+ */
+public class SchemaStoreSingletonFactory {
+
+  private static volatile JSONSchemaStore jsonSchemaStore;
+  private static volatile PipelineMetadataStore pipelineMetadataStore;
+
+  private SchemaStoreSingletonFactory() {
+  }
+
+  /**
+   * Returns a singleton instance of {@link JSONSchemaStore}.
+   */
+  public static JSONSchemaStore getJsonSchemaStore(String schemasLocation) {
+    if (jsonSchemaStore == null) {
+      synchronized (SchemaStoreSingletonFactory.class) {
+        if (jsonSchemaStore == null) {
+          jsonSchemaStore = JSONSchemaStore.of(schemasLocation, BeamFileInputStream::open);
+        }
+      }
+    }
+    return jsonSchemaStore;
+  }
+
+  /**
+   * Returns a singleton instance of {@link PipelineMetadataStore}.
+   */
+  public static PipelineMetadataStore getPipelineMetadataStore(String schemasLocation) {
+    if (pipelineMetadataStore == null) {
+      synchronized (SchemaStoreSingletonFactory.class) {
+        if (pipelineMetadataStore == null) {
+          pipelineMetadataStore = PipelineMetadataStore.of(schemasLocation,
+              BeamFileInputStream::open);
+        }
+      }
+    }
+    return pipelineMetadataStore;
+  }
+
+}

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/schema/BigQuerySchemaStore.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/schema/BigQuerySchemaStore.java
@@ -65,11 +65,6 @@ public class BigQuerySchemaStore extends SchemaStore<Schema> {
     }
 
     @Override
-    protected void ensureSchemasLoaded() {
-      // load schemas on demand
-    }
-
-    @Override
     public Schema getSchema(String path) {
       // can't find schema without tableId
       throw SchemaNotFoundException.forName(path);


### PR DESCRIPTION
We [load schemas](https://github.com/mozilla/gcp-ingestion/blob/fb8d34477ad100e2be2f144be83bee6ab10bce57/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/schema/SchemaStore.java#L151) in the [main processing method](https://github.com/mozilla/gcp-ingestion/blob/fb8d34477ad100e2be2f144be83bee6ab10bce57/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParsePayload.java#L108) of the `ParsePayload` transform. While testing Streaming Engine ([Bug 1792955](https://bugzilla.mozilla.org/show_bug.cgi?id=1792955#c6)) this approach turned out to be suboptimal. The reason was that Streaming Engine uses more worker threads than default Streaming Appliance, scales more agressively, and schema loading is CPU intensive which caused delays when starting new workers.

This PR optimizes loading of schemas in the Decoder by:
* using shared singleton instances of SchemaStores
* eagerly loading schemas in SchemaStores
* initializing SchemaStores in `DoFn.Setup` instead of in the processing method of `ParsePayload` transform. `Setup` is an idiomatic place to initialize `DoFn` resources in Beam

It does improve autoscaling behavior and resource utilization with Streaming Engine enabled. I expect it to cause slightly lower memory utilization with current production configuration.
