### PR TITLE
Pin python docker image to debian buster

### DIFF
--- a/ingestion-edge/Dockerfile
+++ b/ingestion-edge/Dockerfile
@@ -1,8 +1,10 @@
 ARG PYTHON_VERSION=3.10
 
 # build requirements in separate stage because it requires gcc and libc-dev
-FROM python:${PYTHON_VERSION}-slim
+FROM python:${PYTHON_VERSION}-slim-buster AS base
 WORKDIR /app
+
+FROM base AS build
 RUN apt-get update && apt-get install -qqy gcc libc-dev
 COPY requirements.txt /app/
 COPY bin/include/common.sh /app/bin/include/
@@ -10,12 +12,11 @@ COPY bin/build /app/bin/
 ENV VENV=false
 RUN bin/build
 
-FROM python:${PYTHON_VERSION}-slim
-WORKDIR /app
+FROM base
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list && \
   apt-get update && \
   apt-get install -qqy --target-release buster-backports wrk
-COPY --from=0 /usr/local /usr/local
+COPY --from=build /usr/local /usr/local
 COPY . /app
 ENV HOST=0.0.0.0 PORT=8000
 CMD exec gunicorn \


### PR DESCRIPTION
so that wrk can be installed from buster-backports