### PR TITLE
DENG-4080 - Update Edge base image debian version

### DIFF
--- a/ingestion-edge/Dockerfile
+++ b/ingestion-edge/Dockerfile
@@ -1,11 +1,11 @@
 ARG PYTHON_VERSION=3.10
 
 # build requirements in separate stage because it requires gcc and libc-dev
-FROM python:${PYTHON_VERSION}-slim-buster AS base
+FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 WORKDIR /app
 
 FROM base AS build
-RUN apt-get update && apt-get install -qqy gcc libc-dev
+RUN apt-get update && apt-get install -qqy gcc libc-dev wrk
 COPY requirements.txt /app/
 COPY bin/include/common.sh /app/bin/include/
 COPY bin/build /app/bin/
@@ -13,9 +13,6 @@ ENV VENV=false
 RUN bin/build
 
 FROM base
-RUN echo 'deb http://archive.debian.org/debian buster-backports main' >> /etc/apt/sources.list && \
-  apt-get update && \
-  apt-get install -qqy --target-release buster-backports wrk
 COPY --from=build /usr/local /usr/local
 COPY . /app
 ENV HOST=0.0.0.0 PORT=8000


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DENG-4080

Tested locally with:
```
docker-compose -f docker-compose.yml -f docker-compose.circleci.yml --project-name circleci-ingestion-edge run --rm test bin/pytest tests/integration
```
@whd can we deploy Edge after merging this to keep stage/prod in sync with the main branch?

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy)
for details.
