### PR TITLE
Bug 1941536 - Ignore com-atomic-browser-ios-client namespace

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -126,6 +126,7 @@ public class MessageScrubber {
       .put("com-feifan-topvan", "1924135") //
       .put("com-feifan-chrome-ios-dev", "1930793") //
       .put("us-spotco-fennec-dos", "1938660") //
+      .put("com-atomic-browser-ios-client", "1941536") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1941536