### PR TITLE
Get buster-backports from archive.debian.org in ingestion-edge

### DIFF
--- a/ingestion-edge/Dockerfile
+++ b/ingestion-edge/Dockerfile
@@ -13,7 +13,7 @@ ENV VENV=false
 RUN bin/build
 
 FROM base
-RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list && \
+RUN echo 'deb http://archive.debian.org/debian buster-backports main' >> /etc/apt/sources.list && \
   apt-get update && \
   apt-get install -qqy --target-release buster-backports wrk
 COPY --from=build /usr/local /usr/local


### PR DESCRIPTION
buster-backports is no longer in deb.debian.org but it is in archive.debian.org: https://lists.debian.org/debian-backports-announce/2024/04/msg00000.html

This should fix the failing build but buster LTS support is ending June 30: https://wiki.debian.org/LTS.  Updating the debian version is higher risk so I'll create a ticket to track that

Filed
https://mozilla-hub.atlassian.net/browse/DENG-4080
https://mozilla-hub.atlassian.net/browse/DENG-4081