### PR TITLE
Bug 1930793 - Block com-feifan-chrome-ios-dev namespace

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -124,6 +124,7 @@ public class MessageScrubber {
       .put("com-ff2024-01-firefox", "1925612") //
       .put("org-mozilla-firefox-cp", "1925615") //
       .put("com-feifan-topvan", "1924135") //
+      .put("com-feifan-chrome-ios-dev", "1930793") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1930793