### PR TITLE
singletonAllowedEvents initialize in synchronized block

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/amplitude/ParseAmplitudeEvents.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/amplitude/ParseAmplitudeEvents.java
@@ -192,30 +192,32 @@ public class ParseAmplitudeEvents extends
       throw new IllegalArgumentException("File location must be defined");
     }
 
-    try (InputStream inputStream = BeamFileInputStream.open(eventsAllowListPath);
-        InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
-        BufferedReader reader = new BufferedReader(inputStreamReader)) {
-      singletonAllowedEvents = new ArrayList<String[]>();
+    synchronized (ParseAmplitudeEvents.class) {
+      try (InputStream inputStream = BeamFileInputStream.open(eventsAllowListPath);
+          InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+          BufferedReader reader = new BufferedReader(inputStreamReader)) {
+        singletonAllowedEvents = new ArrayList<String[]>();
 
-      while (reader.ready()) {
-        String line = reader.readLine();
+        while (reader.ready()) {
+          String line = reader.readLine();
 
-        if (line != null && !line.isEmpty()) {
-          String[] separated = line.split(",");
+          if (line != null && !line.isEmpty()) {
+            String[] separated = line.split(",");
 
-          if (separated.length != 4) {
-            throw new IllegalArgumentException(
-                "Invalid mapping: " + line + "; four-column csv expected");
+            if (separated.length != 4) {
+              throw new IllegalArgumentException(
+                  "Invalid mapping: " + line + "; four-column csv expected");
+            }
+
+            singletonAllowedEvents.add(separated);
           }
-
-          singletonAllowedEvents.add(separated);
         }
+      } catch (IOException e) {
+        throw new IOException("Exception thrown while fetching " + eventsAllowListPath, e);
       }
-
-      return singletonAllowedEvents;
-    } catch (IOException e) {
-      throw new IOException("Exception thrown while fetching " + eventsAllowListPath, e);
     }
+
+    return singletonAllowedEvents;
   }
 
   /**


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/gcp-ingestion/pull/2744#pullrequestreview-2651560882

During initialization `ConcurrentModificationException` when initializing the event allow list. This doesn't block the pipeline from running, but putting it into a `synchronized` block should fix the issue