### PR TITLE
[DENG-7762] Drop user-characteristics ping from Firefox Android

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -272,6 +272,10 @@ public class MessageScrubber {
       }
     }
 
+    if (deng7762Affected(namespace, docType)) {
+      throw new MessageShouldBeDroppedException("deng7762");
+    }
+
     // Check for unwanted data; these messages aren't thrown out, but this class of errors will be
     // ignored for most pipeline monitoring.
     if (IGNORED_NAMESPACES.containsKey(namespace)) {
@@ -502,6 +506,14 @@ public class MessageScrubber {
                 DESKTOP_SEARCH_CONTENT_PATTERN);
           }
         });
+  }
+
+  // See https://mozilla-hub.atlassian.net/browse/DENG-7762
+  private static boolean deng7762Affected(String namespace, String docType) {
+    return ("org-mozilla-fenix".equals(namespace) //
+        || "org-mozilla-firefox-beta".equals(namespace) //
+        || "org-mozilla-firefox".equals(namespace)) //
+        && "user-characteristics".equals(docType);
   }
 
   private static void sanitizeDesktopSearchKeys(ObjectNode searchNode, Pattern pattern) {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -773,4 +773,31 @@ public class MessageScrubberTest {
         .build();
     MessageScrubber.scrub(attributes, Json.createObjectNode());
   }
+
+  @Test
+  public void testDropDeng7762() {
+    final ImmutableMap.Builder<String, String> attributeBuilder = ImmutableMap
+        .<String, String>builder().put(Attribute.DOCUMENT_TYPE, "user-characteristics")
+        .put(Attribute.X_TELEMETRY_AGENT, "Glean");
+
+    assertThrows(MessageShouldBeDroppedException.class,
+        () -> MessageScrubber.scrub(
+            attributeBuilder.put(Attribute.DOCUMENT_NAMESPACE, "org-mozilla-fenix").build(),
+            Json.createObjectNode()));
+    assertThrows(MessageShouldBeDroppedException.class,
+        () -> MessageScrubber.scrub(attributeBuilder
+            .put(Attribute.DOCUMENT_NAMESPACE, "org-mozilla-firefox").buildKeepingLast(),
+            Json.createObjectNode()));
+    assertThrows(MessageShouldBeDroppedException.class,
+        () -> MessageScrubber.scrub(attributeBuilder
+            .put(Attribute.DOCUMENT_NAMESPACE, "org-mozilla-firefox-beta").buildKeepingLast(),
+            Json.createObjectNode()));
+
+    // valid documents
+    MessageScrubber.scrub(
+        attributeBuilder.put(Attribute.DOCUMENT_NAMESPACE, "firefox-desktop").buildKeepingLast(),
+        Json.createObjectNode());
+    MessageScrubber.scrub(ImmutableMap.of(Attribute.DOCUMENT_NAMESPACE, "org-mozilla-firefox",
+        Attribute.DOCUMENT_TYPE, "metrics"), Json.createObjectNode());
+  }
 }


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/DENG-7762 and the doc linked there.

I'm just dropping all the messages instead of doing a submission_timestamp filter because I'm not sure how reliable submission_timestamp would be and also just in case we determine we should keep dropping these after 2025-02-03.  I figure it's easy enough to revert and redeploy when we get confirmation.