### PR TITLE
[DENG-8480] Use CODEOWNERS for tagging reviewers for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,6 @@ updates:
     versions: [ ">=2.2.0" ]
   schedule:
     interval: daily
-  reviewers:
-  - mozilla/data-platform-infra-wg
   labels:
   - dependencies
   - java
@@ -28,8 +26,6 @@ updates:
   - dependency-name: com.google.cloud:libraries-bom
   schedule:
     interval: daily
-  reviewers:
-  - mozilla/data-platform-infra-wg
   labels:
   - dependencies
   - java
@@ -37,8 +33,6 @@ updates:
   directory: /ingestion-edge
   schedule:
     interval: daily
-  reviewers:
-  - mozilla/data-platform-infra-wg
   labels:
   - dependencies
   - python

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Dependency updates (via dependabot)
+/ingestion-edge/requirements.txt @mozilla/data-platform-infra-wg
+/ingestion-edge/requirements.in @mozilla/data-platform-infra-wg
+/*/pom.xml @mozilla/data-platform-infra-wg
+pom.xml @mozilla/data-platform-infra-wg


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-8480

Dependabot reviewers configuration is being removed, and instead they are recommending to rely on CODEOWNERS files to assign reviewers