### PR TITLE
Bug 1941442 - Add workaround for installer windows_ubr field

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -348,6 +348,17 @@ public class MessageScrubber {
       }
     }
 
+    if (bug1934302Affected(namespace, docType)) {
+      if (json.path("windows_ubr").isTextual()) {
+        try {
+          json.put("windows_ubr", Integer.parseInt(json.path("windows_ubr").asText()));
+          markBugCounter("1934302");
+        } catch (NumberFormatException e) {
+          // can't convert and will be rejected by schema validation
+        }
+      }
+    }
+
     if (ParseUri.TELEMETRY.equals(namespace) && "main".equals(docType)) {
       processForBug1751753(json);
     }
@@ -485,6 +496,10 @@ public class MessageScrubber {
     return "mozillavpn".equals(namespace) && "main".equals(docType)
         && ParsePayload.getGleanClientInfo(json).path("telemetry_sdk_build").asText("")
             .matches("0[.]([0-9]|1[0-6])[.].*"); // < 0.17
+  }
+
+  private static boolean bug1934302Affected(String namespace, String docType) {
+    return "firefox-installer".equals(namespace) && "install".equals(docType);
   }
 
   // See bug 1751753 for explanation of context.

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -247,8 +247,9 @@ public class ParseUri {
     public static final Pattern PING_VERSION_PATTERN = Pattern
         .compile(String.format("^v(?<%s>[6-9]|1[0-9])(-(?<%s>\\d+))?$", VERSION, FUNNELCAKE));
 
+    // set v9 to 43 to backfill UnexpectedPathElementsException
     public static final Map<String, Integer> SUFFIX_LENGTH = ImmutableMap.of("6", 36, "7", 37, "8",
-        39, "9", 41, "10", 43);
+        39, "9", 43, "10", 43);
 
     /**
      * NOTE: When adding new fields here, the version must be incremented on the client.

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -249,7 +249,7 @@ public class ParseUri {
 
     // set v9 to 43 to backfill UnexpectedPathElementsException
     public static final Map<String, Integer> SUFFIX_LENGTH = ImmutableMap.of("6", 36, "7", 37, "8",
-        39, "9", 43, "10", 43);
+        39, "9", 41, "10", 43);
 
     /**
      * NOTE: When adding new fields here, the version must be incremented on the client.
@@ -350,6 +350,10 @@ public class ParseUri {
     private static ObjectNode parsePingVersion(String[] elements) throws InvalidUriException {
       // Parse ping version using a regex pattern
       String pingVersion = elements[0];
+      if (pingVersion.startsWith("v9") && elements.length == 43) {
+        elements[0] = "v10";
+        pingVersion = elements[0];
+      }
       Matcher matcher = PING_VERSION_PATTERN.matcher(pingVersion);
       if (!matcher.find()) {
         throw new UnknownPingVersionException(pingVersion);

--- a/ingestion-beam/start_dataflow_20250122.sh
+++ b/ingestion-beam/start_dataflow_20250122.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -exo pipefail
+
+PROJECT="moz-fx-data-backfill-1"
+JOB_NAME="firefox-installer-backfill-1"
+
+# this script assumes it's being run from the ingestion-beam directory
+# of the gcp-ingestion repo.
+
+mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dmaven.compiler.release=11 -Dexec.args="\
+    --runner=Dataflow \
+    --jobName=$JOB_NAME \
+    --project=$PROJECT  \
+    --geoCityDatabase=gs://moz-fx-data-prod-geoip/GeoIP2-City/20250121/GeoIP2-City.mmdb \
+    --geoCityFilter=gs://moz-fx-data-prod-dataflow-templates/cities15000.txt \
+    --geoIspDatabase=gs://moz-fx-data-prod-geoip/GeoIP2-ISP/20250121/GeoIP2-ISP.mmdb \
+    --schemasLocation=gs://moz-fx-data-prod-dataflow/schemas/202501220242_71ee553f.tar.gz \
+    --inputType=bigquery_table \
+    --input='$PROJECT:payload_bytes_error.backfill' \
+    --bqRowRestriction=\"DATE(submission_timestamp) BETWEEN '2024-12-30' AND '2025-01-22'\" \
+    --bqReadMethod=storageapi \
+    --outputType=bigquery \
+    --bqWriteMethod=file_loads \
+    --bqClusteringFields=submission_timestamp \
+    --output=${PROJECT}:firefox_installer_live.\${document_type}_v\${document_version} \
+    --errorOutputType=bigquery \
+    --errorOutput=${PROJECT}:payload_bytes_error.structured \
+    --experiments=shuffle_mode=service \
+    --region=us-central1 \
+    --usePublicIps=false \
+    --gcsUploadBufferSizeBytes=16777216 \
+    --tempLocation=gs://dataflow-staging-us-central1-215736861657/temp/ \
+    --numWorkers=5 \
+    --maxNumWorkers=200 \
+"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1941442

This change should coerce the invalid pings into an acceptable format.  This is just meant for backfill and we shouldn't need to merge this (can't merge ParseUri changes).  We can manually build and deploy to dataflow similar to https://github.com/mozilla/bigquery-backfill/tree/main/backfill/2024-11-06-metrics-pings-metric-labels-over-max-length