### PR TITLE
Send suggest interactions from prerelease channels to AMP

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/VerifyMetadata.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/VerifyMetadata.java
@@ -58,19 +58,9 @@ public class VerifyMetadata extends
             throw new RejectedMessageException("Invalid user agent: " + userAgent, "user_agent");
           }
 
-          // Verify release channel for specific doctype
-          String doctype = attributes.get(Attribute.DOCUMENT_TYPE);
-          String channel = attributes.get(Attribute.NORMALIZED_CHANNEL);
-          // Bug 1737185
-          if (doctype.startsWith("quicksuggest-") || "quick-suggest".equals(doctype)) {
-            if (!"release".equals(channel)) {
-              throw new RejectedMessageException(
-                  String.format("Disallowed channel %s for doctype %s: ", channel, doctype));
-            }
-          }
-
           // Filter out a specific signature associated with fraud in the past;
           // see https://mozilla-hub.atlassian.net/browse/CONSVC-1764
+          String doctype = attributes.get(Attribute.DOCUMENT_TYPE);
           if (("topsites-click".equals(doctype) || "top-sites".equals(doctype))
               && "IN".equals(attributes.get(Attribute.GEO_COUNTRY))
               && "Infonet Comm Enterprises".equals(attributes.get(Attribute.ISP_NAME))) {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/VerifyMetadataTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/VerifyMetadataTest.java
@@ -97,49 +97,6 @@ public class VerifyMetadataTest {
   }
 
   @Test
-  public void testRejectChannel() {
-    // Build list of messages with different doctype/version combinations
-    final List<PubsubMessage> input = Streams
-        .zip(Stream.of("quicksuggest-impression", "quicksuggest-click"),
-            Stream.of("beta", "release"),
-            (doctype, channel) -> ImmutableMap.of(Attribute.DOCUMENT_TYPE, doctype, //
-                Attribute.DOCUMENT_NAMESPACE, "contextual-services", //
-                Attribute.USER_AGENT_BROWSER, "Firefox", //
-                Attribute.USER_AGENT_VERSION, "93", //
-                Attribute.CLIENT_COMPRESSION, "gzip", //
-                Attribute.NORMALIZED_CHANNEL, channel))
-        .map(attributes -> new PubsubMessage(new byte[] {}, attributes))
-        .collect(Collectors.toList());
-
-    WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage> result = pipeline //
-        .apply(Create.of(input)) //
-        .apply(VerifyMetadata.of());
-
-    PAssert.that(result.failures()).satisfies(messages -> {
-      Assert.assertEquals(1, Iterables.size(messages));
-      PubsubMessage message = Iterables.get(messages, 0);
-
-      String errorMessage = message.getAttribute("error_message");
-      Assert.assertTrue(errorMessage.contains(RejectedMessageException.class.getCanonicalName()));
-      Assert.assertTrue(errorMessage.contains("Disallowed channel"));
-
-      return null;
-    });
-
-    PAssert.that(result.output()).satisfies(messages -> {
-      Assert.assertEquals(1, Iterables.size(messages));
-      Assert.assertEquals("quicksuggest-click",
-          Iterables.get(messages, 0).getAttribute(Attribute.DOCUMENT_TYPE));
-      Assert.assertEquals("release",
-          Iterables.get(messages, 0).getAttribute(Attribute.NORMALIZED_CHANNEL));
-
-      return null;
-    });
-
-    pipeline.run();
-  }
-
-  @Test
   public void testRejectIspCountry() {
     Map<String, String> baseAttributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE, "topsites-click",
         Attribute.DOCUMENT_NAMESPACE, "contextual-services", //


### PR DESCRIPTION
We currently filter out Suggest impressions and clicks originating from pre-release channels (beta, nightly, etc.). Reasons for doing so have been lost to time, and we are aligned with adMarketplace that we can stop doing this; as these impressions and clicks are coming from real users.

Reverts #1871.