### PR TITLE
Relax URL validation rules for suggest clicks

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
@@ -545,10 +545,7 @@ public class ParseReportingUrl extends
         requireParamPresent(builtUrl, "sub1");
         requireParamPresent(builtUrl, "sub2");
       } else {
-        requireParamPresent(builtUrl, "partner");
         requireParamPresent(builtUrl, "sub1");
-        requireParamPresent(builtUrl, "ctaid");
-        requireParamPresent(builtUrl, "source");
         requireParamPresent(builtUrl, "custom-data");
         requireParamPresent(builtUrl, "ctag");
       }


### PR DESCRIPTION
We're still getting suggest clicks with the old URL format. These are likely coming from clients who haven't picked up Remote Settings changes.

While we investigate what is going on with Remote Settings, we can relax the validation for non-Amazon advertisers to be a subset of the query parameters for the old URL format, so that we're not dropping clicks due to missing parameters.