### PR TITLE
[DENG-8592] Implement Posthog POC event pipeline

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -76,6 +76,7 @@ natively
 nginx
 ok
 POC
+Posthog
 per-doctype
 pre-production
 protobuf

--- a/docs/ingestion-beam/posthog-job.md
+++ b/docs/ingestion-beam/posthog-job.md
@@ -1,0 +1,95 @@
+# Posthog Publisher Job
+
+The Posthog publisher job sends a specific set of events to the Posthog batch API. This job is currently used to run a proof-of-concept evaluation of Posthog on a subset of events. For more context see: https://mozilla-hub.atlassian.net/browse/DENG-7616
+
+The code is defined in the [`com.mozilla.telemetry.PosthogPublisher`](https://github.com/mozilla/gcp-ingestion/blob/main/ingestion-beam/src/main/java/com/mozilla/telemetry/PosthogPublisher.java) class.
+
+This job reads from per doctype Pub/Sub topics of specific applications.
+
+## Beam Pipeline Transforms
+
+The goal is to have event data in Posthog that is as close as possible to the data used for calculating KPIs and is used for other creating other datasets in BigQuery. Therefore, the transformation steps closely resemble [those of the Decoder job](https://mozilla.github.io/gcp-ingestion/ingestion-beam/decoder-job/).
+
+### Pub/Sub republished topic
+
+The input to this job is the subset of decoded messages from various namespaces that have pings with event data and `metrics` pings.
+
+### Decompress
+
+Attempt to decompress payload with gzip, on failure pass the message through
+unmodified.
+
+### Filter by Doc Type and Namespaces
+
+Depending on what Pub/Sub topic the job is configured to read from, this will allow to filter for specific namespaces and doc types that should be processed further.
+
+### [optional] Sampling
+
+Optionally, a sampling can be configured for the job. This is to reduce the number of events that get sent to the Posthog API.
+
+### Parse Posthog Events
+
+This step reads an external CSV configuration file that contains a set of events that should be sent do Posthog. The format of this file is as follows:
+
+```csv
+<namespace>,<doc type>,<event category>,<event name or '*'>
+```
+
+The `events` are getting parsed from the message payload and transformed into individual events that can be sent to the Posthog API. Events that don't match the allow list are being filtered out.
+
+This step also maps `metrics` pings to `user_activity` events, which are sent to Posthog to indicate that a user was active on a given day.
+For the POC, the decision was made to use the `metrics` ping instead of the more precise `baseline` ping because the event volume for baseline pings is significantly higher and would exceed Posthog storage limits. The `metrics` ping gets sent at most once a day per client, resulting a much lower volume. However, it's important to note that these pings may not reliably indicate active client sessions, as they are scheduled to be sent at 4 a.m. client time. If the browser is closed and not running at this time, the metrics ping may be sent later.
+
+For the POC, the metrics ping is considered as good enough. If/when this moves to production, coming up with a more accurate way to measure user activity might be needed.
+
+### Batching of Events
+
+Since the Posthog API has [limitations](https://posthog.com/docs/api/capture#batch-events) around how large the event payload can be for a single request, this step creates batches of events.
+
+### Send request
+
+This step sends batched events to the Posthog API.
+// todo: retry mechanism on failures which can happen when API limits are exceeded
+
+### Working with the Beam Job
+
+Options specific to this job are found in https://github.com/mozilla/gcp-ingestion/blob/main/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogPublisherOptions.java
+
+### Test Deployment
+
+This job can be deployed in a sandbox project for testing.
+
+There are a few required components to get a job running:
+
+- Upload a `.ndjson` file with example payload data to a GCS bucket
+- A event allowed list stored in GCS
+- Optionally, if reporting is enabled, a file with the Posthog API key uploaded to GCS
+- The Beam pipeline running on Dataflow, reading from the input, and sending data to Posthog
+
+Example script to start the Dataflow job from the ingestion-beam directory:
+
+```
+#!/bin/bash
+
+set -ux
+
+PROJECT="posthog-dev"
+JOB_NAME="posthog"
+path="$BUCKET/data/*.ndjson"
+
+mvn -X compile exec:java -Dexec.mainClass=com.mozilla.telemetry.PosthogPublisher -Dexec.args="\
+    --runner=Dataflow \
+    --jobName=$JOB_NAME \
+    --project=$PROJECT  \
+    --inputType=file \
+    --input=$path \
+    --bqReadMethod=storageapi \
+    --outputType=bigquery \
+    --bqWriteMethod=file_loads \
+    --errorOutputType=stderr \
+    --tempLocation=posthog-data-dev/temp/bq-loads \
+    --eventsAllowList=posthog-data-dev/eventsAllowlist.csv \
+    --apiKeys=posthog-data-dev/apiKeys.csv \
+    --region=us-central1 \
+"
+```

--- a/ingestion-beam/bin/run-posthog-dev.sh
+++ b/ingestion-beam/bin/run-posthog-dev.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -exo pipefail
+
+PROJECT=""
+JOB_NAME="posthog-test"
+BUCKET="gs://$PROJECT"
+
+path="$BUCKET/data/*.ndjson"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# this script assumes it's being run from the ingestion-beam directory
+# of the gcp-ingestion repo.
+
+$SCRIPT_DIR/mvn -X compile exec:java -Dexec.mainClass=com.mozilla.telemetry.PosthogPublisher -Dexec.args="\
+    --runner=Dataflow \
+    --jobName=$JOB_NAME \
+    --project=$PROJECT  \
+    --allowedNamespaces=org-mozilla-ios-firefox,org-mozilla-ios-firefoxbeta \
+    --allowedDocTypes=events,metrics \
+    --inputType=file \
+    --input=$path \
+    --bqReadMethod=storageapi \
+    --outputType=bigquery \
+    --bqWriteMethod=file_loads \
+    --errorOutputType=stderr \
+    --tempLocation=${BUCKET}/temp/bq-loads \
+    --eventsAllowList=${BUCKET}/eventsAllowlist.csv \
+    --apiKeys=${BUCKET}/apiKeys.csv \
+    --maxEventBatchSize=50 \
+    --region=us-central1 \
+"

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/PosthogPublisher.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/PosthogPublisher.java
@@ -1,0 +1,115 @@
+package com.mozilla.telemetry;
+
+import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import com.mozilla.telemetry.posthog.FilterByDocType;
+import com.mozilla.telemetry.posthog.ParsePosthogEvents;
+import com.mozilla.telemetry.posthog.PosthogEvent;
+import com.mozilla.telemetry.posthog.PosthogPublisherOptions;
+import com.mozilla.telemetry.posthog.SendPosthogRequest;
+import com.mozilla.telemetry.republisher.RandomSampler;
+import com.mozilla.telemetry.transforms.DecompressPayload;
+import com.mozilla.telemetry.transforms.PubsubConstraints;
+import com.mozilla.telemetry.util.BeamFileInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.GroupIntoBatches;
+import org.apache.beam.sdk.transforms.WithKeys;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.joda.time.Duration;
+
+/**
+ * Get event data and publish to Posthog.
+ */
+public class PosthogPublisher extends Sink {
+
+  public static void main(String[] args) {
+    run(args);
+  }
+
+  /**
+   * Run the Posthog publisher pipeline with command line arguments.
+   */
+  public static PipelineResult run(String[] args) {
+    registerOptions();
+    final PosthogPublisherOptions.Parsed options = PosthogPublisherOptions
+        .parsePosthogPublisherOptions(PipelineOptionsFactory.fromArgs(args).withValidation()
+            .as(PosthogPublisherOptions.class));
+    return run(options);
+  }
+
+  /**
+   * Run the Posthog publisher pipeline.
+   */
+  public static PipelineResult run(PosthogPublisherOptions.Parsed options) {
+    final Pipeline pipeline = Pipeline.create(options);
+    final List<PCollection<PubsubMessage>> errorCollections = new ArrayList<>();
+
+    PCollection<PubsubMessage> messages = pipeline.apply(options.getInputType().read(options))
+        .apply(FilterByDocType.of(options.getAllowedDocTypes(), options.getAllowedNamespaces()));
+
+    if (options.getRandomSampleRatio() != null) {
+      final Double ratio = options.getRandomSampleRatio();
+      messages.apply("SampleBySampleIdOrRandomNumber", Filter.by(message -> {
+        message = PubsubConstraints.ensureNonNull(message);
+        String sampleId = message.getAttribute(Attribute.SAMPLE_ID);
+        return RandomSampler.filterBySampleIdOrRandomNumber(sampleId, ratio);
+      })).apply("RepublishRandomSample", options.getOutputType().write(options));
+    }
+
+    final Map<String, String> apiKeys = readPosthogApiKeysFromFile(options.getApiKeys());
+
+    PCollection<KV<String, Iterable<PosthogEvent>>> events = messages
+        .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())
+            .withClientCompressionRecorded())
+        .apply(ParsePosthogEvents.of(options.getEventsAllowList())).failuresTo(errorCollections)
+        .apply(WithKeys.of((PosthogEvent event) -> event.getPlatform()))
+        .setCoder(KvCoder.of(StringUtf8Coder.of(), PosthogEvent.getCoder()))
+        .apply(GroupIntoBatches.<String, PosthogEvent>ofSize(options.getMaxEventBatchSize())
+            .withMaxBufferingDuration(Duration.standardSeconds(options.getMaxBufferingDuration())))
+        .apply(SendPosthogRequest.of(apiKeys, options.getReportingEnabled(),
+            options.getMaxBatchesPerSecond()))
+        .failuresTo(errorCollections);
+
+    PCollectionList.of(errorCollections).apply("FlattenErrorCollections", Flatten.pCollections())
+        .apply("WriteErrorOutput", options.getErrorOutputType().write(options)).output();
+
+    return pipeline.run();
+  }
+
+  static Map<String, String> readPosthogApiKeysFromFile(String path) {
+    Map<String, String> apiKeys = new HashMap<>();
+    try (InputStream inputStream = BeamFileInputStream.open(path);
+        InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+        BufferedReader reader = new BufferedReader(inputStreamReader)) {
+
+      while (reader.ready()) {
+        String line = reader.readLine();
+
+        if (line != null && !line.isEmpty()) {
+          String[] data = line.split(",");
+          apiKeys.put(data[0], data[1]);
+        }
+      }
+    } catch (IOException e) {
+      System.err.println("Exception thrown while fetching " + path);
+    }
+
+    return apiKeys;
+  }
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/FilterByDocType.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/FilterByDocType.java
@@ -1,0 +1,78 @@
+package com.mozilla.telemetry.posthog;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import com.mozilla.telemetry.metrics.PerDocTypeCounter;
+import com.mozilla.telemetry.transforms.PubsubConstraints;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.commons.lang3.StringUtils;
+
+public class FilterByDocType
+    extends PTransform<PCollection<PubsubMessage>, PCollection<PubsubMessage>> {
+
+  private final String allowedDocTypes;
+  private final String allowedNamespaces;
+
+  private static transient Set<String> allowedDocTypesSet;
+  private static transient Set<String> allowedNamespacesSet;
+
+  @VisibleForTesting
+  static synchronized void clearSingletonsForTests() {
+    allowedDocTypesSet = null;
+    allowedNamespacesSet = null;
+  }
+
+  /** Constructor. */
+  public FilterByDocType(String allowedDocTypes, String allowedNamespaces) {
+    this.allowedDocTypes = allowedDocTypes;
+    this.allowedNamespaces = allowedNamespaces;
+  }
+
+  public static FilterByDocType of(String allowedDocTypes, String allowedNamespaces) {
+    return new FilterByDocType(allowedDocTypes, allowedNamespaces);
+  }
+
+  private Set<String> parseAllowlistString(String allowlistString, String argument) {
+    if (allowlistString == null) {
+      throw new IllegalArgumentException(
+          String.format("Required --%s argument not found", argument));
+    }
+    return Arrays.stream(allowlistString.split(",")).filter(StringUtils::isNotBlank)
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public PCollection<PubsubMessage> expand(PCollection<PubsubMessage> input) {
+    return input.apply(ParDo.of(new Fn()));
+  }
+
+  private class Fn extends DoFn<PubsubMessage, PubsubMessage> {
+
+    @ProcessElement
+    public void processElement(@Element PubsubMessage message, OutputReceiver<PubsubMessage> out) {
+      message = PubsubConstraints.ensureNonNull(message);
+      if (allowedNamespacesSet == null || allowedDocTypesSet == null) {
+        allowedDocTypesSet = parseAllowlistString(allowedDocTypes, "allowedDocTypes");
+        allowedNamespacesSet = parseAllowlistString(allowedNamespaces, "allowedNamespaces");
+      }
+
+      final String namespace = message.getAttribute(Attribute.DOCUMENT_NAMESPACE);
+      final String doctype = message.getAttribute(Attribute.DOCUMENT_TYPE);
+
+      if (!allowedNamespacesSet.contains(namespace) || !allowedDocTypesSet.contains(doctype)) {
+        PerDocTypeCounter.inc(message.getAttributeMap(), "doctype_filter_rejected");
+        return;
+      }
+      PerDocTypeCounter.inc(message.getAttributeMap(), "doctype_filter_passed");
+
+      out.output(message);
+    }
+  }
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/InvalidAttributeException.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/InvalidAttributeException.java
@@ -1,0 +1,12 @@
+package com.mozilla.telemetry.posthog;
+
+public class InvalidAttributeException extends RuntimeException {
+
+  public InvalidAttributeException(String message) {
+    super(message);
+  }
+
+  public InvalidAttributeException(String message, String reason) {
+    super(message);
+  }
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/ParsePosthogEvents.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/ParsePosthogEvents.java
@@ -1,0 +1,251 @@
+package com.mozilla.telemetry.posthog;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import com.mozilla.telemetry.transforms.FailureMessage;
+import com.mozilla.telemetry.transforms.PubsubConstraints;
+import com.mozilla.telemetry.util.BeamFileInputStream;
+import com.mozilla.telemetry.util.Json;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.transforms.FlatMapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.WithFailures.ExceptionElement;
+import org.apache.beam.sdk.transforms.WithFailures.Result;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/**
+ * Convert PubSub Message with event data to Posthog event.
+ */
+public class ParsePosthogEvents extends
+    PTransform<PCollection<PubsubMessage>, Result<PCollection<PosthogEvent>, PubsubMessage>> {
+
+  private final String eventsAllowListPath;
+  private static transient volatile List<String[]> singletonAllowedEvents;
+
+  public static ParsePosthogEvents of(String eventsAllowListPath) {
+    return new ParsePosthogEvents(eventsAllowListPath);
+  }
+
+  private ParsePosthogEvents(String eventsAllowListPath) {
+    this.eventsAllowListPath = eventsAllowListPath;
+  }
+
+  @Override
+  public Result<PCollection<PosthogEvent>, PubsubMessage> expand(
+      PCollection<PubsubMessage> messages) {
+    return messages.apply(
+        FlatMapElements.into(TypeDescriptor.of(PosthogEvent.class)).via((PubsubMessage message) -> {
+          message = PubsubConstraints.ensureNonNull(message);
+          ObjectNode payload;
+          try {
+            payload = Json.readObjectNode(message.getPayload());
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+          try {
+            readAllowedEventsFromFile();
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+          final String namespace = Optional
+              .ofNullable(message.getAttribute(Attribute.DOCUMENT_NAMESPACE))
+              .orElseThrow(() -> new InvalidAttributeException("Missing namespace"));
+          final String docType = Optional.ofNullable(message.getAttribute(Attribute.DOCUMENT_TYPE))
+              .orElseThrow(() -> new InvalidAttributeException("Missing docType"));
+          final String clientId = Optional.ofNullable(message.getAttribute(Attribute.CLIENT_ID))
+              .orElseThrow(() -> new InvalidAttributeException("Missing clientId"));
+          final Integer sampleId = Optional
+              .ofNullable(Integer.parseInt(message.getAttribute(Attribute.SAMPLE_ID)))
+              .orElseThrow(() -> new InvalidAttributeException("Missing sampleId"));
+          final String appVersion = Optional.ofNullable(message.getAttribute(Attribute.APP_VERSION))
+              .orElseGet(() -> (null));
+          final String osName = Optional.ofNullable(message.getAttribute(Attribute.NORMALIZED_OS))
+              .orElseGet(() -> (null));
+          final String osVersion = Optional
+              .ofNullable(message.getAttribute(Attribute.NORMALIZED_OS_VERSION))
+              .orElseGet(() -> (null));
+          final String country = Optional.ofNullable(message.getAttribute(Attribute.GEO_COUNTRY))
+              .orElseGet(() -> (null));
+          final String device_model = Optional
+              .ofNullable(message.getAttribute(Attribute.DEVICE_MODEL)).orElseGet(() -> (null));
+          final String device_manufacturer = Optional
+              .ofNullable(message.getAttribute(Attribute.DEVICE_MANUFACTURER))
+              .orElseGet(() -> (null));
+          final String locale = Optional.ofNullable(message.getAttribute(Attribute.LOCALE))
+              .orElseGet(() -> (null));
+
+          final JsonNode experimentsNode = payload.path(Attribute.PING_INFO)
+              .path(Attribute.EXPERIMENTS);
+          final Map<String, String> experiments = new HashMap<>();
+          if (!experimentsNode.isMissingNode()) {
+            Iterator<Map.Entry<String, JsonNode>> fields = experimentsNode.fields();
+            while (fields.hasNext()) {
+              Map.Entry<String, JsonNode> field = fields.next();
+              String experiment = field.getKey();
+              String branch = field.getValue().get("branch").asText();
+              experiments.put(experiment, branch);
+            }
+          }
+
+          try {
+            if (docType.equals("metrics")) {
+              PosthogEvent.Builder userActivityEventBuilder = PosthogEvent.builder();
+              userActivityEventBuilder.setTime(Instant.now().toEpochMilli());
+              userActivityEventBuilder.setUserId(clientId);
+              userActivityEventBuilder.setSampleId(sampleId);
+              userActivityEventBuilder.setAppVersion(appVersion);
+              userActivityEventBuilder.setPlatform(namespace);
+              userActivityEventBuilder.setOsName(osName);
+              userActivityEventBuilder.setOsVersion(osVersion);
+              userActivityEventBuilder.setCountry(country);
+              userActivityEventBuilder.setDeviceModel(device_model);
+              userActivityEventBuilder.setDeviceManufacturer(device_manufacturer);
+              userActivityEventBuilder.setLanguage(locale);
+              userActivityEventBuilder.setExperiments(experiments);
+              userActivityEventBuilder.setEventType("user_activity");
+              return ImmutableList.of(userActivityEventBuilder.build());
+            } else {
+              final List<ObjectNode> events = extractEvents(payload, namespace, docType);
+              return events.stream().map((ObjectNode event) -> {
+                PosthogEvent.Builder posthogEventBuilder = PosthogEvent.builder();
+                posthogEventBuilder.setTime(extractTimestamp(payload, event));
+                posthogEventBuilder.setUserId(clientId);
+                posthogEventBuilder.setSampleId(sampleId);
+                posthogEventBuilder.setAppVersion(appVersion);
+                posthogEventBuilder.setPlatform(namespace);
+                posthogEventBuilder.setOsName(osName);
+                posthogEventBuilder.setOsVersion(osVersion);
+                posthogEventBuilder.setCountry(country);
+                posthogEventBuilder.setDeviceModel(device_model);
+                posthogEventBuilder.setDeviceManufacturer(device_manufacturer);
+                posthogEventBuilder.setLanguage(locale);
+                posthogEventBuilder.setExperiments(experiments);
+                posthogEventBuilder.setEventType(event.get("event_type").asText());
+                posthogEventBuilder.setEventExtras(event.get("event_extras").toString());
+                return posthogEventBuilder.build();
+              }).collect(Collectors.toList());
+            }
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        }).exceptionsInto(TypeDescriptor.of(PubsubMessage.class))
+            .exceptionsVia((ExceptionElement<PubsubMessage> ee) -> {
+              try {
+                throw ee.exception();
+              } catch (UncheckedIOException | IOException | IllegalArgumentException
+                  | InvalidAttributeException e) {
+                return FailureMessage.of(ParsePosthogEvents.class.getSimpleName(), ee.element(),
+                    ee.exception());
+              }
+            }));
+  }
+
+  @VisibleForTesting
+  static long timestampStringToMillis(String timestamp) {
+    return Instant.parse(timestamp).toEpochMilli();
+  }
+
+  @VisibleForTesting
+  private static long extractTimestamp(ObjectNode payload, ObjectNode event) {
+    JsonNode gleanTimestamp = event.path("event_extras").path(Attribute.GLEAN_TIMESTAMP);
+    if (!gleanTimestamp.isMissingNode()) {
+      return gleanTimestamp.asLong();
+    }
+    JsonNode startTime = payload.path(Attribute.PING_INFO).path(Attribute.PARSED_START_TIME);
+    JsonNode eventTime = event.path(Attribute.TIMESTAMP);
+    if (!startTime.isMissingNode() && !eventTime.isMissingNode()) {
+      long timestampMillis = timestampStringToMillis(startTime.textValue());
+      return timestampMillis + eventTime.asLong();
+    }
+    return Instant.now().toEpochMilli();
+  }
+
+  List<String[]> readAllowedEventsFromFile() throws IOException {
+    if (singletonAllowedEvents != null) {
+      return singletonAllowedEvents;
+    }
+    if (eventsAllowListPath == null) {
+      throw new IllegalArgumentException("File location must be defined");
+    }
+    synchronized (ParsePosthogEvents.class) {
+      if (singletonAllowedEvents == null) {
+        try (InputStream inputStream = BeamFileInputStream.open(eventsAllowListPath);
+            InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+            BufferedReader reader = new BufferedReader(inputStreamReader)) {
+          singletonAllowedEvents = new ArrayList<String[]>();
+          while (reader.ready()) {
+            String line = reader.readLine();
+            if (line != null && !line.isEmpty()) {
+              String[] separated = line.split(",");
+              if (separated.length != 4) {
+                throw new IllegalArgumentException(
+                    "Invalid mapping: " + line + "; four-column csv expected");
+              }
+              singletonAllowedEvents.add(separated);
+            }
+          }
+        } catch (IOException e) {
+          throw new IOException("Exception thrown while fetching " + eventsAllowListPath, e);
+        }
+      }
+    }
+    return singletonAllowedEvents;
+  }
+
+  @VisibleForTesting
+  static List<ObjectNode> extractEvents(ObjectNode payload, String namespace, String docType)
+      throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    return StreamSupport.stream(payload.path("events").spliterator(), false).map(event -> {
+      final ObjectNode result = mapper.createObjectNode();
+      final JsonNode eventCategory = event.get("category");
+      final JsonNode eventName = event.get("name");
+      String eventType = "";
+      if (eventCategory != null && !eventCategory.isNull()) {
+        eventType = eventCategory.asText();
+        if (eventName != null && !eventName.isNull()) {
+          eventType += "." + eventName.asText();
+        }
+      }
+      if (isEventAllowed(namespace, docType, eventCategory, eventName)) {
+        result.put("event_type", eventType);
+        result.put("event_extras", event.get("extra"));
+        result.put("timestamp", event.get(Attribute.TIMESTAMP));
+        return result;
+      }
+      return null;
+    }).filter(result -> result != null).collect(Collectors.toList());
+  }
+
+  static boolean isEventAllowed(String namespace, String docType, JsonNode eventCategory,
+      JsonNode eventName) {
+    return singletonAllowedEvents.stream()
+        .anyMatch(c -> c[0].equals(namespace) && c[1].equals(docType)
+            && (c[2].equals(eventCategory.asText()) || c[2].equals("*"))
+            && (c[3].equals("*") || c[3].equals(eventName.asText())));
+  }
+
+  private static Optional<JsonNode> optionalNode(JsonNode... nodes) {
+    return Stream.of(nodes).filter(n -> !n.isMissingNode()).findFirst();
+  }
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogEvent.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogEvent.java
@@ -1,0 +1,167 @@
+package com.mozilla.telemetry.posthog;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.schemas.AutoValueSchema;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.SchemaCoder;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+@AutoValue
+@DefaultSchema(AutoValueSchema.class)
+public abstract class PosthogEvent implements Serializable {
+
+  abstract String getUserId();
+
+  abstract String getEventType();
+
+  public abstract long getTime();
+
+  public abstract String getPlatform();
+
+  public abstract Integer getSampleId();
+
+  @Nullable
+  abstract String getAppVersion();
+
+  @Nullable
+  abstract String getEventExtras();
+
+  @Nullable
+  abstract String getOsName();
+
+  @Nullable
+  abstract String getOsVersion();
+
+  @Nullable
+  abstract String getCountry();
+
+  @Nullable
+  abstract String getDeviceModel();
+
+  @Nullable
+  abstract String getDeviceManufacturer();
+
+  @Nullable
+  abstract String getLanguage();
+
+  @Nullable
+  abstract Map<String, String> getExperiments();
+
+  abstract Builder toBuilder();
+
+  public static Builder builder() {
+    return new AutoValue_PosthogEvent.Builder();
+  }
+
+  /**
+   * Convert event to JSON.
+   */
+  public ObjectNode toJson() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    final ObjectNode json = objectMapper.createObjectNode();
+    json.put("event", getEventType());
+
+    final ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("distinct_id", getUserId());
+
+    // Add all other fields as properties except userId and eventType
+    if (getSampleId() != null) {
+      properties.put("sample_id", getSampleId());
+    }
+    if (getAppVersion() != null && !getAppVersion().equals("null")) {
+      properties.put("app_version", getAppVersion());
+    }
+    if (getEventExtras() != null && !getEventExtras().equals("null")) {
+      try {
+        JsonNode extras = objectMapper.readTree(getEventExtras());
+        properties.set("event_extras", extras);
+      } catch (Exception e) {
+        // ignore parse error
+      }
+    }
+    if (getOsName() != null && !getOsName().equals("null")) {
+      properties.put("os_name", getOsName());
+    }
+    if (getOsVersion() != null && !getOsVersion().equals("null")) {
+      properties.put("os_version", getOsVersion());
+    }
+    if (getCountry() != null && !getCountry().equals("null")) {
+      properties.put("country", getCountry());
+    }
+    if (getDeviceModel() != null && !getDeviceModel().equals("null")) {
+      properties.put("device_model", getDeviceModel());
+    }
+    if (getDeviceManufacturer() != null && !getDeviceManufacturer().equals("null")) {
+      properties.put("device_manufacturer", getDeviceManufacturer());
+    }
+    if (getPlatform() != null && !getPlatform().equals("null")) {
+      properties.put("platform", getPlatform());
+    }
+    if (getLanguage() != null && !getLanguage().equals("null")) {
+      properties.put("language", getLanguage());
+    }
+    if (getExperiments() != null) {
+      properties.set("experiments", objectMapper.valueToTree(getExperiments()));
+    }
+
+    json.set("properties", properties);
+
+    return json;
+  }
+
+  /**
+   * Get a Coder for a PosthogEvent.
+   */
+  public static Coder<PosthogEvent> getCoder() {
+    AutoValueSchema autoValueSchema = new AutoValueSchema();
+    TypeDescriptor<PosthogEvent> td = TypeDescriptor.of(PosthogEvent.class);
+    Schema schema = autoValueSchema.schemaFor(td);
+    if (schema != null) {
+      return SchemaCoder.of(schema, td, autoValueSchema.toRowFunction(td),
+          autoValueSchema.fromRowFunction(td));
+    }
+    return null;
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setUserId(String value);
+
+    public abstract Builder setEventType(String value);
+
+    public abstract Builder setTime(long value);
+
+    public abstract Builder setPlatform(String value);
+
+    public abstract Builder setSampleId(Integer value);
+
+    public abstract Builder setAppVersion(String value);
+
+    public abstract Builder setEventExtras(String value);
+
+    public abstract Builder setOsName(String value);
+
+    public abstract Builder setOsVersion(String value);
+
+    public abstract Builder setCountry(String value);
+
+    public abstract Builder setDeviceModel(String value);
+
+    public abstract Builder setDeviceManufacturer(String value);
+
+    public abstract Builder setLanguage(String value);
+
+    public abstract Builder setExperiments(Map<String, String> value);
+
+    public abstract PosthogEvent build();
+  }
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogPublisherOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogPublisherOptions.java
@@ -1,0 +1,77 @@
+package com.mozilla.telemetry.posthog;
+
+import com.mozilla.telemetry.options.SinkOptions;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.Hidden;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+public interface PosthogPublisherOptions extends SinkOptions, PipelineOptions {
+
+  @Description("Path (local or gs://) to CSV text file containing events that should be published to Posthog")
+  String getEventsAllowList();
+
+  void setEventsAllowList(String value);
+
+  @Description("Path (local or gs://) to a text file containing the Posthog API key")
+  String getApiKeys();
+
+  void setApiKeys(String value);
+
+  @Description("Comma-separated strings representing a list of doc types for which to send reporting requests; "
+      + "doc types are not namespace qualified (e.g. quicksuggest-click is a correct argument)")
+  String getAllowedDocTypes();
+
+  void setAllowedDocTypes(String value);
+
+  @Description("Comma-separated strings representing a list of namespaces for which to send reporting requests "
+      + "(e.g. contextual-services is a correct argument)")
+  @Default.String("contextual-services")
+  String getAllowedNamespaces();
+
+  void setAllowedNamespaces(String value);
+
+  @Description("If set to true, send HTTP requests to Posthog API. "
+      + "Can be set to false for testing purposes.")
+  @Default.Boolean(true)
+  Boolean getReportingEnabled();
+
+  void setReportingEnabled(Boolean value);
+
+  @Description("Maximum number of event batches sent to Posthog API per second.")
+  @Default.Integer(10)
+  Integer getMaxBatchesPerSecond();
+
+  void setMaxBatchesPerSecond(Integer value);
+
+  @Description("Maximum number of Posthog events in a single batch.")
+  @Default.Integer(10)
+  Integer getMaxEventBatchSize();
+
+  void setMaxEventBatchSize(Integer value);
+
+  @Description("Maximum buffering duration when batching events in seconds")
+  @Default.Integer(1)
+  Integer getMaxBufferingDuration();
+
+  void setMaxBufferingDuration(Integer value);
+
+  @Description("A sampling ratio between 0.0 and 1.0; if not set, no random sample is produced")
+  Double getRandomSampleRatio();
+
+  void setRandomSampleRatio(Double value);
+
+  @Hidden
+  interface Parsed extends PosthogPublisherOptions, SinkOptions.Parsed {
+  }
+
+  /**
+   * Parse pipeline options.
+   */
+  static PosthogPublisherOptions.Parsed parsePosthogPublisherOptions(
+      PosthogPublisherOptions options) {
+    final PosthogPublisherOptions.Parsed parsed = options.as(PosthogPublisherOptions.Parsed.class);
+    SinkOptions.enrichSinkOptions(parsed);
+    return parsed;
+  }
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/SendPosthogRequest.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/SendPosthogRequest.java
@@ -1,0 +1,154 @@
+package com.mozilla.telemetry.posthog;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.mozilla.telemetry.metrics.KeyedCounter;
+import com.mozilla.telemetry.transforms.FailureMessage;
+import com.mozilla.telemetry.util.Json;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.metrics.Distribution;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.WithFailures.ExceptionElement;
+import org.apache.beam.sdk.transforms.WithFailures.Result;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+@SuppressWarnings("checkstyle:lineLength")
+public class SendPosthogRequest extends
+    PTransform<PCollection<KV<String, Iterable<PosthogEvent>>>, Result<PCollection<KV<String, Iterable<PosthogEvent>>>, PubsubMessage>> {
+
+  private static OkHttpClient httpClient;
+  private final String posthogUrl;
+
+  private final Distribution requestTimer = Metrics.distribution(SendPosthogRequest.class,
+      "reporting_request_millis");
+  private final Map<String, String> apiKeys;
+  private final boolean reportingEnabled;
+  private final int maxBatchesPerSecond;
+
+  public static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+  private static class HttpRequestException extends IOException {
+
+    HttpRequestException(String message, int code) {
+      super("HTTP " + code + ": " + message);
+    }
+  }
+
+  private static class HttpRedirectException extends IOException {
+
+    HttpRedirectException(String url) {
+      super("Redirects not allowed: " + url);
+    }
+  }
+
+  /**
+   * Constructor without custom Posthog URL.
+   */
+  public SendPosthogRequest(Map<String, String> apiKeys, Boolean reportingEnabled,
+      Integer maxBatchesPerSecond) {
+    this(apiKeys, reportingEnabled, maxBatchesPerSecond, "https://us.i.posthog.com");
+  }
+
+  private SendPosthogRequest(Map<String, String> apiKeys, boolean reportingEnabled,
+      int maxBatchesPerSecond, String posthogUrl) {
+    this.apiKeys = apiKeys;
+    this.reportingEnabled = reportingEnabled;
+    this.maxBatchesPerSecond = maxBatchesPerSecond;
+    this.posthogUrl = posthogUrl;
+  }
+
+  public static SendPosthogRequest of(Map<String, String> apiKeys, boolean reportingEnabled,
+      int maxBatchesPerSecond) {
+    return new SendPosthogRequest(apiKeys, reportingEnabled, maxBatchesPerSecond);
+  }
+
+  public static SendPosthogRequest of(Map<String, String> apiKeys, Boolean reportingEnabled,
+      Integer maxBatchesPerSecond, String posthogUrl) {
+    return new SendPosthogRequest(apiKeys, reportingEnabled, maxBatchesPerSecond, posthogUrl);
+  }
+
+  @Override
+  public Result<PCollection<KV<String, Iterable<PosthogEvent>>>, PubsubMessage> expand(
+      PCollection<KV<String, Iterable<PosthogEvent>>> eventBatches) {
+    TypeDescriptor<KV<String, Iterable<PosthogEvent>>> td = new TypeDescriptor<KV<String, Iterable<PosthogEvent>>>() {
+    };
+    return eventBatches
+        .apply(MapElements.into(td).via((KV<String, Iterable<PosthogEvent>> eventBatch) -> {
+          getOrCreateHttpClient();
+          ObjectNode body = Json.createObjectNode();
+
+          if (apiKeys.containsKey(eventBatch.getKey())) {
+            body.put("api_key", this.apiKeys.get(eventBatch.getKey()));
+          } else {
+            throw new UncheckedIOException(
+                new IOException("No API key for " + eventBatch.getKey()));
+          }
+
+          ArrayNode jsonEvents = Json.createArrayNode();
+
+          for (PosthogEvent event : eventBatch.getValue()) {
+            jsonEvents.add(event.toJson());
+          }
+
+          body.put("batch", jsonEvents);
+
+          RequestBody requestBody = RequestBody.create(body.toString(), JSON);
+          Request request = new Request.Builder().url(posthogUrl + "/batch").post(requestBody)
+              .build();
+
+          if (reportingEnabled) {
+            sendRequest(request);
+          }
+
+          return eventBatch;
+        }).exceptionsInto(TypeDescriptor.of(PubsubMessage.class))
+            .exceptionsVia((ExceptionElement<KV<String, Iterable<PosthogEvent>>> ee) -> {
+              try {
+                throw ee.exception();
+              } catch (UncheckedIOException e) {
+                return FailureMessage.of(SendPosthogRequest.class.getSimpleName(), ee.element(),
+                    ee.exception());
+              }
+            }));
+  }
+
+  private void sendRequest(Request request) {
+    try (Response response = httpClient.newCall(request).execute()) {
+      KeyedCounter.inc("reporting_response_" + response.code());
+
+      long requestDuration = response.receivedResponseAtMillis() - response.sentRequestAtMillis();
+      requestTimer.update(requestDuration);
+
+      // TODO: first iteration of job does not retry requests on errors
+      if (response.isRedirect()) {
+        // Get url without query params
+        HttpUrl url = request.url();
+        throw new HttpRedirectException(url.host() + url.encodedPath());
+      } else if (!response.isSuccessful()) {
+        throw new HttpRequestException(response.message(), response.code());
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private OkHttpClient getOrCreateHttpClient() {
+    if (httpClient == null) {
+      httpClient = new OkHttpClient.Builder().followRedirects(false).build();
+    }
+    return httpClient;
+  }
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/PosthogPublisherTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/PosthogPublisherTest.java
@@ -1,0 +1,18 @@
+package com.mozilla.telemetry;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import org.junit.Test;
+
+public class PosthogPublisherTest {
+
+  private static final String API_KEYS = "src/test/resources/posthog/apiKeys.csv";
+
+  @Test
+  public void testReadPosthogApiKeysFromFile() {
+    Map<String, String> apiKeys = PosthogPublisher.readPosthogApiKeysFromFile(API_KEYS);
+    assertEquals("xxxx", apiKeys.get("org-mozilla-ios-firefox"));
+    assertEquals("yyyy", apiKeys.get("org-mozilla-firefox"));
+  }
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/FilterByDocTypeTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/FilterByDocTypeTest.java
@@ -1,0 +1,60 @@
+package com.mozilla.telemetry.posthog;
+
+import com.google.common.collect.ImmutableMap;
+import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class FilterByDocTypeTest {
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testMessagesFiltered() {
+    FilterByDocType.clearSingletonsForTests();
+    String allowedDocTypes = "type-a,type-b,";
+    String allowedNamespaces = "ns-1,ns-2,";
+
+    List<PubsubMessage> inputDocTypes = Stream
+        .of(List.of("type-a", "ns-1"), List.of("type-b", "ns-2"), List.of("type-b", "ns-3"),
+            List.of("type-a", "ns-1"), List.of("type-d", "ns-1"))
+        .map(tuple -> ImmutableMap.of(Attribute.DOCUMENT_TYPE, tuple.get(0),
+            Attribute.DOCUMENT_NAMESPACE, tuple.get(1)))
+        .map(attributes -> new PubsubMessage("{}".getBytes(StandardCharsets.UTF_8), attributes))
+        .collect(Collectors.toList());
+
+    PCollection<PubsubMessage> output = pipeline.apply(Create.of(inputDocTypes))
+        .apply(FilterByDocType.of(allowedDocTypes, allowedNamespaces));
+
+    PAssert.that(output).satisfies(messages -> {
+      HashMap<String, Integer> docTypeCount = new HashMap<>();
+
+      for (PubsubMessage message : messages) {
+        String docType = message.getAttribute(Attribute.DOCUMENT_TYPE);
+        int count = docTypeCount.getOrDefault(docType, 0);
+        docTypeCount.put(docType, count + 1);
+      }
+
+      Map<String, Integer> expected = ImmutableMap.of("type-a", 2, "type-b", 1);
+
+      Assert.assertEquals(expected, docTypeCount);
+
+      return null;
+    });
+
+    pipeline.run();
+  }
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/ParsePosthogEventsTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/ParsePosthogEventsTest.java
@@ -1,0 +1,315 @@
+package com.mozilla.telemetry.posthog;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import com.mozilla.telemetry.util.Json;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.WithFailures.Result;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ParsePosthogEventsTest {
+
+  private static final String EVENTS_ALLOW_LIST = "src/test/resources/posthog/eventsAllowlist.csv";
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testAllowedEventsLoadAndFilter() throws IOException {
+    pipeline.run();
+
+    ArrayList<String[]> expectedAllowedEvents = new ArrayList<>();
+    expectedAllowedEvents
+        .add(new String[] { "firefox-desktop", "events", "accessibility", "dynamic_text" });
+    expectedAllowedEvents
+        .add(new String[] { "org-mozilla-fenix", "events", "nimbus_events", "enroll_failed" });
+    expectedAllowedEvents
+        .add(new String[] { "firefox-desktop", "quick-suggest", "top_site", "contile_click" });
+    expectedAllowedEvents.add(new String[] { "firefox-desktop", "events", "bookmark", "*" });
+    expectedAllowedEvents
+        .add(new String[] { "org-mozilla-ios-firefox", "events", "bookmark", "*" });
+    ParsePosthogEvents parsePosthogEvents = ParsePosthogEvents.of(EVENTS_ALLOW_LIST);
+    List<String[]> allowedEvents = parsePosthogEvents.readAllowedEventsFromFile();
+    assert expectedAllowedEvents.size() == allowedEvents.size();
+    for (int i = 0; i < expectedAllowedEvents.size(); i++) {
+      assert Arrays.equals(expectedAllowedEvents.get(i), allowedEvents.get(i));
+    }
+  }
+
+  @Test
+  public void testExtractEvents() throws IOException {
+    final ObjectNode payload = Json.createObjectNode();
+    ObjectNode eventObject = Json.createObjectNode();
+    eventObject.put("category", "top_site");
+    eventObject.put("name", "contile_click");
+    eventObject.put("timestamp", "0");
+    payload.putArray("events").add(eventObject);
+
+    ObjectNode expectedEventObject = Json.createObjectNode();
+    expectedEventObject.put("event_type", "top_site.contile_click");
+    String nullValue = null;
+    expectedEventObject.put("event_extras", nullValue);
+    expectedEventObject.put("timestamp", "0");
+
+    List<ObjectNode> expect = new ArrayList<ObjectNode>();
+    expect.add(expectedEventObject);
+
+    ParsePosthogEvents parsePosthogEvents = ParsePosthogEvents.of(EVENTS_ALLOW_LIST);
+    parsePosthogEvents.readAllowedEventsFromFile();
+
+    List<ObjectNode> actual = parsePosthogEvents.extractEvents(payload, "firefox-desktop",
+        "quick-suggest");
+    if (!expect.equals(actual)) {
+      System.err.println(Json.asString(actual));
+      System.err.println(Json.asString(expect));
+    }
+    assert expect.equals(actual);
+  }
+
+  @Test
+  public void testParsedPosthogEvents() {
+    final Map<String, String> attributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE, "events",
+        Attribute.CLIENT_ID, "xxx", Attribute.SAMPLE_ID, "1", Attribute.DOCUMENT_NAMESPACE,
+        "firefox-desktop", Attribute.USER_AGENT_OS, "Windows", Attribute.SUBMISSION_TIMESTAMP,
+        "2022-03-15T16:42:38Z");
+
+    List<PubsubMessage> input = Stream.of("dynamic_text", "non_existing").map(eventName -> {
+      final ObjectNode payload = Json.createObjectNode();
+      payload.put(Attribute.NORMALIZED_COUNTRY_CODE, "US");
+      payload.put(Attribute.VERSION, "87.0");
+      final ArrayNode events = payload.putArray("events");
+
+      ObjectNode eventObject = Json.createObjectNode();
+      eventObject.put("category", "accessibility");
+      eventObject.put("name", eventName);
+      eventObject.put(Attribute.TIMESTAMP, "0");
+
+      ObjectNode eventExtra = Json.createObjectNode();
+      eventExtra.put(Attribute.GLEAN_TIMESTAMP, "1738782714952");
+      eventObject.put("extra", eventExtra);
+      events.add(eventObject);
+
+      return payload;
+    }).map(payload -> new PubsubMessage(Json.asBytes(payload), attributes))
+        .collect(Collectors.toList());
+
+    Result<PCollection<PosthogEvent>, PubsubMessage> result = pipeline //
+        .apply(Create.of(input)) //
+        .apply(ParsePosthogEvents.of(EVENTS_ALLOW_LIST));
+
+    PAssert.that(result.output()).satisfies(posthogEvents -> {
+      List<PosthogEvent> payloads = new ArrayList<>();
+      posthogEvents.forEach(payloads::add);
+
+      Assert.assertEquals("1 events in output", 1, payloads.size());
+
+      Assert.assertTrue("posthog event type is accessibility.dynamic_text",
+          payloads.get(0).getEventType().equals("accessibility.dynamic_text"));
+      Assert.assertTrue("posthog event user ID is xxx", payloads.get(0).getUserId().equals("xxx"));
+      Assert.assertTrue("posthog event sample ID is 1", payloads.get(0).getSampleId() == 1);
+      Assert.assertTrue("posthog event app version is null",
+          payloads.get(0).getAppVersion() == null);
+      Assert.assertTrue("posthog event timestamp is ", payloads.get(0).getTime() == 1738782714952L);
+
+      return null;
+    });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testParsedPosthogEventsEventTimestamps() {
+    final Map<String, String> attributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE, "events",
+        Attribute.CLIENT_ID, "xxx", Attribute.SAMPLE_ID, "1", Attribute.DOCUMENT_NAMESPACE,
+        "firefox-desktop", Attribute.USER_AGENT_OS, "Windows", Attribute.SUBMISSION_TIMESTAMP,
+        "2022-03-15T16:42:38Z");
+
+    final ObjectNode payload1 = Json.createObjectNode();
+    payload1.put(Attribute.NORMALIZED_COUNTRY_CODE, "US");
+    payload1.put(Attribute.VERSION, "87.0");
+
+    ObjectNode pingInfo = Json.createObjectNode();
+    pingInfo.put(Attribute.PARSED_START_TIME, "2022-03-15T16:42:38Z");
+
+    ObjectNode experiments = Json.createObjectNode();
+    ObjectNode experiment1 = Json.createObjectNode();
+    experiment1.put("branch", "b1");
+    experiments.put("experiment1", experiment1);
+    pingInfo.put(Attribute.EXPERIMENTS, experiments);
+    payload1.put(Attribute.PING_INFO, pingInfo);
+    final ArrayNode events1 = payload1.putArray("events");
+
+    String nullValue = null;
+    ObjectNode bookmarkEventObject = Json.createObjectNode();
+    bookmarkEventObject.put("category", "bookmark");
+    bookmarkEventObject.put("name", nullValue);
+    bookmarkEventObject.put(Attribute.TIMESTAMP, "10");
+
+    ObjectNode bookmarkAddEventObject = Json.createObjectNode();
+    bookmarkAddEventObject.put("category", "bookmark");
+    bookmarkAddEventObject.put("name", "add");
+    bookmarkAddEventObject.put(Attribute.TIMESTAMP, "10");
+
+    events1.add(bookmarkEventObject);
+    events1.add(bookmarkAddEventObject);
+
+    final ObjectNode payload2 = Json.createObjectNode();
+    payload2.put(Attribute.NORMALIZED_COUNTRY_CODE, "US");
+    payload2.put(Attribute.VERSION, "87.0");
+
+    final ArrayNode events2 = payload2.putArray("events");
+
+    ObjectNode bookmarkTestEventObject = Json.createObjectNode();
+    bookmarkTestEventObject.put("category", "bookmark");
+    bookmarkTestEventObject.put("name", "test");
+    bookmarkTestEventObject.put(Attribute.TIMESTAMP, "10");
+
+    // gets filtered due to non-matching category
+    ObjectNode testFooEventObject = Json.createObjectNode();
+    testFooEventObject.put("category", "test");
+    testFooEventObject.put("name", "foo");
+    testFooEventObject.put(Attribute.TIMESTAMP, "1");
+
+    events2.add(bookmarkTestEventObject);
+    events2.add(testFooEventObject);
+
+    // gets filtered due to non-matching doctype and namespace
+    final Map<String, String> incorrectAttributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE, "test",
+        Attribute.CLIENT_ID, "xxx", Attribute.SAMPLE_ID, "1", Attribute.DOCUMENT_NAMESPACE, "test",
+        Attribute.USER_AGENT_OS, "Windows", Attribute.SUBMISSION_TIMESTAMP, "2022-03-15T16:42:38Z");
+
+    final ObjectNode payload3 = Json.createObjectNode();
+    final ArrayNode events3 = payload3.putArray("events");
+
+    ObjectNode bookmarkXxxxEventObject = Json.createObjectNode();
+    bookmarkXxxxEventObject.put("category", "bookmark");
+    bookmarkXxxxEventObject.put("name", "xxxxx");
+    bookmarkXxxxEventObject.put(Attribute.TIMESTAMP, "0");
+
+    events3.add(bookmarkXxxxEventObject);
+
+    List<PubsubMessage> input = ImmutableList.of(
+        new PubsubMessage(Json.asBytes(payload1), attributes),
+        new PubsubMessage(Json.asBytes(payload2), attributes),
+        new PubsubMessage(Json.asBytes(payload3), incorrectAttributes));
+
+    Result<PCollection<PosthogEvent>, PubsubMessage> result = pipeline //
+        .apply(Create.of(input)) //
+        .apply(ParsePosthogEvents.of(EVENTS_ALLOW_LIST));
+
+    PAssert.that(result.output()).satisfies(posthogEvents -> {
+      List<PosthogEvent> payloads = new ArrayList<>();
+      posthogEvents.forEach(payloads::add);
+
+      Assert.assertEquals("3 events in output", 3, payloads.size());
+
+      for (PosthogEvent event : posthogEvents) {
+        if (event.getEventType().equals("bookmark.add")) {
+          Assert.assertTrue("posthog event timestamp is 1647362558010l",
+              event.getTime() == 1647362558010L);
+        } else if (event.getEventType().equals("bookmark")) {
+          Assert.assertTrue("posthog event timestamp is 1647362558010l",
+              event.getTime() == 1647362558010L);
+        } else if (event.getEventType().equals("bookmark.test")) {
+          Assert.assertTrue("posthog event timestamp is larger 0", payloads.get(2).getTime() > 0);
+        } else {
+          System.err.println(event.getEventType());
+          Assert.assertTrue("posthog event with unknown type", false);
+        }
+      }
+
+      return null;
+    });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testParsedPosthogEventsWithMissingClientId() {
+    final Map<String, String> attributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE, "events",
+        Attribute.DOCUMENT_NAMESPACE, "firefox-desktop", Attribute.USER_AGENT_OS, "Windows",
+        Attribute.SUBMISSION_TIMESTAMP, "2022-03-15T16:42:38Z", Attribute.SAMPLE_ID, "1");
+
+    final ObjectNode payload = Json.createObjectNode();
+    payload.put(Attribute.NORMALIZED_COUNTRY_CODE, "US");
+    payload.put(Attribute.VERSION, "87.0");
+    final ArrayNode events = payload.putArray("events");
+
+    ObjectNode eventObject = Json.createObjectNode();
+    eventObject.put("category", "accessibility");
+    eventObject.put("name", "test");
+    eventObject.put(Attribute.TIMESTAMP, "0");
+
+    ObjectNode eventExtra = Json.createObjectNode();
+    eventExtra.put(Attribute.GLEAN_TIMESTAMP, "1738782714952");
+    eventObject.put("extra", eventExtra);
+    events.add(eventObject);
+
+    List<PubsubMessage> input = ImmutableList
+        .of(new PubsubMessage(Json.asBytes(payload), attributes));
+
+    Result<PCollection<PosthogEvent>, PubsubMessage> result = pipeline //
+        .apply(Create.of(input)) //
+        .apply(ParsePosthogEvents.of(EVENTS_ALLOW_LIST));
+
+    PAssert.that(result.failures()).satisfies(messages -> {
+      Assert.assertEquals(1, Iterators.size(messages.iterator()));
+      return null;
+    });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testParsedPosthogEventsMetricsPing() {
+    final Map<String, String> attributes = ImmutableMap.of(Attribute.DOCUMENT_TYPE, "metrics",
+        Attribute.DOCUMENT_NAMESPACE, "firefox-desktop", Attribute.USER_AGENT_OS, "Windows",
+        Attribute.SUBMISSION_TIMESTAMP, "2022-03-15T16:42:38Z", Attribute.CLIENT_ID, "xxx",
+        Attribute.SAMPLE_ID, "1");
+
+    final ObjectNode payload = Json.createObjectNode();
+    payload.put(Attribute.NORMALIZED_COUNTRY_CODE, "US");
+    payload.put(Attribute.VERSION, "87.0");
+
+    List<PubsubMessage> input = ImmutableList
+        .of(new PubsubMessage(Json.asBytes(payload), attributes));
+
+    Result<PCollection<PosthogEvent>, PubsubMessage> result = pipeline //
+        .apply(Create.of(input)) //
+        .apply(ParsePosthogEvents.of(EVENTS_ALLOW_LIST));
+
+    PAssert.that(result.output()).satisfies(posthogEvents -> {
+      List<PosthogEvent> payloads = new ArrayList<>();
+      posthogEvents.forEach(payloads::add);
+
+      Assert.assertEquals("1 event in output", 1, payloads.size());
+
+      Assert.assertTrue("event type is user_activity",
+          payloads.get(0).getEventType().equals("user_activity"));
+      Assert.assertTrue("posthog event user ID is xxx", payloads.get(0).getUserId().equals("xxx"));
+      Assert.assertTrue("posthog event app version is null",
+          payloads.get(0).getAppVersion() == null);
+
+      return null;
+    });
+
+    pipeline.run();
+  }
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/PosthogEventTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/PosthogEventTest.java
@@ -1,0 +1,50 @@
+package com.mozilla.telemetry.posthog;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PosthogEventTest {
+
+  @Test
+  public void testToJson() throws JsonProcessingException {
+    PosthogEvent event = PosthogEvent.builder().setUserId("test").setSampleId(1)
+        .setEventType("bookmark.event").setPlatform("firefox-desktop").setLanguage("en")
+        .setTime(1738620582500L).build();
+
+    Map<String, String> experiments = new HashMap<>();
+    experiments.put("experiment1", null);
+    experiments.put("experiment2", "branch_b");
+    PosthogEvent eventWithExtras = PosthogEvent.builder().setUserId("test").setSampleId(1)
+        .setEventType("bookmark.event").setPlatform("firefox-desktop").setTime(1738620582500L)
+        .setEventExtras("{\"metadata1\":\"extra\",\"metadata2\":\"more_extra\"}")
+        .setExperiments(experiments).build();
+
+    String expectedJsonEvent = "{" + "\"event\":\"bookmark.event\","
+        + "\"properties\":{\"distinct_id\":\"test\",\"sample_id\":1,"
+        + "\"platform\":\"firefox-desktop\",\"language\":\"en\"}}";
+    String expectedJsonEventWithExtras = "{" + "\"event\":\"bookmark.event\","
+        + "\"properties\":{\"distinct_id\":\"test\",\"sample_id\":1,"
+        + "\"event_extras\":{\"metadata1\":\"extra\",\"metadata2\":\"more_extra\"},"
+        + "\"platform\":\"firefox-desktop\","
+        + "\"experiments\":{\"experiment2\":\"branch_b\",\"experiment1\":null}}}";
+
+    Assert.assertEquals(expectedJsonEvent, event.toJson().toString());
+    Assert.assertEquals(expectedJsonEventWithExtras, eventWithExtras.toJson().toString());
+  }
+
+  @Test
+  public void testToJsonWithNull() throws JsonProcessingException {
+    PosthogEvent eventWithNullExtras = PosthogEvent.builder().setUserId("test").setSampleId(1)
+        .setEventType("bookmark.event").setPlatform("firefox-desktop").setTime(1738620582500L)
+        .setEventExtras("null").build();
+
+    String expectedJsonEvent = "{" + "\"event\":\"bookmark.event\","
+        + "\"properties\":{\"distinct_id\":\"test\",\"sample_id\":1,"
+        + "\"platform\":\"firefox-desktop\"}}";
+
+    Assert.assertEquals(expectedJsonEvent, eventWithNullExtras.toJson().toString());
+  }
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/SendPosthogRequestTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/SendPosthogRequestTest.java
@@ -1,0 +1,156 @@
+package com.mozilla.telemetry.posthog;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.WithFailures;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SendPosthogRequestTest {
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
+  private PosthogEvent.Builder getTestPosthogEvent() {
+    return PosthogEvent.builder().setUserId("test123").setSampleId(1).setEventType("category.event")
+        .setPlatform("firefox-desktop").setTime(1738620582500L);
+  }
+
+  private PosthogEvent.Builder getTestPosthogEventWithExtras() {
+    return PosthogEvent.builder().setUserId("test123").setSampleId(1).setEventType("category.event")
+        .setPlatform("firefox-desktop").setTime(1738620582500L)
+        .setEventExtras("{\"test\": 12, \"foo\": true}");
+  }
+
+  private Map<String, String> getApiKeys() {
+    Map<String, String> apiKeys = new HashMap<>();
+    apiKeys.put("firefox-desktop", "test");
+    return apiKeys;
+  }
+
+  @Test
+  public void testReportingDisabled() {
+    MockWebServer server = new MockWebServer();
+
+    PosthogEvent event = getTestPosthogEvent().build();
+    List<KV<String, Iterable<PosthogEvent>>> input = ImmutableList
+        .of(KV.of("firefox-desktop", ImmutableList.of(event)));
+
+    pipeline.apply(Create.of(input)).apply(SendPosthogRequest.of(getApiKeys(), false, 10));
+
+    pipeline.run();
+
+    Assert.assertEquals(0, server.getRequestCount());
+  }
+
+  @Test
+  public void testRequestExceptionOnError() {
+    MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse().setResponseCode(401));
+
+    PosthogEvent event = getTestPosthogEvent().build();
+
+    List<KV<String, Iterable<PosthogEvent>>> input = ImmutableList.of(
+        KV.of("firefox-desktop", ImmutableList.of(event)),
+        KV.of("firefox-desktop", ImmutableList.of(event)));
+
+    WithFailures.Result<PCollection<KV<String, Iterable<PosthogEvent>>>, PubsubMessage> result = pipeline
+        .apply(Create.of(input))
+        .apply(SendPosthogRequest.of(getApiKeys(), true, 10, server.url("/batch").toString()));
+
+    PAssert.that(result.failures()).satisfies(messages -> {
+      Assert.assertEquals(2, Iterables.size(messages));
+      return null;
+    });
+
+    pipeline.run();
+    Assert.assertEquals(2, server.getRequestCount());
+  }
+
+  @Test
+  public void testSuccessfulSend() throws JsonProcessingException {
+    MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setResponseCode(200));
+    server.enqueue(new MockResponse().setResponseCode(204));
+
+    PosthogEvent event = getTestPosthogEventWithExtras().build();
+
+    List<KV<String, Iterable<PosthogEvent>>> input = ImmutableList.of(
+        KV.of("firefox-desktop", ImmutableList.of(event)),
+        KV.of("firefox-desktop", ImmutableList.of(event)));
+
+    WithFailures.Result<PCollection<KV<String, Iterable<PosthogEvent>>>, PubsubMessage> result = pipeline
+        .apply(Create.of(input))
+        .apply(SendPosthogRequest.of(getApiKeys(), true, 1, server.url("/batch").toString()));
+
+    PAssert.that(result.output()).satisfies(messages -> {
+      Assert.assertEquals(2, Iterables.size(messages));
+      return null;
+    });
+
+    pipeline.run();
+    Assert.assertEquals(2, server.getRequestCount());
+  }
+
+  @Test
+  public void testSuccessfulBatchSend() throws JsonProcessingException {
+    MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setResponseCode(200));
+    server.enqueue(new MockResponse().setResponseCode(204));
+
+    PosthogEvent event = getTestPosthogEventWithExtras().build();
+
+    List<KV<String, Iterable<PosthogEvent>>> input = ImmutableList.of(
+        KV.of("firefox-desktop", ImmutableList.of(event, event)),
+        KV.of("firefox-desktop", ImmutableList.of(event, event)));
+
+    WithFailures.Result<PCollection<KV<String, Iterable<PosthogEvent>>>, PubsubMessage> result = pipeline
+        .apply(Create.of(input))
+        .apply(SendPosthogRequest.of(getApiKeys(), true, 2, server.url("/batch").toString()));
+
+    PAssert.that(result.output()).satisfies(messages -> {
+      Assert.assertEquals(2, Iterables.size(messages));
+      return null;
+    });
+
+    pipeline.run();
+    Assert.assertEquals(2, server.getRequestCount());
+  }
+
+  @Test
+  public void testRedirectError() {
+    MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setResponseCode(302));
+
+    PosthogEvent event = getTestPosthogEventWithExtras().build();
+
+    List<KV<String, Iterable<PosthogEvent>>> input = ImmutableList
+        .of(KV.of("firefox-desktop", ImmutableList.of(event)));
+
+    WithFailures.Result<PCollection<KV<String, Iterable<PosthogEvent>>>, PubsubMessage> result = pipeline
+        .apply(Create.of(input))
+        .apply(SendPosthogRequest.of(getApiKeys(), true, 1, server.url("/batch").toString()));
+
+    PAssert.that(result.failures()).satisfies(messages -> {
+      Assert.assertEquals(1, Iterables.size(messages));
+      return null;
+    });
+
+    pipeline.run();
+    Assert.assertEquals(1, server.getRequestCount());
+  }
+}

--- a/ingestion-beam/src/test/resources/posthog/apiKeys.csv
+++ b/ingestion-beam/src/test/resources/posthog/apiKeys.csv
@@ -1,0 +1,2 @@
+org-mozilla-ios-firefox,xxxx
+org-mozilla-firefox,yyyy

--- a/ingestion-beam/src/test/resources/posthog/eventsAllowlist.csv
+++ b/ingestion-beam/src/test/resources/posthog/eventsAllowlist.csv
@@ -1,0 +1,5 @@
+firefox-desktop,events,accessibility,dynamic_text
+org-mozilla-fenix,events,nimbus_events,enroll_failed
+firefox-desktop,quick-suggest,top_site,contile_click
+firefox-desktop,events,bookmark,*
+org-mozilla-ios-firefox,events,bookmark,*


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DENG-8592

Depends on https://github.com/mozilla/gcp-ingestion/pull/2804

This adds a POC pipeline for sending events to a Posthog test instance. This pipeline will run for about 2-3 weeks. Most of the logic is derived from the previous [Amplitude POC pipeline
](https://github.com/mozilla/gcp-ingestion/pull/2729).

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy)
for details.
