### PR TITLE
Updated version number and arguments of Stub URI parser

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -248,7 +248,7 @@ public class ParseUri {
         .compile(String.format("^v(?<%s>[6-8])(-(?<%s>\\d+))?$", VERSION, FUNNELCAKE));
 
     public static final Map<String, Integer> SUFFIX_LENGTH = ImmutableMap.of("6", 36, "7", 37, "8",
-        39);
+        39, "9", 41);
 
     public static final List<BiConsumer<String, ObjectNode>> HANDLERS = ImmutableList.of(//
         ignore(), // ping_version handled by parsePingVersion
@@ -287,7 +287,8 @@ public class ParseUri {
         // Default browser setting code
         putBoolPerCode(ImmutableMap.of("set_default", 2)), //
         putString("download_ip"), putString("attribution"),
-        putIntegerAsString("profile_cleanup_prompt"), putBool("profile_cleanup_requested"));
+        putIntegerAsString("profile_cleanup_prompt"), putBool("profile_cleanup_requested"),
+        putString("distribution_id"), putString("distribution_version"));
 
     private static BiConsumer<String, ObjectNode> ignore() {
       return (value, payload) -> {

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -245,7 +245,7 @@ public class ParseUri {
     public static final String FUNNELCAKE = "funnelcake";
 
     public static final Pattern PING_VERSION_PATTERN = Pattern
-        .compile(String.format("^v(?<%s>[6-8])(-(?<%s>\\d+))?$", VERSION, FUNNELCAKE));
+        .compile(String.format("^v(?<%s>[6-9])(-(?<%s>\\d+))?$", VERSION, FUNNELCAKE));
 
     public static final Map<String, Integer> SUFFIX_LENGTH = ImmutableMap.of("6", 36, "7", 37, "8",
         39, "9", 41);


### PR DESCRIPTION
Added parsing for new stub installer telemetry which records partner distribution IDs and versions. Also updated stub installer URI to version 9 to accommodate for new telemetry fields.