### PR TITLE
Bug 1987968 - Mark com-dykt-main and com-agci-acebrowser as unwanted namespaces

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -140,6 +140,8 @@ public class MessageScrubber {
       .put("org-hexis-firefox", "1978366") //
       .put("org-global-glaxy", "1981558") //
       .put("org-mozilla-zxff", "1981560") //
+      .put("com-dykt-main", "1987968") //
+      .put("com-agci-acebrowser", "1987968") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap


### PR DESCRIPTION
## Description

**_Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]._**

## Related Tickets & Documents

- https://bugzilla.mozilla.org/show_bug.cgi?id=1987968

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy)
for details.
