### PR TITLE
[DENG-7616] Fix reading Amplitude API keys

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/AmplitudePublisher.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/AmplitudePublisher.java
@@ -127,7 +127,6 @@ public class AmplitudePublisher extends Sink {
         if (line != null && !line.isEmpty()) {
           String[] data = line.split(",");
           apiKeys.put(data[0], data[1]);
-          break;
         }
       }
     } catch (IOException e) {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/AmplitudePublisherTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/AmplitudePublisherTest.java
@@ -1,0 +1,17 @@
+package com.mozilla.telemetry;
+
+import java.util.Map;
+import org.junit.Test;
+
+public class AmplitudePublisherTest {
+
+  private static final String API_KEYS = "src/test/resources/amplitude/apiKeys.csv";
+
+  @Test
+  public void testReadAmplitudeApiKeysFromFile() {
+    Map<String, String> apiKeys = AmplitudePublisher.readAmplitudeApiKeysFromFile(API_KEYS);
+
+    assert apiKeys.get("org-mozilla-ios-firefox").equals("xxxx");
+    assert apiKeys.get("org-mozilla-firefox").equals("yyyy");
+  }
+}

--- a/ingestion-beam/src/test/resources/amplitude/apiKeys.csv
+++ b/ingestion-beam/src/test/resources/amplitude/apiKeys.csv
@@ -1,0 +1,2 @@
+org-mozilla-ios-firefox,xxxx
+org-mozilla-firefox,yyyy


### PR DESCRIPTION
Removing a `break;` which stopped reading from the API key file after parsing the first key.