### PR TITLE
DENG-9752 - Add counter to measure source zone for log entries

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseLogEntry.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseLogEntry.java
@@ -3,6 +3,7 @@ package com.mozilla.telemetry.decoder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import com.mozilla.telemetry.metrics.KeyedCounter;
 import com.mozilla.telemetry.transforms.FailureMessage;
 import com.mozilla.telemetry.util.Json;
 import java.io.IOException;
@@ -60,7 +61,6 @@ public class ParseLogEntry extends
       countLogEntryPayload.inc();
 
       ObjectNode logEntry;
-      Map<String, String> attributes = new HashMap<String, String>(m.getAttributeMap());
       try {
         logEntry = Json.readObjectNode(m.getPayload());
       } catch (IOException e) {
@@ -77,6 +77,7 @@ public class ParseLogEntry extends
       String documentVersion = fields.path("document_version").textValue();
       String payload = fields.path("payload").textValue();
       String receiveTimestamp = logEntry.path("receiveTimestamp").textValue();
+      String zone = logEntry.path("resource").path("labels").path("location").textValue();
 
       boolean isValidLogEntry = documentId != null && documentNamespace != null
           && documentType != null && documentVersion != null && payload != null
@@ -86,6 +87,12 @@ public class ParseLogEntry extends
             "Message has no submission_timestamp but is not in a known LogEntry format");
       }
 
+    // Measure zone/namespace combinations for routed logs. See https://mozilla-hub.atlassian.net/browse/SVCSE-3450
+      if (zone != null && documentNamespace != null) {
+        KeyedCounter.inc("log_entry_zone/" + zone + "/" + documentNamespace);
+      }
+
+      Map<String, String> attributes = new HashMap<String, String>(m.getAttributeMap());
       attributes.put(Attribute.DOCUMENT_ID, documentId);
       attributes.put(Attribute.SUBMISSION_TIMESTAMP, receiveTimestamp);
       attributes.put(Attribute.DOCUMENT_NAMESPACE, documentNamespace);

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseLogEntry.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseLogEntry.java
@@ -87,7 +87,8 @@ public class ParseLogEntry extends
             "Message has no submission_timestamp but is not in a known LogEntry format");
       }
 
-    // Measure zone/namespace combinations for routed logs. See https://mozilla-hub.atlassian.net/browse/SVCSE-3450
+      // Measure zone/namespace combinations for routed logs. See
+      // https://mozilla-hub.atlassian.net/browse/SVCSE-3450
       if (zone != null && documentNamespace != null) {
         KeyedCounter.inc("log_entry_zone/" + zone + "/" + documentNamespace);
       }


### PR DESCRIPTION
## Description

This adds a metric to easily track how many log entries are we getting from each region.

## Related Tickets & Documents

- https://mozilla-hub.atlassian.net/browse/DENG-9752
- https://mozilla-hub.atlassian.net/browse/SVCSE-3450


## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy)
for details.
