### PR TITLE
[DENG-8592] Improve SendPosthogRequest throughput by sharding keys and adding reshuffle

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogEvent.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogEvent.java
@@ -18,7 +18,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 @DefaultSchema(AutoValueSchema.class)
 public abstract class PosthogEvent implements Serializable {
 
-  abstract String getUserId();
+  public abstract String getUserId();
 
   abstract String getEventType();
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/SendPosthogRequest.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/SendPosthogRequest.java
@@ -90,11 +90,13 @@ public class SendPosthogRequest extends
           getOrCreateHttpClient();
           ObjectNode body = Json.createObjectNode();
 
-          if (apiKeys.containsKey(eventBatch.getKey())) {
-            body.put("api_key", this.apiKeys.get(eventBatch.getKey()));
+          String shardedKey = eventBatch.getKey();
+          String platform = shardedKey.split("::")[0];
+
+          if (apiKeys.containsKey(platform)) {
+            body.put("api_key", this.apiKeys.get(platform));
           } else {
-            throw new UncheckedIOException(
-                new IOException("No API key for " + eventBatch.getKey()));
+            throw new UncheckedIOException(new IOException("No API key for " + platform));
           }
 
           ArrayNode jsonEvents = Json.createArrayNode();


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-8592

The pipeline got deployed, but I noticed that `SendPosthogRequest` was running very slowly in streaming mode, with low throughput and increasing watermark lag.

This PR shards keys by platform + shardId to allow batching to run in parallel, and adds a Reshuffle.viaRandomKey() to break fusion so the send step can scale independently. I tested this on a larger dataset (1.3mil events) in my sandbox and the SendPosthogRequest step was much faster.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy)
for details.
