### PR TITLE
Ignore `us-spotco-fennec-dos` namespace (bug 1938660)

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -125,6 +125,7 @@ public class MessageScrubber {
       .put("org-mozilla-firefox-cp", "1925615") //
       .put("com-feifan-topvan", "1924135") //
       .put("com-feifan-chrome-ios-dev", "1930793") //
+      .put("us-spotco-fennec-dos", "1938660") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap


### PR DESCRIPTION
To fix [bug 1938660](https://bugzilla.mozilla.org/show_bug.cgi?id=1938660) "missing namespace `us-spotco-fennec-dos`".