### PR TITLE
Gracefully handle duplicate query keys in contextual services pipeline

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
@@ -62,7 +62,7 @@ public class BuildReportingUrl {
             .map(param -> param.split("="))
             .collect(Collectors.toMap(item -> item[0], item -> item.length > 1 ? item[1] : ""));
       }
-    } catch(IllegalStateException e) {
+    } catch (IllegalStateException e) {
       throw new InvalidUrlException("Reporting URL contains duplicate query keys: " + reportingUrl);
     }
   }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/BuildReportingUrl.java
@@ -54,12 +54,16 @@ public class BuildReportingUrl {
       throw new InvalidUrlException("Reporting URL null or missing: " + reportingUrl);
     }
 
-    if (this.reportingUrl.getQuery() == null) {
-      queryParams = new HashMap<>();
-    } else {
-      queryParams = Arrays.stream(this.reportingUrl.getQuery().split("&"))
-          .map(param -> param.split("="))
-          .collect(Collectors.toMap(item -> item[0], item -> item.length > 1 ? item[1] : ""));
+    try {
+      if (this.reportingUrl.getQuery() == null) {
+        queryParams = new HashMap<>();
+      } else {
+        queryParams = Arrays.stream(this.reportingUrl.getQuery().split("&"))
+            .map(param -> param.split("="))
+            .collect(Collectors.toMap(item -> item[0], item -> item.length > 1 ? item[1] : ""));
+      }
+    } catch(IllegalStateException e) {
+      throw new InvalidUrlException("Reporting URL contains duplicate query keys: " + reportingUrl);
     }
   }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/BuildReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/BuildReportingUrlTest.java
@@ -1,15 +1,10 @@
 package com.mozilla.telemetry.contextualservices;
 
-import org.apache.beam.sdk.testing.TestPipeline;
-import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
 
 public class BuildReportingUrlTest {
-
-  @Rule
-  public final transient TestPipeline pipeline = TestPipeline.create();
 
   @Test
   public void testDuplicateQueryKeys() {
@@ -18,4 +13,5 @@ public class BuildReportingUrlTest {
         () -> new BuildReportingUrl("https://example.com?foo=bar&foo=bar")
     );
   }
+
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/BuildReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/BuildReportingUrlTest.java
@@ -1,8 +1,8 @@
 package com.mozilla.telemetry.contextualservices;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
 
 public class BuildReportingUrlTest {
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/BuildReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/BuildReportingUrlTest.java
@@ -1,0 +1,21 @@
+package com.mozilla.telemetry.contextualservices;
+
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+
+public class BuildReportingUrlTest {
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testDuplicateQueryKeys() {
+    assertThrows(
+        BuildReportingUrl.InvalidUrlException.class,
+        () -> new BuildReportingUrl("https://example.com?foo=bar&foo=bar")
+    );
+  }
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/BuildReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/BuildReportingUrlTest.java
@@ -8,10 +8,8 @@ public class BuildReportingUrlTest {
 
   @Test
   public void testDuplicateQueryKeys() {
-    assertThrows(
-        BuildReportingUrl.InvalidUrlException.class,
-        () -> new BuildReportingUrl("https://example.com?foo=bar&foo=bar")
-    );
+    assertThrows(BuildReportingUrl.InvalidUrlException.class,
+        () -> new BuildReportingUrl("https://example.com?foo=bar&foo=bar"));
   }
 
 }


### PR DESCRIPTION
Fixes #2696