### PR TITLE
DENG-1536 - Add option to enable ingestion-sink opencensus metrics

### DIFF
--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/BigQuery.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/BigQuery.java
@@ -77,8 +77,8 @@ public class BigQuery {
     /** Constructor. */
     public Write(com.google.cloud.bigquery.BigQuery bigQuery, long maxBytes, int maxMessages,
         Duration maxDelay, PubsubMessageToTemplatedString batchKeyTemplate, Executor executor,
-        PubsubMessageToObjectNode encoder) {
-      super(maxBytes, maxMessages, maxDelay, batchKeyTemplate, executor);
+        boolean enableOpenCensus, PubsubMessageToObjectNode encoder) {
+      super(maxBytes, maxMessages, maxDelay, batchKeyTemplate, executor, enableOpenCensus);
       this.bigQuery = bigQuery;
       this.encoder = encoder;
     }
@@ -165,8 +165,9 @@ public class BigQuery {
 
     /** Constructor. */
     public Load(com.google.cloud.bigquery.BigQuery bigQuery, Storage storage, long maxBytes,
-        int maxFiles, Duration maxDelay, Executor executor, Delete delete) {
-      super(maxBytes, maxFiles, maxDelay, null, executor);
+        int maxFiles, Duration maxDelay, Executor executor, boolean enableOpenCensus,
+        Delete delete) {
+      super(maxBytes, maxFiles, maxDelay, null, executor, enableOpenCensus);
       this.bigQuery = bigQuery;
       this.storage = storage;
       this.delete = delete;

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/io/Gcs.java
@@ -37,11 +37,13 @@ public class Gcs {
 
       private final PubsubMessageToObjectNode encoder;
 
+      /** Constructor. */
       public Ndjson(Storage storage, long maxBytes, int maxMessages, Duration maxDelay,
           PubsubMessageToTemplatedString batchKeyTemplate, Executor executor,
-          PubsubMessageToObjectNode encoder,
+          boolean enableOpenCensus, PubsubMessageToObjectNode encoder,
           Function<Blob, CompletableFuture<Void>> batchCloseHook) {
-        super(storage, maxBytes, maxMessages, maxDelay, batchKeyTemplate, executor, batchCloseHook);
+        super(storage, maxBytes, maxMessages, maxDelay, batchKeyTemplate, executor,
+            enableOpenCensus, batchCloseHook);
         this.encoder = encoder;
       }
 
@@ -73,8 +75,8 @@ public class Gcs {
 
     private Write(Storage storage, long maxBytes, int maxMessages, Duration maxDelay,
         PubsubMessageToTemplatedString batchKeyTemplate, Executor executor,
-        Function<Blob, CompletableFuture<Void>> batchCloseHook) {
-      super(maxBytes, maxMessages, maxDelay, batchKeyTemplate, executor);
+        boolean enableOpenCensus, Function<Blob, CompletableFuture<Void>> batchCloseHook) {
+      super(maxBytes, maxMessages, maxDelay, batchKeyTemplate, executor, enableOpenCensus);
       this.storage = storage;
       this.batchCloseHook = batchCloseHook;
     }

--- a/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/Env.java
+++ b/ingestion-sink/src/main/java/com/mozilla/telemetry/ingestion/sink/util/Env.java
@@ -85,6 +85,10 @@ public class Env {
     return optString(key).map(Long::new).orElse(defaultValue);
   }
 
+  public Boolean getBool(String key, Boolean defaultValue) {
+    return optString(key).map(Boolean::valueOf).orElse(defaultValue);
+  }
+
   public Duration getDuration(String key, String defaultValue) {
     return Time.parseJavaDuration(getString(key, defaultValue));
   }

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/BigQueryLoadTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/BigQueryLoadTest.java
@@ -46,7 +46,7 @@ public class BigQueryLoadTest {
     when(blob.getBlobId()).thenReturn(BlobId.of("bucket", name));
     when(blob.getSize()).thenReturn(1L);
     try {
-      new BigQuery.Load(bigQuery, storage, 0, 0, Duration.ZERO, ForkJoinPool.commonPool(),
+      new BigQuery.Load(bigQuery, storage, 0, 0, Duration.ZERO, ForkJoinPool.commonPool(), false,
           BigQuery.Load.Delete.onSuccess).apply(blob).join();
     } catch (CompletionException e) {
       if (e.getCause() instanceof BigQuery.BigQueryErrors) {

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/GcsWriteTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/io/GcsWriteTest.java
@@ -44,7 +44,7 @@ public class GcsWriteTest {
   public void mockBigQueryResponse() {
     storage = mock(Storage.class);
     output = new Gcs.Write.Ndjson(storage, MAX_BYTES, MAX_MESSAGES, MAX_DELAY, BATCH_KEY_TEMPLATE,
-        ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of(), this::batchCloseHook);
+        ForkJoinPool.commonPool(), false, PubsubMessageToObjectNode.Raw.of(), this::batchCloseHook);
   }
 
   @Test
@@ -58,7 +58,7 @@ public class GcsWriteTest {
   @Test
   public void canSendWithNoDelay() {
     output = new Gcs.Write.Ndjson(storage, MAX_BYTES, MAX_MESSAGES, Duration.ofMillis(0),
-        BATCH_KEY_TEMPLATE, ForkJoinPool.commonPool(), PubsubMessageToObjectNode.Raw.of(),
+        BATCH_KEY_TEMPLATE, ForkJoinPool.commonPool(), false, PubsubMessageToObjectNode.Raw.of(),
         this::batchCloseHook);
     output.apply(EMPTY_MESSAGE).join();
     assertEquals(1, output.batches.get(BATCH_KEY).size);

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/BatchWriteTest.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/BatchWriteTest.java
@@ -14,7 +14,7 @@ public class BatchWriteTest {
     int batchCount = 0;
 
     private NoopBatchWrite(long maxBytes, int maxMessages, Duration maxDelay) {
-      super(maxBytes, maxMessages, maxDelay, null, ForkJoinPool.commonPool());
+      super(maxBytes, maxMessages, maxDelay, null, ForkJoinPool.commonPool(), false);
     }
 
     @Override

--- a/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/BoundedSink.java
+++ b/ingestion-sink/src/test/java/com/mozilla/telemetry/ingestion/sink/util/BoundedSink.java
@@ -26,7 +26,9 @@ public class BoundedSink {
       final int currentMessages = counter.incrementAndGet();
       if (currentMessages >= messageCount) {
         input.get().stopAsync();
-        StackdriverStatsExporter.unregister();
+        if (SinkConfig.getEnableOpenCensus(output.commonEnv)) {
+          StackdriverStatsExporter.unregister();
+        }
       }
       return v;
     }))));


### PR DESCRIPTION
fixes [DENG-1536](https://mozilla-hub.atlassian.net/browse/DENG-1536)

the new environment variable to configure this is `ENABLE_OPEN_CENSUS`, and the default is false.


[DENG-1536]: https://mozilla-hub.atlassian.net/browse/DENG-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ