### PR TITLE
Stream support for unnesting events in ParseAmplitudeEvents

### DIFF
--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/amplitude/ParseAmplitudeEventsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/amplitude/ParseAmplitudeEventsTest.java
@@ -71,13 +71,13 @@ public class ParseAmplitudeEventsTest {
     expectedEventObject.put("event_extras", nullValue);
     expectedEventObject.put("timestamp", "0");
 
-    ArrayList<ObjectNode> expect = new ArrayList<ObjectNode>();
+    List<ObjectNode> expect = new ArrayList<ObjectNode>();
     expect.add(expectedEventObject);
 
     ParseAmplitudeEvents parseAmplitudeEvents = ParseAmplitudeEvents.of(EVENTS_ALLOW_LIST);
     parseAmplitudeEvents.readAllowedEventsFromFile();
 
-    ArrayList<ObjectNode> actual = parseAmplitudeEvents.extractEvents(payload, "firefox-desktop",
+    List<ObjectNode> actual = parseAmplitudeEvents.extractEvents(payload, "firefox-desktop",
         "quick-suggest");
     if (!expect.equals(actual)) {
       System.err.println(Json.asString(actual));


### PR DESCRIPTION
We were running into the following exception when unnesting events while running this pipeline in streaming mode:

```
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1634)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:127)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:502)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:488)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:528)
	at com.mozilla.telemetry.amplitude.ParseAmplitudeEvents.lambda$extractEvents$11(ParseAmplitudeEvents.java:240)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at com.mozilla.telemetry.amplitude.ParseAmplitudeEvents.extractEvents(ParseAmplitudeEvents.java:228)
	at com.mozilla.telemetry.amplitude.ParseAmplitudeEvents.lambda$expand$1fb25989$1(ParseAmplitudeEvents.java:114)
	at org.apache.beam.sdk.transforms.FlatMapElements$FlatMapWithFailures$2.processElement(FlatMapElements.java:362)
```

This PR refactors the unnesting of events to be compatible when streaming