### PR TITLE
Make bq_ properties in PipelineMetadataStore nullable

### DIFF
--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/schema/PipelineMetadataStore.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/schema/PipelineMetadataStore.java
@@ -169,10 +169,13 @@ public class PipelineMetadataStore extends SchemaStore<PipelineMetadataStore.Pip
       return new AutoValue_PipelineMetadataStore_PipelineMetadata.Builder();
     }
 
+    @Nullable
     public abstract String bq_dataset_family();
 
+    @Nullable
     public abstract String bq_table();
 
+    @Nullable
     public abstract String bq_metadata_format();
 
     @Nullable


### PR DESCRIPTION
In https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/806 we added `json_object_path_regex` and removed `bq_dataset_family`, `bq_metadata_format`, and `bq_table` from base Glean schema metadata.
This caused schema loading to fail with:
```
ValueInstantiationException: Cannot construct instance of `com.mozilla.telemetry.ingestion.core.schema.AutoValue_PipelineMetadataStore_PipelineMetadata$Builder`, problem: Missing required properties: bq_dataset_family bq_table bq_metadata_format
```

To unblock schema loading we'll set these fields as `@Nullable` so PipelineMetadata for the base Glean schema can be instantiated.
This is a safe change because these fields are not used anywhere in the ingestion logic (proposal that brought them in hasn't been fully implemented).