### PR TITLE
fix(ci): Fix test coverage reporting job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,10 @@ jobs:
       run:
         name: Report code coverage
         command: |
+          # Install gpgv if not available (Debian Trixie moved it to separate package)
+          if ! command -v gpgv >/dev/null 2>&1; then
+            apt-get update && apt-get install -y gpgv
+          fi
           curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM


### PR DESCRIPTION
## Description

`ingestion-edge` CI job recently started [failing](https://app.circleci.com/pipelines/github/mozilla/gcp-ingestion/7521/workflows/bcd6c1dc-5927-454c-9b02-f0d81650279d/jobs/86079/parallel-runs/0/steps/0-107) on `main` after `python:3.10` Docker image [migrated to Debian Trixie](https://github.com/docker-library/python/commit/093598a0190ba9074b899d6a0a21a00c859aac56#diff-cac65b631a94b37177dc499f055eaceeed7f0c13867d5105c3367be464c7c5e8) which uses slimmed down `gpg` package. We now need to install `gpgv`.


## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy)
for details.
