### PR TITLE
Add country code and form factor to Sponsored Suggest reporting URLs

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
@@ -265,15 +265,14 @@ public class ParseReportingUrl extends
             addAdditionalDimensionsForTopSitesClicks(builtUrl, attributes);
           }
 
-          // If we're on desktop and quicksuggest then add the attribution source (data sharing
-          // preference) to the `custom-data` query param
-          // https://mozilla-hub.atlassian.net/browse/DENG-392
-          if (SponsoredInteraction.FORM_DESKTOP.equals(interaction.getFormFactor())
-              && SponsoredInteraction.SOURCE_SUGGEST.equals(interaction.getSource())) {
-            addCustomDataForDesktopSuggest(builtUrl, interaction);
-          }
-
           if (SponsoredInteraction.SOURCE_SUGGEST.equals(interaction.getSource())) {
+            // If we're on desktop and quicksuggest then add the attribution source (data sharing
+            // preference) to the `custom-data` query param
+            // https://mozilla-hub.atlassian.net/browse/DENG-392
+            if (SponsoredInteraction.FORM_DESKTOP.equals(interaction.getFormFactor())) {
+              addCustomDataForDesktopSuggest(builtUrl, interaction);
+            }
+
             addAdditionalDimensionsForInternationalSuggest(builtUrl, interaction, payload);
           }
 
@@ -307,19 +306,27 @@ public class ParseReportingUrl extends
 
   private static void addAdditionalDimensionsForInternationalSuggest(BuildReportingUrl builtUrl,
       SponsoredInteraction interaction, ObjectNode payload) {
-    // Do not add additional parameters for legacy suggest URLs
+    // Do not add additional parameters for legacy suggest URLs.
+    //
+    // Glean events do not indicate how the suggest data was sourced (from the AMP SFTP server or
+    // the new AMP Suggest API), so we resort to looking at the reporting URL.
+    //
+    // AMP uses {mozillacla,firefoxmobilecla}.ampxdirect.com for click URLs and
+    // https://imp.mt48.net/static for impression URLs for suggestions sourced from the SFTP server
+    // (i.e. US suggestions currently).
+    //
+    // They use bridge.*.admarketplace.net for click URLs and and https://imp.mt48.net/imp for
+    // impression URLs for suggestions sourced from the Suggest API.
     String baseUrl = builtUrl.getBaseUrl();
     if (baseUrl.contains("ampxdirect.com") || baseUrl.startsWith("https://imp.mt48.net/static")) {
       return;
     }
 
-    if (!payload.hasNonNull(Attribute.NORMALIZED_COUNTRY_CODE)) {
-      throw new RejectedMessageException(
-          "Missing required payload value " + Attribute.NORMALIZED_COUNTRY_CODE, "country");
+    if (payload.hasNonNull(Attribute.NORMALIZED_COUNTRY_CODE)) {
+      builtUrl.addQueryParam(BuildReportingUrl.PARAM_COUNTRY_CODE,
+          payload.get(Attribute.NORMALIZED_COUNTRY_CODE).asText());
     }
 
-    builtUrl.addQueryParam(BuildReportingUrl.PARAM_COUNTRY_CODE,
-        payload.get(Attribute.NORMALIZED_COUNTRY_CODE).asText());
     builtUrl.addQueryParam(BuildReportingUrl.PARAM_FORM_FACTOR, interaction.getFormFactor());
   }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
@@ -43,8 +43,10 @@ public class ParseReportingUrlTest {
 
     List<Set<String>> allowedUrlSets = parseReportingUrl.loadAllowedUrls();
 
-    Set<String> expectedClickUrls = ImmutableSet.of("click.com", "click2.com", "test.com");
-    Set<String> expectedImpressionUrls = ImmutableSet.of("impression.com", "test.com");
+    Set<String> expectedClickUrls = ImmutableSet.of("click.com", "click2.com", "test.com",
+        "admarketplace.net", "ampxdirect.com");
+    Set<String> expectedImpressionUrls = ImmutableSet.of("impression.com", "test.com",
+        "imp.mt48.net");
 
     Assert.assertEquals(expectedClickUrls, allowedUrlSets.get(0));
     Assert.assertEquals(expectedImpressionUrls, allowedUrlSets.get(1));
@@ -713,7 +715,8 @@ public class ParseReportingUrlTest {
   public void testMobileSuggestPings() {
     final String contextId = "aaaaaaaa-cc1d-49db-927d-3ea2fc2ae9c1";
 
-    ObjectNode basePayload = Json.createObjectNode();
+    ObjectNode basePayload = Json.createObjectNode().put(Attribute.NORMALIZED_COUNTRY_CODE, "US");
+
     ObjectNode metrics = basePayload.putObject("metrics");
     metrics.putObject("url").put("fx_suggest.reporting_url",
         "https://test.com?v=a&adv-id=1&ctag=1&partner=1&version=1&sub2=1&sub1=1&ci=1&custom-data=1");
@@ -918,6 +921,73 @@ public class ParseReportingUrlTest {
           Assert.assertTrue("contains dma code",
               reportingUrl.contains(String.format("%s=&", BuildReportingUrl.PARAM_DMA_CODE))
                   || reportingUrl.endsWith(String.format("%s=", BuildReportingUrl.PARAM_DMA_CODE)));
+
+          return null;
+        });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testInternationalSuggest() {
+    // Context IDs are not relevant to the behavior; we just use them to simplify the assertions
+    final String contextId = "my-special-context-id";
+
+    ObjectNode basePayload = Json.createObjectNode().put(Attribute.NORMALIZED_COUNTRY_CODE, "GB");
+
+    Map<String, String> attributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE, "quick-suggest",
+        Attribute.DOCUMENT_NAMESPACE, "firefox-desktop");
+
+    ObjectNode impressionPayload = basePayload.deepCopy();
+    ObjectNode impressionMetrics = impressionPayload.putObject("metrics");
+    impressionMetrics.putObject("uuid").put("quick_suggest.context_id", contextId);
+    impressionMetrics.putObject("string").put("quick_suggest.ping_type", "quicksuggest-impression");
+    impressionMetrics.putObject("url").put("quick_suggest.reporting_url",
+        "https://imp.mt48.net/imp?foo=bar");
+
+    ObjectNode clickPayload = basePayload.deepCopy();
+    ObjectNode clickMetrics = clickPayload.putObject("metrics");
+    clickMetrics.putObject("uuid").put("quick_suggest.context_id", contextId);
+    clickMetrics.putObject("string").put("quick_suggest.ping_type", "quicksuggest-click");
+    clickMetrics.putObject("url").put("quick_suggest.reporting_url",
+        "https://bridge.pdx1.admarketplace.net/ctp?foo=bar");
+
+    ObjectNode legacyImpressionPayload = basePayload.deepCopy();
+    ObjectNode legacyImpressionMetrics = legacyImpressionPayload.putObject("metrics");
+    legacyImpressionMetrics.putObject("string").put("quick_suggest.ping_type",
+        "quicksuggest-impression");
+    legacyImpressionMetrics.putObject("url").put("quick_suggest.reporting_url",
+        "https://imp.mt48.net/static?foo=bar");
+
+    ObjectNode legacyClickPayload = basePayload.deepCopy();
+    ObjectNode legacyClickMetrics = legacyClickPayload.putObject("metrics");
+    legacyClickMetrics.putObject("string").put("quick_suggest.ping_type", "quicksuggest-click");
+    legacyClickMetrics.putObject("url").put("quick_suggest.reporting_url",
+        "https://mozillacla.ampxdirect.com/?foo=bar");
+
+    List<PubsubMessage> input = ImmutableList.of(
+        new PubsubMessage(Json.asBytes(impressionPayload), attributes),
+        new PubsubMessage(Json.asBytes(clickPayload), attributes),
+        new PubsubMessage(Json.asBytes(legacyImpressionPayload), attributes),
+        new PubsubMessage(Json.asBytes(legacyClickPayload), attributes));
+
+    Result<PCollection<SponsoredInteraction>, PubsubMessage> result = pipeline //
+        .apply(Create.of(input)) //
+        .apply(ParseReportingUrl.of(URL_ALLOW_LIST));
+
+    PAssert.that(result.output().setCoder(SponsoredInteraction.getCoder()))
+        .satisfies(sponsoredInteractions -> {
+          Assert.assertEquals(4, Iterables.size(sponsoredInteractions));
+
+          sponsoredInteractions.forEach(interaction -> {
+            String reportingUrl = interaction.getReportingUrl();
+            boolean shouldEnrichUrl = interaction.getContextId().equals(contextId);
+
+            Assert.assertEquals("country-code in reporting url", shouldEnrichUrl,
+                reportingUrl.contains("country-code=GB"));
+            Assert.assertEquals("form-factor in reporting url", shouldEnrichUrl,
+                reportingUrl.contains("form-factor=desktop"));
+          });
 
           return null;
         });

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/contextualservices/ParseReportingUrlTest.java
@@ -716,7 +716,6 @@ public class ParseReportingUrlTest {
     final String contextId = "aaaaaaaa-cc1d-49db-927d-3ea2fc2ae9c1";
 
     ObjectNode basePayload = Json.createObjectNode();
-
     ObjectNode metrics = basePayload.putObject("metrics");
     metrics.putObject("url").put("fx_suggest.reporting_url",
         "https://test.com?v=a&adv-id=1&ctag=1&partner=1&version=1&sub2=1&sub1=1&ci=1&custom-data=1");

--- a/ingestion-beam/src/test/resources/contextualServices/urlAllowlist.csv
+++ b/ingestion-beam/src/test/resources/contextualServices/urlAllowlist.csv
@@ -3,3 +3,6 @@ impression.com,impression
 click2.com,click
 test.com,click
 test.com,impression
+imp.mt48.net,impression
+ampxdirect.com,click
+admarketplace.net,click


### PR DESCRIPTION
This is per the [integration guidelines](https://docs.google.com/document/d/165T1slU78f6ZqFhvFoTtlpUtwsMdEzwICi8_F297jUg/edit?usp=sharing) for the new AMP Suggest API.

In the following weeks, we will also:
1. Add the Firefox version to click URLs
2. Aggregate impressions similar to what we're doing for Sponsored Tiles today

I originally considered doing this during ingestion (see https://github.com/mozilla-services/mars/pull/573), but ultimately decided against it as:

1. The 2 changes mentioned above will require us to update the Contextual Services pipeline anyway, and it makes sense to have it all in one place
2. There will be some portion of users with country codes that don't match the suggest set (e.g. QA users in Romania testing UK suggest). I think it makes sense to send accurate country information in these cases.