### PR TITLE
Bug 1947334 - Drop org-lilo-browser-chrome-ios-herebedragons namespace

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -127,6 +127,7 @@ public class MessageScrubber {
       .put("com-feifan-chrome-ios-dev", "1930793") //
       .put("us-spotco-fennec-dos", "1938660") //
       .put("com-atomic-browser-ios-client", "1941536") //
+      .put("org-lilo-browser-chrome-ios-herebedragons", "1947334") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1947334