### PR TITLE
[DENG-8592] Flatten experiment properties when sending events to Posthog

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogEvent.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/posthog/PosthogEvent.java
@@ -117,7 +117,15 @@ public abstract class PosthogEvent implements Serializable {
       properties.put("language", getLanguage());
     }
     if (getExperiments() != null) {
-      properties.set("experiments", objectMapper.valueToTree(getExperiments()));
+      for (Map.Entry<String, String> entry : getExperiments().entrySet()) {
+        String key = "experiments_" + entry.getKey();
+        String value = entry.getValue();
+        if (value == null) {
+          properties.putNull(key);
+        } else {
+          properties.put(key, value);
+        }
+      }
     }
 
     json.set("properties", properties);

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/PosthogEventTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/posthog/PosthogEventTest.java
@@ -35,11 +35,9 @@ public class PosthogEventTest {
         + "\"event_extras_boolVal\":\"true\"," + "\"event_extras_nullVal\":null,"
         + "\"event_extras_nested\":\"{\\\"subkey\\\":\\\"subval\\\",\\\"subnum\\\":7}\","
         + "\"platform\":\"firefox-desktop\","
-        + "\"experiments\":{\"experiment2\":\"branch_b\",\"experiment1\":null}}}";
+        + "\"experiments_experiment2\":\"branch_b\",\"experiments_experiment1\":null}}";
 
     Assert.assertEquals(expectedJsonEvent, event.toJson().toString());
-    System.out.println(eventWithExtras.toJson().toString());
-    System.out.println(expectedJsonEventWithExtras);
     Assert.assertEquals(expectedJsonEventWithExtras, eventWithExtras.toJson().toString());
   }
 


### PR DESCRIPTION
## Description

Follow-up to https://mozilla-hub.atlassian.net/browse/DENG-8592

There is a desire to also flatten experiment properties when sending events to Posthog to make it easier to filter on them. Experiment slugs/keys are being prefixed with `experiments_`. The value is the experiment branch.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy)
for details.
