### PR TITLE
Bug 1804285 - Scrub`com-netsweeper-clientfilter-homeprotectbylgfl`

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -51,6 +51,7 @@ public class MessageScrubber {
       .put("com-athena-equality-firefox", "1686088") //
       .put("com-authenticatedreality-fireios", "1686087") //
       .put("com-netsweeper-clientfilter-lgfl-homeprotect", "1686085") //
+      .put("com-netsweeper-clientfilter-homeprotectbylgfl", "1804285") //
       .put("com-myie9-xf", "1684918") //
       .put("com-netsweeper-clientfilter-lgfl-socialblocked", "1688689") //
       .put("com-only4free-activate", "1687350") //


### PR DESCRIPTION
Fixes [1804285](https://bugzilla.mozilla.org/show_bug.cgi?id=1804285)
Marking `com-netsweeper-clientfilter-homeprotectbylgfl` as UnwantedData.