### PR TITLE
Bump Dataflow template base image to 20240918-rc00

### DIFF
--- a/ingestion-beam/Dockerfile
+++ b/ingestion-beam/Dockerfile
@@ -15,7 +15,7 @@ RUN mvn package -Dmaven.test.skip=true -Dmaven.compiler.release=11
 # https://cloud.google.com/dataflow/docs/guides/templates/configuring-flex-templates#changing_the_base_image
 # and the versions available are defined here:
 # https://cloud.google.com/dataflow/docs/reference/flex-templates-base-images
-FROM gcr.io/dataflow-templates-base/java11-template-launcher-base:20220418_RC00
+FROM gcr.io/dataflow-templates-base/java11-template-launcher-base:20240918-rc00
 ARG PACKAGE_VERSION=0.1-SNAPSHOT
 COPY --from=build /app/ingestion-beam/target/ingestion-beam-$PACKAGE_VERSION.lib/ /template/ingestion-beam-$PACKAGE_VERSION.lib/
 # copy jar after dependencies to maximize docker caching and reduce upload size


### PR DESCRIPTION
Per [changelog](https://cloud.google.com/dataflow/docs/reference/flex-templates-base-images), `20240918-rc00` and previous versions include security fixes.

I [tested this manually](https://console.cloud.google.com/dataflow/jobs/us-west1/2024-10-23_07_34_45-7865765598113450989;logsSeverity=DEBUG;graphView=0?project=akomar-server-telemetry-poc&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22))) to confirm that jobs are started correctly.

