### PR TITLE
Bump spring-core version, ignore 6.x in Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
   - dependency-name: com.google.cloud:libraries-bom
   - dependency-name: com.fasterxml.jackson:jackson-bom
   - dependency-name: org.apache.avro:avro
+  - dependency-name: org.springframework:spring-core
+    # Spring 6 requires Java 17
+    versions: [">=6.0.0"]
   schedule:
     interval: daily
   reviewers:

--- a/ingestion-beam/pom.xml
+++ b/ingestion-beam/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.3.29</version>
+            <version>5.3.39</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This updates `spring-core` to latest 5.x version and configures Dependabot to ignore versions `6.x+`.
Spring 6 requires Java 17 so we'd need to update JDK first.

This is a test-scope dependency, does not affect production.

closes https://github.com/mozilla/gcp-ingestion/pull/2650