### PR TITLE
Bug 1933847 - ParseUri updates needed for stub installer exit code enhancements

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -268,14 +268,12 @@ public class ParseUri {
             .put("out_of_retries", ImmutableSet.of(11)).put("file_error", ImmutableSet.of(20))
             .put("sig_not_trusted", ImmutableSet.of(21, 23))
             .put("sig_unexpected", ImmutableSet.of(22, 23))
-            .put("install_timeout", ImmutableSet.of(30))
-            .put("unknown_error", ImmutableSet.of(1))
+            .put("install_timeout", ImmutableSet.of(30)).put("unknown_error", ImmutableSet.of(1))
             .put("sig_check_timeout", ImmutableSet.of(24))
             .put("hardware_req_not_met", ImmutableSet.of(25))
             .put("os_version_req_not_met", ImmutableSet.of(26))
             .put("disk_space_req_not_met", ImmutableSet.of(27))
-             .put("writeable_req_not_met", ImmutableSet.of(28))
-            .build()),
+            .put("writeable_req_not_met", ImmutableSet.of(28)).build()),
         // Launch code
         putBoolPerCode(ImmutableMap.of("old_running", 1, "new_launched", 2)),
         putInteger("download_retries"), putInteger("bytes_downloaded"), putInteger("download_size"),

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -264,16 +264,20 @@ public class ParseUri {
         putString("service_pack"), putBool("server_os"),
         // Exit code
         putBoolPerCodeSet(new ImmutableMap.Builder<String, Set<Integer>>()
-            .put("succeeded", ImmutableSet.of(0)).put("user_cancelled", ImmutableSet.of(10))
-            .put("out_of_retries", ImmutableSet.of(11)).put("file_error", ImmutableSet.of(20))
-            .put("sig_not_trusted", ImmutableSet.of(21, 23))
-            .put("sig_unexpected", ImmutableSet.of(22, 23))
-            .put("install_timeout", ImmutableSet.of(30)).put("unknown_error", ImmutableSet.of(1))
-            .put("sig_check_timeout", ImmutableSet.of(24))
-            .put("hardware_req_not_met", ImmutableSet.of(25))
-            .put("os_version_req_not_met", ImmutableSet.of(26))
-            .put("disk_space_req_not_met", ImmutableSet.of(27))
-            .put("writeable_req_not_met", ImmutableSet.of(28)).build()),
+            .put("succeeded", ImmutableSet.of(0)) //
+            .put("user_cancelled", ImmutableSet.of(10)) //
+            .put("out_of_retries", ImmutableSet.of(11)) //
+            .put("file_error", ImmutableSet.of(20)) //
+            .put("sig_not_trusted", ImmutableSet.of(21, 23)) //
+            .put("sig_unexpected", ImmutableSet.of(22, 23)) //
+            .put("install_timeout", ImmutableSet.of(30)) //
+            .put("unknown_error", ImmutableSet.of(1)) //
+            .put("sig_check_timeout", ImmutableSet.of(24)) //
+            .put("hardware_req_not_met", ImmutableSet.of(25)) //
+            .put("os_version_req_not_met", ImmutableSet.of(26)) //
+            .put("disk_space_req_not_met", ImmutableSet.of(27)) //
+            .put("writeable_req_not_met", ImmutableSet.of(28)) //
+            .build()),
         // Launch code
         putBoolPerCode(ImmutableMap.of("old_running", 1, "new_launched", 2)),
         putInteger("download_retries"), putInteger("bytes_downloaded"), putInteger("download_size"),

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -268,7 +268,14 @@ public class ParseUri {
             .put("out_of_retries", ImmutableSet.of(11)).put("file_error", ImmutableSet.of(20))
             .put("sig_not_trusted", ImmutableSet.of(21, 23))
             .put("sig_unexpected", ImmutableSet.of(22, 23))
-            .put("install_timeout", ImmutableSet.of(30)).build()),
+            .put("install_timeout", ImmutableSet.of(30))
+            .put("unknown_error", ImmutableSet.of(1))
+            .put("sig_check_timeout", ImmutableSet.of(24))
+            .put("hardware_req_not_met", ImmutableSet.of(25))
+            .put("os_version_req_not_met", ImmutableSet.of(26))
+            .put("disk_space_req_not_met", ImmutableSet.of(27))
+             .put("writeable_req_not_met", ImmutableSet.of(28))
+            .build()),
         // Launch code
         putBoolPerCode(ImmutableMap.of("old_running", 1, "new_launched", 2)),
         putInteger("download_retries"), putInteger("bytes_downloaded"), putInteger("download_size"),

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -263,7 +263,7 @@ public class ParseUri {
         appendString(Attribute.OS_VERSION, "."), //
         putString("service_pack"), putBool("server_os"),
         // Exit code
-        putBoolPerCodeSet(new ImmutableMap.Builder<String, Set<Integer>>()
+        putBoolPerCodeSet(new ImmutableMap.Builder<String, Set<Integer>>() //
             .put("succeeded", ImmutableSet.of(0)) //
             .put("user_cancelled", ImmutableSet.of(10)) //
             .put("out_of_retries", ImmutableSet.of(11)) //

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
@@ -170,39 +170,89 @@ public class ParseUriTest extends TestWithDeterministicJson {
               .put("0",
                   "\"succeeded\":true,\"user_cancelled\":false,\"out_of_retries\":false,"
                       + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false")
-              .put("1",
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+             .put("1",
                   "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
                       + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false")
+                      + "\"install_timeout\":false,\"unknown_error\":true,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
               .put("10",
                   "\"succeeded\":false,\"user_cancelled\":true,\"out_of_retries\":false,"
                       + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false")
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
               .put("11",
                   "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":true,"
                       + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false")
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
               .put("20",
                   "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
                       + "\"file_error\":true,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false")
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
               .put("21",
                   "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
                       + "\"file_error\":false,\"sig_not_trusted\":true,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false")
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
               .put("22",
                   "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
                       + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":true,"
-                      + "\"install_timeout\":false")
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
               .put("23",
                   "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
                       + "\"file_error\":false,\"sig_not_trusted\":true,\"sig_unexpected\":true,"
-                      + "\"install_timeout\":false")
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+
+
+              .put("24",
+                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":true,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+               .put("25",
+                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":true,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+              .put("26",
+                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":true,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+              .put("27",
+                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":true,\"writeable_req_not_met\":false")
+              .put("28",
+                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":true")
               .put("30",
                   "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
                       + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":true")
+                      + "\"install_timeout\":true,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
               .build(), //
           // Launch code
           ImmutableMap.of(//

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
@@ -150,150 +150,149 @@ public class ParseUriTest extends TestWithDeterministicJson {
     }
   }
 
-  private static final Map<String, String> VALID_V6_DIMENSIONS = joinCases(
-      Arrays.asList(validStringCases("build_channel"), //
-          validStringCases("update_channel"), //
-          validStringCases("locale"), //
-          // Build architecture code
-          ImmutableMap.of(//
-              "0", "\"64bit_build\":false", //
-              "1", "\"64bit_build\":true"),
-          // OS architecture code
-          ImmutableMap.of(//
-              "0", "\"64bit_os\":false", //
-              "1", "\"64bit_os\":true"), //
-          ImmutableMap.of("1/2/3", "\"os_version\":\"1.2.3\""), //
-          validStringCases("service_pack"), //
-          validBoolCases("server_os"), //
-          // Exit code
-          new ImmutableMap.Builder<String, String>() //
-              .put("0",
-                  "\"succeeded\":true,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-             .put("1",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":true,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-              .put("10",
-                  "\"succeeded\":false,\"user_cancelled\":true,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-              .put("11",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":true,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-              .put("20",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":true,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-              .put("21",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":true,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-              .put("22",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":true,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-              .put("23",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":true,\"sig_unexpected\":true,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+  private static final Map<String, String> VALID_V6_DIMENSIONS = joinCases(Arrays.asList(
+      validStringCases("build_channel"), //
+      validStringCases("update_channel"), //
+      validStringCases("locale"), //
+      // Build architecture code
+      ImmutableMap.of(//
+          "0", "\"64bit_build\":false", //
+          "1", "\"64bit_build\":true"),
+      // OS architecture code
+      ImmutableMap.of(//
+          "0", "\"64bit_os\":false", //
+          "1", "\"64bit_os\":true"), //
+      ImmutableMap.of("1/2/3", "\"os_version\":\"1.2.3\""), //
+      validStringCases("service_pack"), //
+      validBoolCases("server_os"), //
+      // Exit code
+      new ImmutableMap.Builder<String, String>() //
+          .put("0",
+              "\"succeeded\":true,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .put("1",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":true,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .put("10",
+              "\"succeeded\":false,\"user_cancelled\":true,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .put("11",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":true,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .put("20",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":true,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .put("21",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":true,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .put("22",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":true,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .put("23",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":true,\"sig_unexpected\":true,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
 
-
-              .put("24",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":true,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-               .put("25",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":true,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-              .put("26",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":true,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-              .put("27",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":true,\"writeable_req_not_met\":false")
-              .put("28",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":true")
-              .put("30",
-                  "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
-                      + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
-                      + "\"install_timeout\":true,\"unknown_error\":false,\"sig_check_timeout\":false,"
-                      + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
-                      + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
-              .build(), //
-          // Launch code
-          ImmutableMap.of(//
-              "0", "\"old_running\":false,\"new_launched\":false", //
-              "1", "\"old_running\":true,\"new_launched\":false", //
-              "2", "\"old_running\":false,\"new_launched\":true"), //
-          validIntCases("download_retries"), //
-          validIntCases("bytes_downloaded"), //
-          validIntCases("download_size"), //
-          validIntCases("intro_time"), //
-          validIntCases("options_time"), //
-          validIntCases("download_time"), //
-          ImmutableMap.of("", ""), // ignored field
-          validIntCases("download_latency"), //
-          validIntCases("preinstall_time"), //
-          validIntCases("install_time"), //
-          validIntCases("finish_time"), //
-          // Initial install requirements code
-          ImmutableMap.of(//
-              "0", "\"disk_space_error\":false,\"no_write_access\":false", //
-              "1", "\"disk_space_error\":true,\"no_write_access\":false", //
-              "2", "\"disk_space_error\":false,\"no_write_access\":true"), //
-          validBoolCases("manual_download"), //
-          validBoolCases("had_old_install"), //
-          validStringCases("old_version"), //
-          validStringCases("old_build_id"), //
-          validStringCases("version"), //
-          validStringCases("build_id"), //
-          validBoolCases("default_path"), //
-          validBoolCases("admin_user"), //
-          // Default browser status code
-          ImmutableMap.of(//
-              "0", "\"new_default\":false,\"old_default\":false", //
-              "1", "\"new_default\":true,\"old_default\":false", //
-              "2", "\"new_default\":false,\"old_default\":true"), //
-          // Default browser setting code
-          ImmutableMap.of(//
-              "0", "\"set_default\":false", //
-              "1", "\"set_default\":false", //
-              "2", "\"set_default\":true"), //
-          validStringCases("download_ip")));
+          .put("24",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":true,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .put("25",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":true,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .put("26",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":true,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .put("27",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":true,\"writeable_req_not_met\":false")
+          .put("28",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":false,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":true")
+          .put("30",
+              "\"succeeded\":false,\"user_cancelled\":false,\"out_of_retries\":false,"
+                  + "\"file_error\":false,\"sig_not_trusted\":false,\"sig_unexpected\":false,"
+                  + "\"install_timeout\":true,\"unknown_error\":false,\"sig_check_timeout\":false,"
+                  + "\"hardware_req_not_met\":false,\"os_version_req_not_met\":false,"
+                  + "\"disk_space_req_not_met\":false,\"writeable_req_not_met\":false")
+          .build(), //
+      // Launch code
+      ImmutableMap.of(//
+          "0", "\"old_running\":false,\"new_launched\":false", //
+          "1", "\"old_running\":true,\"new_launched\":false", //
+          "2", "\"old_running\":false,\"new_launched\":true"), //
+      validIntCases("download_retries"), //
+      validIntCases("bytes_downloaded"), //
+      validIntCases("download_size"), //
+      validIntCases("intro_time"), //
+      validIntCases("options_time"), //
+      validIntCases("download_time"), //
+      ImmutableMap.of("", ""), // ignored field
+      validIntCases("download_latency"), //
+      validIntCases("preinstall_time"), //
+      validIntCases("install_time"), //
+      validIntCases("finish_time"), //
+      // Initial install requirements code
+      ImmutableMap.of(//
+          "0", "\"disk_space_error\":false,\"no_write_access\":false", //
+          "1", "\"disk_space_error\":true,\"no_write_access\":false", //
+          "2", "\"disk_space_error\":false,\"no_write_access\":true"), //
+      validBoolCases("manual_download"), //
+      validBoolCases("had_old_install"), //
+      validStringCases("old_version"), //
+      validStringCases("old_build_id"), //
+      validStringCases("version"), //
+      validStringCases("build_id"), //
+      validBoolCases("default_path"), //
+      validBoolCases("admin_user"), //
+      // Default browser status code
+      ImmutableMap.of(//
+          "0", "\"new_default\":false,\"old_default\":false", //
+          "1", "\"new_default\":true,\"old_default\":false", //
+          "2", "\"new_default\":false,\"old_default\":true"), //
+      // Default browser setting code
+      ImmutableMap.of(//
+          "0", "\"set_default\":false", //
+          "1", "\"set_default\":false", //
+          "2", "\"set_default\":true"), //
+      validStringCases("download_ip")));
 
   private static final Map<String, String> VALID_V7_DIMENSIONS = joinCases(
       Arrays.asList(VALID_V6_DIMENSIONS, validStringCases("attribution")));

--- a/ingestion-sink/pom.xml
+++ b/ingestion-sink/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.50.0</version>
+                <version>26.51.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Corresponding code change for the stub installer and documentation:
https://phabricator.services.mozilla.com/D230471

Corresponding schema change: 
https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/834