### PR TITLE
Emit additional metrics for TopSites

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/EmitCounters.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/EmitCounters.java
@@ -39,6 +39,13 @@ public class EmitCounters
             attributes.put(Attribute.DOCUMENT_NAMESPACE, interaction.getOriginalNamespace());
           }
 
+          String interactionType = interaction.getInteractionType();
+          if (SponsoredInteraction.INTERACTION_IMPRESSION.equals(interactionType)) {
+            PerDocTypeCounter.inc(attributes, "valid_impression_url");
+          } else if (SponsoredInteraction.INTERACTION_CLICK.equals(interactionType)) {
+            PerDocTypeCounter.inc(attributes, "valid_click_url");
+          }
+
           PerDocTypeCounter.inc(attributes, "valid_submission");
           if (interaction.getRequestId() != null) {
             PerDocTypeCounter.inc(attributes, "valid_submission_merino");


### PR DESCRIPTION
The Glean migration collapsed the
`contextual_services/topsites_impression_v1/valid_url` and `contextual_services/topsites_click_v1/valid_url` metrics that were used on [this dashboard](https://earthangel-b40313e5.influxcloud.net/d/oak1zw6Gz/contile-infrastructure?orgId=1) onto a single `firefox_desktop/top_sites_v1/valid_url` metric.

This introduces two new metrics: `firefox_desktop/top_sites/valid_click` and `firefox_desktop/top_sites/valid_impression` which we can use to fix the dashboard.

JIRA: [AE-155](https://mozilla-hub.atlassian.net/browse/AE-155)

[AE-155]: https://mozilla-hub.atlassian.net/browse/AE-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ