### PR TITLE
[DENG-8592] Flatten event extras when sending events to Posthog

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogEvent.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogEvent.java
@@ -82,23 +82,17 @@ public abstract class PosthogEvent implements Serializable {
     if (getEventExtras() != null && !getEventExtras().equals("null")) {
       try {
         JsonNode extras = objectMapper.readTree(getEventExtras());
-        if (extras.isObject()) {
-          extras.fields().forEachRemaining(entry -> {
-            String key = "event_extras_" + entry.getKey();
-            JsonNode value = entry.getValue();
-            if (value.isNull()) {
-              properties.putNull(key);
-            } else if (value.isTextual()) {
-              properties.put(key, value.asText());
-            } else if (value.isNumber()) {
-              properties.put(key, value.numberValue().toString());
-            } else {
-              properties.set(key, value);
-            }
-          });
-        }
+        extras.fields().forEachRemaining(entry -> {
+          String key = "event_extras_" + entry.getKey();
+          JsonNode value = entry.getValue();
+          if (value.isNull()) {
+            properties.putNull(key);
+          } else {
+            properties.put(key, value.asText());
+          }
+        });
       } catch (Exception e) {
-        // ignore parse error
+        System.err.println("Error parsing event extras: " + e.getMessage());
       }
     }
     if (getOsName() != null && !getOsName().equals("null")) {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/PosthogEventTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/PosthogEventTest.java
@@ -20,8 +20,9 @@ public class PosthogEventTest {
     PosthogEvent eventWithExtras = PosthogEvent.builder().setUserId("test").setSampleId(1)
         .setEventType("bookmark.event").setPlatform("firefox-desktop").setTime(1738620582500L)
         .setEventExtras("{" + "\"metadata1\":\"extra\"," + "\"metadata2\":\"more_extra\","
-            + "\"intVal\":42," + "\"floatVal\":3.14," + "\"boolVal\":true," + "\"nullVal\":null,"
-            + "\"nested\":{\"subkey\":\"subval\",\"subnum\":7}" + "}")
+            + "\"intVal\":\"42\"," + "\"floatVal\":\"3.14\"," + "\"boolVal\":\"true\","
+            + "\"nullVal\":null,"
+            + "\"nested\":\"{\\\"subkey\\\":\\\"subval\\\",\\\"subnum\\\":7}\"" + "}")
         .setExperiments(experiments).build();
 
     String expectedJsonEvent = "{" + "\"event\":\"bookmark.event\","
@@ -31,12 +32,14 @@ public class PosthogEventTest {
         + "\"properties\":{\"distinct_id\":\"test\",\"sample_id\":1,"
         + "\"event_extras_metadata1\":\"extra\"," + "\"event_extras_metadata2\":\"more_extra\","
         + "\"event_extras_intVal\":\"42\"," + "\"event_extras_floatVal\":\"3.14\","
-        + "\"event_extras_boolVal\":true," + "\"event_extras_nullVal\":null,"
-        + "\"event_extras_nested\":{\"subkey\":\"subval\",\"subnum\":7},"
+        + "\"event_extras_boolVal\":\"true\"," + "\"event_extras_nullVal\":null,"
+        + "\"event_extras_nested\":\"{\\\"subkey\\\":\\\"subval\\\",\\\"subnum\\\":7}\","
         + "\"platform\":\"firefox-desktop\","
         + "\"experiments\":{\"experiment2\":\"branch_b\",\"experiment1\":null}}}";
 
     Assert.assertEquals(expectedJsonEvent, event.toJson().toString());
+    System.out.println(eventWithExtras.toJson().toString());
+    System.out.println(expectedJsonEventWithExtras);
     Assert.assertEquals(expectedJsonEventWithExtras, eventWithExtras.toJson().toString());
   }
 

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/PosthogEventTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/PosthogEventTest.java
@@ -19,7 +19,9 @@ public class PosthogEventTest {
     experiments.put("experiment2", "branch_b");
     PosthogEvent eventWithExtras = PosthogEvent.builder().setUserId("test").setSampleId(1)
         .setEventType("bookmark.event").setPlatform("firefox-desktop").setTime(1738620582500L)
-        .setEventExtras("{\"metadata1\":\"extra\",\"metadata2\":\"more_extra\"}")
+        .setEventExtras("{" + "\"metadata1\":\"extra\"," + "\"metadata2\":\"more_extra\","
+            + "\"intVal\":42," + "\"floatVal\":3.14," + "\"boolVal\":true," + "\"nullVal\":null,"
+            + "\"nested\":{\"subkey\":\"subval\",\"subnum\":7}" + "}")
         .setExperiments(experiments).build();
 
     String expectedJsonEvent = "{" + "\"event\":\"bookmark.event\","
@@ -27,7 +29,10 @@ public class PosthogEventTest {
         + "\"platform\":\"firefox-desktop\",\"language\":\"en\"}}";
     String expectedJsonEventWithExtras = "{" + "\"event\":\"bookmark.event\","
         + "\"properties\":{\"distinct_id\":\"test\",\"sample_id\":1,"
-        + "\"event_extras\":{\"metadata1\":\"extra\",\"metadata2\":\"more_extra\"},"
+        + "\"event_extras_metadata1\":\"extra\"," + "\"event_extras_metadata2\":\"more_extra\","
+        + "\"event_extras_intVal\":\"42\"," + "\"event_extras_floatVal\":\"3.14\","
+        + "\"event_extras_boolVal\":true," + "\"event_extras_nullVal\":null,"
+        + "\"event_extras_nested\":{\"subkey\":\"subval\",\"subnum\":7},"
         + "\"platform\":\"firefox-desktop\","
         + "\"experiments\":{\"experiment2\":\"branch_b\",\"experiment1\":null}}}";
 


### PR DESCRIPTION
## Description
https://mozilla-hub.atlassian.net/browse/DENG-8592

Based on https://mozilla-hub.atlassian.net/browse/DENG-8592?focusedCommentId=1102624 it is desired to flatten out `event_extras` (only top-level) when sending them to Posthog as it makes working with event extras easier

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy)
for details.
