### PR TITLE
Bump docker image version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
     - &setup_remote_docker
       setup_remote_docker:
         docker_layer_caching: true
-        version: 19.03.13
+        version: default
     - &create_version_json
       run:
         name: Create version.json


### PR DESCRIPTION
[Latest build on main failed](https://app.circleci.com/pipelines/github/mozilla/gcp-ingestion/6762/workflows/a56885fc-add0-4b9f-9d84-4a0f3a20859f/jobs/79119) because CircleCI deprecated Docker version that we use. This bumps it to a [recommended `default`](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176#what-do-i-need-to-do-2).