### PR TITLE
As of beam 2.44 google-cloud-storage is no longer a test-only dependency

### DIFF
--- a/ingestion-beam/pom.xml
+++ b/ingestion-beam/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.maxmind.geoip2</groupId>


### PR DESCRIPTION
fixes https://github.com/mozilla/gcp-ingestion/pull/2518#issuecomment-1828448944