### PR TITLE
AE-443 Updated quick-suggest clickURL required params.

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
@@ -546,6 +546,7 @@ public class ParseReportingUrl extends
         && SponsoredInteraction.SOURCE_SUGGEST.equals(interaction.getSource())) {
       // Per https://bugzilla.mozilla.org/show_bug.cgi?id=1738974
       // Per https://mozilla-hub.atlassian.net/browse/AE-443
+      //AMP behaviour varies by advertiser name.
       if ("amazon".equals(interaction.getAdvertiser())) {
         requireParamPresent(builtUrl, "ctag");
         requireParamPresent(builtUrl, "custom-data");

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
@@ -546,7 +546,7 @@ public class ParseReportingUrl extends
         && SponsoredInteraction.SOURCE_SUGGEST.equals(interaction.getSource())) {
       // Per https://bugzilla.mozilla.org/show_bug.cgi?id=1738974
       // Per https://mozilla-hub.atlassian.net/browse/AE-443
-      //AMP behaviour varies by advertiser name.
+      // AMP behaviour varies by advertiser name.
       if ("amazon".equals(interaction.getAdvertiser())) {
         requireParamPresent(builtUrl, "ctag");
         requireParamPresent(builtUrl, "custom-data");

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
@@ -167,6 +167,9 @@ public class ParseReportingUrl extends
 
             // parse position
             interactionBuilder.setPosition(parsePosition(metrics).orElse("no_position"));
+
+            // parse advertiser
+            interactionBuilder.setAdvertiser(parseAdvertiser(metrics).orElse(null));
           } else if (NS_DESKTOP.equals(namespace)) {
             interactionBuilder.setFormFactor(SponsoredInteraction.FORM_DESKTOP);
             metrics = payload;
@@ -178,6 +181,9 @@ public class ParseReportingUrl extends
 
             // parse position for desktop.
             interactionBuilder.setPosition(parsePosition(payload).orElse("no_position"));
+
+            // parse advertiser
+            interactionBuilder.setAdvertiser(parseAdvertiser(metrics).orElse(null));
           } else {
             // Namespace is one of the many mobile namespaces:
             // * org-mozilla-fenix
@@ -454,6 +460,10 @@ public class ParseReportingUrl extends
     return optionalNode(metrics.path(Attribute.POSITION)).map(JsonNode::asText);
   }
 
+  private Optional<String> parseAdvertiser(JsonNode metrics) {
+    return optionalNode(metrics.path(Attribute.ADVERTISER)).map(JsonNode::asText);
+  }
+
   private String extractReportingUrl(ObjectNode metrics) {
     return optionalNode(metrics.path(Attribute.REPORTING_URL),
         metrics.path("contile_reporting_url")).map(JsonNode::asText).orElse("");
@@ -535,10 +545,20 @@ public class ParseReportingUrl extends
     if (SponsoredInteraction.INTERACTION_CLICK.equals(interaction.getInteractionType())
         && SponsoredInteraction.SOURCE_SUGGEST.equals(interaction.getSource())) {
       // Per https://bugzilla.mozilla.org/show_bug.cgi?id=1738974
-      requireParamPresent(builtUrl, "ctag");
-      requireParamPresent(builtUrl, "custom-data");
-      requireParamPresent(builtUrl, "sub1");
-      requireParamPresent(builtUrl, "sub2");
+      // Per https://mozilla-hub.atlassian.net/browse/AE-443
+      if ("amazon".equals(interaction.getAdvertiser())) {
+        requireParamPresent(builtUrl, "ctag");
+        requireParamPresent(builtUrl, "custom-data");
+        requireParamPresent(builtUrl, "sub1");
+        requireParamPresent(builtUrl, "sub2");
+      } else {
+        requireParamPresent(builtUrl, "partner");
+        requireParamPresent(builtUrl, "sub1");
+        requireParamPresent(builtUrl, "ctaid");
+        requireParamPresent(builtUrl, "source");
+        requireParamPresent(builtUrl, "custom-data");
+        requireParamPresent(builtUrl, "ctag");
+      }
     }
 
     if (SponsoredInteraction.INTERACTION_IMPRESSION.equals(interaction.getInteractionType())

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/SponsoredInteraction.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/SponsoredInteraction.java
@@ -71,6 +71,9 @@ public abstract class SponsoredInteraction implements Serializable {
   public static final String FX_SUGGEST = "reg";
 
   @Nullable
+  abstract String getAdvertiser();
+
+  @Nullable
   public abstract String getSubmissionTimestamp();
 
   @Nullable
@@ -131,6 +134,8 @@ public abstract class SponsoredInteraction implements Serializable {
     public abstract Builder setRequestId(String newRequestId);
 
     public abstract Builder setMatchType(String newMatchType);
+
+    public abstract Builder setAdvertiser(String newAdvertiser);
 
     public abstract Builder setSubmissionTimestamp(String newSubmissionTimestamp);
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
@@ -70,13 +70,14 @@ public class ParseReportingUrlTest {
     metrics.putObject("quantity").put("quick_suggest.position", 1);
     final String contextId = "aaaa-bbb-ccc-000";
     metrics.putObject("uuid").put("quick_suggest.context_id", contextId);
+    metrics.putObject("string").put("quick_suggest.advertiser", "newAdvertiser");
 
     ObjectNode expect = Json.createObjectNode();
     expect.put("reporting_url", "http://click.com");
-    expect.put("ping_type", "quicksuggest-click");
     expect.put("improve_suggest_experience", false);
     expect.put("position", 1);
     expect.put("context_id", contextId);
+    expect.put("advertiser", "newAdvertiser");
     ObjectNode actual = ParseReportingUrl.extractMetrics(ImmutableList.of("quick_suggest"),
         payload);
     if (!expect.equals(actual)) {
@@ -508,6 +509,7 @@ public class ParseReportingUrlTest {
             stringMetrics.put(metricPrefix + "match_type",
                 scenario ? "firefox-suggest" : "best-match");
           }
+          stringMetrics.put(metricPrefix + "advertiser", "amazon");
           metrics.putObject("uuid").put(metricPrefix + Attribute.CONTEXT_ID, contextId);
           if (!"click".equals(interactionType) || scenario) {
             metrics.putObject("boolean").put(metricPrefix + "improve_suggest_experience", scenario);
@@ -523,7 +525,101 @@ public class ParseReportingUrlTest {
     // We expect 4 successful messages.
     PAssert.that(result.output().setCoder(SponsoredInteraction.getCoder()))
         .satisfies(sponsoredInteractions -> {
-          Assert.assertEquals(Iterables.size(sponsoredInteractions), 4);
+          Assert.assertEquals(4, Iterables.size(sponsoredInteractions));
+
+          long onlineInteractions = StreamSupport.stream(sponsoredInteractions.spliterator(), false)
+              .filter(interaction -> SponsoredInteraction.ONLINE.equals(interaction.getScenario()))
+              .count();
+
+          long offlineInteractions = StreamSupport
+              .stream(sponsoredInteractions.spliterator(), false)
+              .filter(interaction -> SponsoredInteraction.OFFLINE.equals(interaction.getScenario()))
+              .count();
+
+          long nullInteractions = StreamSupport.stream(sponsoredInteractions.spliterator(), false)
+              .filter(interaction -> interaction.getScenario() == null).count();
+
+          Assert.assertEquals(2, onlineInteractions);
+          Assert.assertEquals(1, offlineInteractions);
+          Assert.assertEquals(1, nullInteractions);
+
+          sponsoredInteractions.forEach(interaction -> {
+            String reportingUrl = interaction.getReportingUrl();
+            String doctype = interaction.getDerivedDocumentType();
+
+            if (doctype.equals("quicksuggest-impression")) {
+              if (SponsoredInteraction.ONLINE.equals(interaction.getScenario())) {
+                Assert.assertTrue(reportingUrl.contains(
+                    String.format("%s=%s", BuildReportingUrl.PARAM_CUSTOM_DATA, "1_online_reg")));
+              } else {
+                Assert.assertTrue(reportingUrl.contains(
+                    String.format("%s=%s", BuildReportingUrl.PARAM_CUSTOM_DATA, "1_offline_top")));
+              }
+            } else if (doctype.equals("quicksuggest-click")) {
+              if (SponsoredInteraction.ONLINE.equals(interaction.getScenario())) {
+                Assert.assertTrue(reportingUrl.contains(
+                    String.format("%s=%s", BuildReportingUrl.PARAM_CUSTOM_DATA, "1_online")));
+              } else {
+                Assert.assertTrue(reportingUrl
+                    .contains(String.format("%s=%s", BuildReportingUrl.PARAM_CUSTOM_DATA, "1")));
+              }
+            }
+
+            Assert.assertEquals("Expect context-id to match", contextId,
+                interaction.getContextId());
+          });
+
+          return null;
+        });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testCustomDataParamOtherAdvertisers() {
+    final String clickUrl = "https://test.com?v=a&adv-id=1&ctag=1&partner=1&version=1&sub1=1&custom-data=1&ctaid=1&source=1";
+
+    final String impressionUrl = "https://test.com?v=a&id=a&adv-id=1&ctag=1&partner=1&version=1&sub2=1"
+        + "&sub1=1&ci=1&custom-data=1";
+
+    final String contextId = "aaaa-bbb-ccc-000";
+
+    List<PubsubMessage> input = Stream.of("impression", "click")
+        .flatMap(interactionType -> Stream.of(true, false).map(scenario -> {
+          final ObjectNode payload = Json.createObjectNode();
+          payload.put(Attribute.NORMALIZED_COUNTRY_CODE, "US");
+          payload.put(Attribute.VERSION, "116.0");
+          final ObjectNode metrics = payload.putObject("metrics");
+          final String metricPrefix = "quick_suggest.";
+          metrics.putObject("url").put(metricPrefix + Attribute.REPORTING_URL,
+              "click".equals(interactionType) ? clickUrl : impressionUrl);
+          final ObjectNode stringMetrics = metrics.putObject("string");
+          stringMetrics.put(metricPrefix + "ping_type", "quicksuggest-" + interactionType);
+          if ("click".equals(interactionType)) {
+            if (scenario) {
+              stringMetrics.putNull(metricPrefix + "match_type");
+            }
+          } else {
+            stringMetrics.put(metricPrefix + "match_type",
+                scenario ? "firefox-suggest" : "best-match");
+          }
+          stringMetrics.put(metricPrefix + "advertiser", "anAdvertiser");
+          metrics.putObject("uuid").put(metricPrefix + Attribute.CONTEXT_ID, contextId);
+          if (!"click".equals(interactionType) || scenario) {
+            metrics.putObject("boolean").put(metricPrefix + "improve_suggest_experience", scenario);
+          }
+          return new PubsubMessage(Json.asBytes(payload), ImmutableMap.of(Attribute.DOCUMENT_TYPE,
+              "quick-suggest", Attribute.DOCUMENT_NAMESPACE, "firefox-desktop"));
+        })).collect(Collectors.toList());
+
+    Result<PCollection<SponsoredInteraction>, PubsubMessage> result = pipeline //
+        .apply(Create.of(input)) //
+        .apply(ParseReportingUrl.of(URL_ALLOW_LIST));
+
+    // We expect 4 successful messages.
+    PAssert.that(result.output().setCoder(SponsoredInteraction.getCoder()))
+        .satisfies(sponsoredInteractions -> {
+          Assert.assertEquals(4, Iterables.size(sponsoredInteractions));
 
           long onlineInteractions = StreamSupport.stream(sponsoredInteractions.spliterator(), false)
               .filter(interaction -> SponsoredInteraction.ONLINE.equals(interaction.getScenario()))
@@ -587,7 +683,8 @@ public class ParseReportingUrlTest {
     inputPayload.put(Attribute.CONTEXT_ID, contextId);
 
     ObjectNode impressionPayload = inputPayload.put(Attribute.REPORTING_URL, impressionUrl);
-    ObjectNode clickPayload = inputPayload.put(Attribute.REPORTING_URL, clickUrl);
+    ObjectNode clickPayload = inputPayload.put(Attribute.REPORTING_URL, clickUrl)
+        .put(Attribute.ADVERTISER, "amazon");
     ImmutableMap impressionAttributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE,
         "quicksuggest" + "-impression", Attribute.DOCUMENT_NAMESPACE, "contextual-services");
     ImmutableMap clickAttributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE, "quicksuggest-click",
@@ -614,7 +711,7 @@ public class ParseReportingUrlTest {
     // We expect 4 successful messages.
     PAssert.that(result.output().setCoder(SponsoredInteraction.getCoder()))
         .satisfies(sponsoredInteractions -> {
-          Assert.assertEquals(Iterables.size(sponsoredInteractions), 4);
+          Assert.assertEquals(4, Iterables.size(sponsoredInteractions));
 
           long onlineInteractions = StreamSupport.stream(sponsoredInteractions.spliterator(), false)
               .filter(interaction -> SponsoredInteraction.ONLINE.equals(interaction.getScenario()))

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
@@ -576,7 +576,7 @@ public class ParseReportingUrlTest {
   }
 
   @Test
-  public void testCustomDataParamOtherAdvertisers() {
+  public void testCustomDataParamAmazon() {
     final String clickUrl = "https://test.com?v=a&adv-id=1&ctag=1&partner=1&version=1&sub1=1&custom-data=1&ctaid=1&source=1";
 
     final String impressionUrl = "https://test.com?v=a&id=a&adv-id=1&ctag=1&partner=1&version=1&sub2=1"

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/Constant.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/Constant.java
@@ -51,6 +51,7 @@ public class Constant {
     public static final String SUBMISSION_TIMESTAMP = "submission_timestamp";
     public static final String POSITION = "position";
     public static final String MATCH_TYPE = "match_type";
+    public static final String ADVERTISER = "advertiser";
     public static final String URI = "uri";
     public static final String USER_AGENT = "user_agent";
     public static final String USER_AGENT_BROWSER = "user_agent_browser";


### PR DESCRIPTION
The json file update for sponsored suggest on `2024-06-21` included changes to the non-Amazon click Urls (the new version does not include `sub2`, includes `ctaid`).

Current Structure

https://mozillacla.ampxdirect.com/chewy?sub1=chewy&sub2=us&custom-data=1220&ctag=319093355us1220%YYYYMMDDHH%

New Structure

https://mozillacla.ampxdirect.com/?partner=firefox_cla&sub1=IS_US&ctaid=74319&source=als_tiles&custom-data=1220&ctag=319154513us1220%YYYYMMDDHH%