### PR TITLE
SNG-1086 - Fix typo in Bing partner codes.

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -151,7 +151,7 @@ public class MessageScrubber {
       // https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/search-telemetry-v2/records
       // Bing
       "MOZ2", "MOZ4", "MOZ5", "MOZA", "MOZB", "MOZD", "MOZE", "MOZI", "MOZL", "MOZM", "MOZO",
-      "MOZR", "MOZT", "MOZW", "MOZX", "MOZSL01", "MOZSL02", "MOZSL03",
+      "MOZR", "MOZT", "MOZW", "MOZX", "MZSL01", "MZSL02", "MZSL03",
       // Google
       "firefox-a", "firefox-b", "firefox-b-1", "firefox-b-ab", "firefox-b-1-ab", "firefox-b-d",
       "firefox-b-1-d", "firefox-b-e", "firefox-b-1-e", "firefox-b-m", "firefox-b-1-m",


### PR DESCRIPTION
These codes were originally listed in desktop's search telemetry incorrectly, and the typo was copied across to here.

This fixes the ingestion, we have a separate fix in progress for desktop.