### PR TITLE
Add position to Impression Aggregation Key

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
@@ -16,7 +16,8 @@ public class BuildReportingUrl {
   static final String PARAM_COUNTRY_CODE = "country-code";
   static final String PARAM_REGION_CODE = "region-code";
   static final String PARAM_OS_FAMILY = "os-family";
-  static final String PARAM_POSITION = "position";
+ //  Slot-number is 1-indexed: the first item will have the index 1, not zero
+  static final String PARAM_POSITION = "slot-number";
   static final String PARAM_FORM_FACTOR = "form-factor";
   static final String PARAM_PRODUCT_VERSION = "product-version";
   static final String PARAM_ID = "id";

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
@@ -16,6 +16,7 @@ public class BuildReportingUrl {
   static final String PARAM_COUNTRY_CODE = "country-code";
   static final String PARAM_REGION_CODE = "region-code";
   static final String PARAM_OS_FAMILY = "os-family";
+  static final String PARAM_POSITION = "position";
   static final String PARAM_FORM_FACTOR = "form-factor";
   static final String PARAM_PRODUCT_VERSION = "product-version";
   static final String PARAM_ID = "id";

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
@@ -16,7 +16,7 @@ public class BuildReportingUrl {
   static final String PARAM_COUNTRY_CODE = "country-code";
   static final String PARAM_REGION_CODE = "region-code";
   static final String PARAM_OS_FAMILY = "os-family";
- //  Slot-number is 1-indexed: the first item will have the index 1, not zero
+  //  Slot-number is 1-indexed: the first item will have the index 1, not zero
   static final String PARAM_POSITION = "slot-number";
   static final String PARAM_FORM_FACTOR = "form-factor";
   static final String PARAM_PRODUCT_VERSION = "product-version";

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
@@ -16,7 +16,7 @@ public class BuildReportingUrl {
   static final String PARAM_COUNTRY_CODE = "country-code";
   static final String PARAM_REGION_CODE = "region-code";
   static final String PARAM_OS_FAMILY = "os-family";
-  //  Slot-number is 1-indexed: the first item will have the index 1, not zero
+  // Slot-number is 1-indexed: the first item will have the index 1, not zero
   static final String PARAM_POSITION = "slot-number";
   static final String PARAM_FORM_FACTOR = "form-factor";
   static final String PARAM_PRODUCT_VERSION = "product-version";

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
@@ -111,6 +111,9 @@ public class ParseReportingUrl extends
           String submissionTimestamp = Optional //
               .ofNullable(message.getAttribute(Attribute.SUBMISSION_TIMESTAMP)) //
               .orElseGet(() -> Time.epochMicrosToTimestamp(new Instant().getMillis() * 1000));
+          String position = Optional //
+              .ofNullable(message.getAttribute(Attribute.POSITION)) //
+              .orElseGet(() -> "no_position");
 
           SponsoredInteraction.Builder interactionBuilder = SponsoredInteraction.builder();
 
@@ -118,6 +121,7 @@ public class ParseReportingUrl extends
           interactionBuilder.setOriginalNamespace(namespace);
           interactionBuilder.setOriginalDocType(docType);
           interactionBuilder.setScenario(parseScenario(payload).orElse(null));
+          interactionBuilder.setPosition(position);
 
           // set fields based on namespace/doctype combos
           if (NS_DESKTOP.equals(namespace)) {
@@ -240,6 +244,7 @@ public class ParseReportingUrl extends
             builtUrl.addQueryParam(BuildReportingUrl.PARAM_OS_FAMILY, osParam);
             builtUrl.addQueryParam(BuildReportingUrl.PARAM_FORM_FACTOR,
                 interaction.getFormFactor());
+            builtUrl.addQueryParam(BuildReportingUrl.PARAM_POSITION, interaction.getPosition());
 
             builtUrl.addQueryParam(BuildReportingUrl.PARAM_DMA_CODE,
                 message.getAttribute(Attribute.GEO_DMA_CODE));

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/SponsoredInteraction.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/SponsoredInteraction.java
@@ -57,6 +57,9 @@ public abstract class SponsoredInteraction implements Serializable {
   public abstract String getReportingUrl();
 
   @Nullable
+  abstract String getPosition();
+
+  @Nullable
   abstract String getRequestId();
 
   @Nullable
@@ -106,6 +109,8 @@ public abstract class SponsoredInteraction implements Serializable {
     public abstract Builder setSource(String newSource);
 
     public abstract Builder setFormFactor(String newFormFactor);
+
+    public abstract Builder setPosition(String newPosition);
 
     public abstract Builder setScenario(String newScenario);
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
@@ -72,12 +72,14 @@ public class AggregateImpressionsTest {
     SponsoredInteraction.Builder baseInteraction = getTestInteraction();
 
     String attributesUrl1 = String.format("https://test.com?%s=US&%s=&%s=1",
-        BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE, BuildReportingUrl.PARAM_POSITION);
+        BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE,
+        BuildReportingUrl.PARAM_POSITION);
     String attributesUrl2 = String.format("https://test.com?%s=DE&%s=&%s=1",
-        BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE, BuildReportingUrl.PARAM_POSITION);
+        BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE,
+        BuildReportingUrl.PARAM_POSITION);
     String attributesUrl3 = String.format("https://test.com?%s=DE&%s=&%s=2",
-            BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE, BuildReportingUrl.PARAM_POSITION);
-
+        BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE,
+        BuildReportingUrl.PARAM_POSITION);
 
     List<SponsoredInteraction> input = ImmutableList.of(
         baseInteraction.setReportingUrl(attributesUrl1).build(),

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
@@ -58,13 +58,13 @@ public class AggregateImpressionsTest {
 
   @Test
   public void testGetAggregationKey() {
-    String url = "http://test.com?position=3&country-code=US&abc=abc&def=a";
+    String url = "http://test.com?slot-number=3&country-code=US&abc=abc&def=a";
     SponsoredInteraction interaction = getTestInteraction().setReportingUrl(url).build();
 
     String aggKey = AggregateImpressions.getAggregationKey(interaction);
 
     // Should return url with sorted query params
-    Assert.assertEquals(aggKey, "http://test.com?abc=abc&country-code=US&def=a&position=3");
+    Assert.assertEquals(aggKey, "http://test.com?abc=abc&country-code=US&def=a&slot-number=3");
   }
 
   @Test

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/AggregateImpressionsTest.java
@@ -20,7 +20,7 @@ public class AggregateImpressionsTest {
 
   private SponsoredInteraction.Builder getTestInteraction() {
     return SponsoredInteraction.builder().setInteractionType("click").setSource("topsite")
-        .setFormFactor("phone").setContextId("1");
+        .setFormFactor("phone").setContextId("1").setPosition("3");
   }
 
   @Rule
@@ -58,29 +58,34 @@ public class AggregateImpressionsTest {
 
   @Test
   public void testGetAggregationKey() {
-    String url = "http://test.com?country-code=US&abc=abc&def=a";
+    String url = "http://test.com?position=3&country-code=US&abc=abc&def=a";
     SponsoredInteraction interaction = getTestInteraction().setReportingUrl(url).build();
 
     String aggKey = AggregateImpressions.getAggregationKey(interaction);
 
     // Should return url with sorted query params
-    Assert.assertEquals(aggKey, "http://test.com?abc=abc&country-code=US&def=a");
+    Assert.assertEquals(aggKey, "http://test.com?abc=abc&country-code=US&def=a&position=3");
   }
 
   @Test
   public void testAggregation() {
     SponsoredInteraction.Builder baseInteraction = getTestInteraction();
 
-    String attributesUrl1 = String.format("https://test.com?%s=US&%s=",
-        BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE);
-    String attributesUrl2 = String.format("https://test.com?%s=DE&%s=",
-        BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE);
+    String attributesUrl1 = String.format("https://test.com?%s=US&%s=&%s=1",
+        BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE, BuildReportingUrl.PARAM_POSITION);
+    String attributesUrl2 = String.format("https://test.com?%s=DE&%s=&%s=1",
+        BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE, BuildReportingUrl.PARAM_POSITION);
+    String attributesUrl3 = String.format("https://test.com?%s=DE&%s=&%s=2",
+            BuildReportingUrl.PARAM_COUNTRY_CODE, BuildReportingUrl.PARAM_REGION_CODE, BuildReportingUrl.PARAM_POSITION);
+
 
     List<SponsoredInteraction> input = ImmutableList.of(
         baseInteraction.setReportingUrl(attributesUrl1).build(),
         baseInteraction.setReportingUrl(attributesUrl2).build(),
         baseInteraction.setReportingUrl(attributesUrl1).build(),
         baseInteraction.setReportingUrl(attributesUrl1).build(),
+        baseInteraction.setReportingUrl(attributesUrl3).build(),
+        baseInteraction.setReportingUrl(attributesUrl3).build(),
         baseInteraction.setReportingUrl(attributesUrl2).build());
 
     PCollection<SponsoredInteraction> output = pipeline.apply(Create.of(input))
@@ -88,19 +93,22 @@ public class AggregateImpressionsTest {
 
     PAssert.that(output).satisfies(interactions -> {
 
-      Assert.assertEquals(Iterables.size(interactions), 2);
+      Assert.assertEquals(Iterables.size(interactions), 3);
 
       interactions.forEach(interaction -> {
         String reportingUrl = interaction.getReportingUrl();
         BuildReportingUrl builtUrl = new BuildReportingUrl(reportingUrl);
 
         String country = builtUrl.getQueryParam(BuildReportingUrl.PARAM_COUNTRY_CODE);
+        String position = builtUrl.getQueryParam(BuildReportingUrl.PARAM_POSITION);
         if ("US".equals(country)) {
           Assert.assertEquals(builtUrl.getQueryParam(BuildReportingUrl.PARAM_IMPRESSIONS), "3");
-        } else if ("DE".equals(country)) {
+        } else if ("DE".equals(country) && "1".equals(position)) {
+          Assert.assertEquals(builtUrl.getQueryParam(BuildReportingUrl.PARAM_IMPRESSIONS), "2");
+        } else if ("DE".equals(country) && "2".equals(position)) {
           Assert.assertEquals(builtUrl.getQueryParam(BuildReportingUrl.PARAM_IMPRESSIONS), "2");
         } else {
-          throw new IllegalArgumentException("unknown country value");
+          throw new IllegalArgumentException("unknown value in reporting url parameters");
         }
 
         // Parameters with no values should still be included

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
@@ -63,8 +63,12 @@ public class ParseReportingUrlTest {
   @Test
   public void testParsedUrlOutput() {
 
-    Map<String, String> attributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE, "topsites-impression",
-        Attribute.DOCUMENT_NAMESPACE, "contextual-services", Attribute.USER_AGENT_OS, "Windows");
+    Map<String, String> attributes = ImmutableMap.of(
+            Attribute.DOCUMENT_TYPE, "topsites-impression",
+            Attribute.DOCUMENT_NAMESPACE, "contextual-services",
+            Attribute.USER_AGENT_OS, "Windows",
+            Attribute.POSITION, "1"
+    );
 
     ObjectNode basePayload = Json.createObjectNode();
     basePayload.put(Attribute.NORMALIZED_COUNTRY_CODE, "US");
@@ -106,6 +110,8 @@ public class ParseReportingUrlTest {
           .contains(String.format("%s=%s", BuildReportingUrl.PARAM_COUNTRY_CODE, "US")));
       Assert.assertTrue(reportingUrl
           .contains(String.format("%s=%s", BuildReportingUrl.PARAM_FORM_FACTOR, "desktop")));
+      Assert.assertTrue(reportingUrl
+          .contains(String.format("%s=%s", BuildReportingUrl.PARAM_POSITION, "1")));
       Assert
           .assertTrue(reportingUrl.contains(String.format("%s=&", BuildReportingUrl.PARAM_DMA_CODE))
               || reportingUrl.endsWith(String.format("%s=", BuildReportingUrl.PARAM_DMA_CODE)));

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
@@ -63,12 +63,9 @@ public class ParseReportingUrlTest {
   @Test
   public void testParsedUrlOutput() {
 
-    Map<String, String> attributes = ImmutableMap.of(
-            Attribute.DOCUMENT_TYPE, "topsites-impression",
-            Attribute.DOCUMENT_NAMESPACE, "contextual-services",
-            Attribute.USER_AGENT_OS, "Windows",
-            Attribute.POSITION, "1"
-    );
+    Map<String, String> attributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE, "topsites-impression",
+        Attribute.DOCUMENT_NAMESPACE, "contextual-services", Attribute.USER_AGENT_OS, "Windows",
+        Attribute.POSITION, "1");
 
     ObjectNode basePayload = Json.createObjectNode();
     basePayload.put(Attribute.NORMALIZED_COUNTRY_CODE, "US");
@@ -110,8 +107,8 @@ public class ParseReportingUrlTest {
           .contains(String.format("%s=%s", BuildReportingUrl.PARAM_COUNTRY_CODE, "US")));
       Assert.assertTrue(reportingUrl
           .contains(String.format("%s=%s", BuildReportingUrl.PARAM_FORM_FACTOR, "desktop")));
-      Assert.assertTrue(reportingUrl
-          .contains(String.format("%s=%s", BuildReportingUrl.PARAM_POSITION, "1")));
+      Assert.assertTrue(
+          reportingUrl.contains(String.format("%s=%s", BuildReportingUrl.PARAM_POSITION, "1")));
       Assert
           .assertTrue(reportingUrl.contains(String.format("%s=&", BuildReportingUrl.PARAM_DMA_CODE))
               || reportingUrl.endsWith(String.format("%s=", BuildReportingUrl.PARAM_DMA_CODE)));

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/Constant.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/Constant.java
@@ -49,6 +49,7 @@ public class Constant {
     public static final String REQUEST_ID = "request_id";
     public static final String SAMPLE_ID = "sample_id";
     public static final String SUBMISSION_TIMESTAMP = "submission_timestamp";
+    public static final String POSITION = "position";
     public static final String URI = "uri";
     public static final String USER_AGENT = "user_agent";
     public static final String USER_AGENT_BROWSER = "user_agent_browser";

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/Constant.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/Constant.java
@@ -49,7 +49,7 @@ public class Constant {
     public static final String REQUEST_ID = "request_id";
     public static final String SAMPLE_ID = "sample_id";
     public static final String SUBMISSION_TIMESTAMP = "submission_timestamp";
-    public static final String POSITION = "position";
+    public static final String POSITION = "slot-number";
     public static final String URI = "uri";
     public static final String USER_AGENT = "user_agent";
     public static final String USER_AGENT_BROWSER = "user_agent_browser";


### PR DESCRIPTION
Issue: [JIRA DENG-1226](https://mozilla-hub.atlassian.net/browse/DENG-1226)

As we’re surfacing more sponsored tiles on the New Tab page, there is a business need to share tile position information when sharing aggregated impression data with adMarketplace.

position is already included in the [impression ping schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/main/templates/contextual-services/topsites-impression/topsites-impression.1.schema.json#L21-L24), we’d like to add it to the aggregation key for topsites impressions and send it to adMarketplace along with other reporting fields.

Reference: [Aggregated Impression Sharing for Sponsored Top Sites](https://docs.google.com/document/d/1f1Iek4lUelK31tybGVlEnTdrrTVgRGaTkrLWVbz6NSU/edit?usp=sharing)