### PR TITLE
Change query parameter for suspected fraudulent impressions

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
@@ -23,7 +23,7 @@ public class BuildReportingUrl {
   static final String PARAM_TIMESTAMP_BEGIN = "begin-timestamp";
   static final String PARAM_TIMESTAMP_END = "end-timestamp";
   static final String PARAM_CLICK_STATUS = "click-status";
-  static final String PARAM_IMPPRESSION_STATUS = "impression-status";
+  static final String PARAM_IMPRESSION_STATUS = "custom-data";
   static final String PARAM_DMA_CODE = "dma-code";
   static final String PARAM_CUSTOM_DATA = "custom-data";
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/LabelSpikes.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/LabelSpikes.java
@@ -76,7 +76,7 @@ public class LabelSpikes extends
         this.ghostEventCounter = Metrics.counter(LabelSpikes.class, "ghost_click");
         break;
       case IMPRESSION:
-        this.paramName = BuildReportingUrl.PARAM_IMPPRESSION_STATUS;
+        this.paramName = BuildReportingUrl.PARAM_IMPRESSION_STATUS;
         this.suspiciousParamValue = ParseReportingUrl.IMPRESSION_STATUS_SUSPICIOUS;
         this.ghostEventCounter = Metrics.counter(LabelSpikes.class, "ghost_impression");
         break;

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
@@ -68,7 +68,7 @@ public class ParseReportingUrl extends
   // Values for the click-status API parameter
   public static final String CLICK_STATUS_ABUSE = "64";
   public static final String CLICK_STATUS_GHOST = "65";
-  public static final String IMPRESSION_STATUS_SUSPICIOUS = "1";
+  public static final String IMPRESSION_STATUS_SUSPICIOUS = "invalid";
 
   // Threshold for IP reputation considered likely abuse.
   private static final int IP_REPUTATION_THRESHOLD = 70;

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/LabelSpikesTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/LabelSpikesTest.java
@@ -78,7 +78,7 @@ public class LabelSpikesTest {
     Builder<SponsoredInteraction> eventBuilder = TestStream.create(SponsoredInteraction.getCoder());
 
     // We add 20 messages each only a second apart. The first 10 should saturate the timestamp
-    // state, then the final 10 should be marked as suspicious via impression-status.
+    // state, then the final 10 should be marked as invalid via custom-data.
     for (int i = 1; i <= 20; i++) {
       eventBuilder = eventBuilder.advanceProcessingTime(Duration.standardSeconds(i))
           .addElements(interaction);
@@ -105,11 +105,11 @@ public class LabelSpikesTest {
 
     PAssert.that(result).satisfies(iter -> {
       long countWithStatus = StreamSupport.stream(iter.spliterator(), false) //
-          .filter(m -> m.getReportingUrl().contains("impression-status=1")) //
+          .filter(m -> m.getReportingUrl().contains("custom-data=invalid")) //
           .count();
       int expectedWithStatus = 10;
       assert countWithStatus == expectedWithStatus : ("Expected " + expectedWithStatus
-          + " messages with impression-status, but found " + countWithStatus);
+          + " messages with custom-data=invalid, but found " + countWithStatus);
       return null;
     });
 


### PR DESCRIPTION
We have shipped spike labelling for impressions for Ad Marketplace (woo!) and in it, we were labeling the suspected URLs (woo!), but Ad Marketplace has a specific key and value they would like for the query param we use to do that labeling.

This PR changes that query param to the one requested by the client, and fulfills the acceptance criteria of [DENG-689](https://mozilla-hub.atlassian.net/browse/DENG-689).

[DENG-689]: https://mozilla-hub.atlassian.net/browse/DENG-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ