### PR TITLE
Bug 1990965: Add stub URI parameter for 'launched_by' field

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/ParseUri.java
@@ -248,7 +248,7 @@ public class ParseUri {
         .compile(String.format("^v(?<%s>[6-9]|1[0-9])(-(?<%s>\\d+))?$", VERSION, FUNNELCAKE));
 
     public static final Map<String, Integer> SUFFIX_LENGTH = ImmutableMap.of("6", 36, "7", 37, "8",
-        39, "9", 41, "10", 43);
+        39, "9", 41, "10", 43, "11", 44);
 
     /**
      * NOTE: When adding new fields here, the version must be incremented on the client.
@@ -302,7 +302,8 @@ public class ParseUri {
         putString("download_ip"), putString("attribution"),
         putIntegerAsString("profile_cleanup_prompt"), putBool("profile_cleanup_requested"),
         putString("distribution_id"), putString("distribution_version"), //
-        putInteger("windows_ubr"), putString("stub_build_id"));
+        putInteger("windows_ubr"), putString("stub_build_id"), //
+        putString("launched_by"));
 
     private static BiConsumer<String, ObjectNode> ignore() {
       return (value, payload) -> {

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/ParseUriTest.java
@@ -312,6 +312,10 @@ public class ParseUriTest extends TestWithDeterministicJson {
           validIntCases("windows_ubr"), //
           validStringCases("stub_build_id")));
 
+  private static final Map<String, String> VALID_V11_DIMENSIONS = joinCases(
+      Arrays.asList(VALID_V10_DIMENSIONS, //
+          validStringCases("launched_by")));
+
   private static final Map<String, String> VALID_V6_CASES = joinCases(Arrays.asList(//
       ImmutableMap.of("v6", "\"ping_version\":\"v6\"", //
           "v6-1", "\"ping_version\":\"v6-1\",\"funnelcake\":\"1\""), //
@@ -337,6 +341,11 @@ public class ParseUriTest extends TestWithDeterministicJson {
           "v10-3", "\"ping_version\":\"v10-3\",\"funnelcake\":\"3\""), //
       VALID_V10_DIMENSIONS));
 
+  private static final Map<String, String> VALID_V11_CASES = joinCases(Arrays.asList(//
+      ImmutableMap.of("v11", "\"ping_version\":\"v11\"", //
+          "v11-3", "\"ping_version\":\"v11-3\",\"funnelcake\":\"3\""), //
+      VALID_V11_DIMENSIONS));
+
   @Test
   public void testStubUri() {
     final List<String> input = Streams.stream(Iterables.concat(//
@@ -345,12 +354,14 @@ public class ParseUriTest extends TestWithDeterministicJson {
         VALID_V8_CASES.keySet(), //
         VALID_V9_CASES.keySet(), //
         VALID_V10_CASES.keySet(), //
+        VALID_V11_CASES.keySet(), //
         Arrays.asList(//
             "v6/" + String.join("/", Collections.nCopies(35, " ")), //
             "v7/" + String.join("/", Collections.nCopies(36, " ")), //
             "v8/" + String.join("/", Collections.nCopies(38, " ")), //
             "v9/" + String.join("/", Collections.nCopies(40, " ")), //
             "v10/" + String.join("/", Collections.nCopies(42, " ")), //
+            "v11/" + String.join("/", Collections.nCopies(43, " ")), //
             "v6", "v7", "v8", "v9", "v10", // UnexpectedPathElementsException
             "", "v1", "v61", "v21" // UnknownPingVersionException
         ))).map(v -> "{\"attributeMap\":{\"message_id\":\"00000000001\",\"uri\":\"/stub/" + v
@@ -362,7 +373,8 @@ public class ParseUriTest extends TestWithDeterministicJson {
         VALID_V7_CASES.values(), //
         VALID_V8_CASES.values(), //
         VALID_V9_CASES.values(), //
-        VALID_V10_CASES.values())) //
+        VALID_V10_CASES.values(), //
+        VALID_V11_CASES.values())) //
         .map(v -> sortJSON("{\"installer_type\":\"stub\",\"installer_version\":\"\"," + v + "}"))
         .collect(Collectors.toList());
     final List<String> expectedAttributes = Collections.nCopies(expectedPayloads.size(),
@@ -381,6 +393,8 @@ public class ParseUriTest extends TestWithDeterministicJson {
         "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException",
         "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException",
         "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException",
+        "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException",
+        "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException",
         "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException",
         "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException",
         "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException",


### PR DESCRIPTION
## Description
This adds a new version (v11) to the stub installer URL, and uses it to provide a new `launched_by` property. The idea is that this'll make it possible to determine whether the stub installer was used because of the desktop launcher, or for some other reason.

The added tests are failing for reasons I haven't been able to work out; I *think* the code is right, but I'd appreciate help figuring out what's wrong with the tests and whether the tests cover everything they should. Reverting the test changes fixes the failure (i.e. ≤v10 definitely still works), although that's obviously not tenable.

Overall, this is meant to be closely modelled on #2719 and #2638.

<details>
<summary>Test failure that I'm getting</summary>
<pre>
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.mozilla.telemetry.decoder.ParseUriTest
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 41.18 s <<< FAILURE! -- in com.mozilla.telemetry.decoder.ParseUriTest
[ERROR] com.mozilla.telemetry.decoder.ParseUriTest.testOutput -- Time elapsed: 8.364 s
[ERROR] com.mozilla.telemetry.decoder.ParseUriTest.testStubUri -- Time elapsed: 31.50 s <<< FAILURE!
java.lang.AssertionError:
ExceptionClass/Map/ParMultiDo(Anonymous).output:
Expected: iterable with items ["com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException"] in any order
     but: no item matches: "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException" in ["com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException"]
        at org.apache.beam.sdk.testing.PAssert$PAssertionSite.capture(PAssert.java:176)
        at org.apache.beam.sdk.testing.PAssert.that(PAssert.java:461)
        at org.apache.beam.sdk.testing.PAssert.that(PAssert.java:453)
        at com.mozilla.telemetry.decoder.ParseUriTest.testStubUri(ParseUriTest.java:431)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.apache.beam.sdk.testing.TestPipeline$1.evaluate(TestPipeline.java:331)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:316)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:240)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:214)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
Caused by: java.lang.AssertionError:
Expected: iterable with items ["com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException"] in any order
     but: no item matches: "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException" in ["com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException"]
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at org.apache.beam.sdk.testing.PAssert$AssertContainsInAnyOrder.apply(PAssert.java:1701)
        at org.apache.beam.sdk.testing.PAssert$AssertContainsInAnyOrder.apply(PAssert.java:1681)
        at org.apache.beam.sdk.testing.PAssert$CheckRelationAgainstExpected.apply(PAssert.java:1300)
        at org.apache.beam.sdk.testing.PAssert$CheckRelationAgainstExpected.apply(PAssert.java:1280)
        at org.apache.beam.sdk.testing.PAssert.doChecks(PAssert.java:1632)
        at org.apache.beam.sdk.testing.PAssert$GroupedValuesCheckerDoFn.processElement(PAssert.java:1589)
        at org.apache.beam.sdk.testing.PAssert$GroupedValuesCheckerDoFn$DoFnInvoker.invokeProcessElement(Unknown Source)
        at org.apache.beam.runners.core.SimpleDoFnRunner.invokeProcessElement(SimpleDoFnRunner.java:213)
        at org.apache.beam.runners.core.SimpleDoFnRunner.processElement(SimpleDoFnRunner.java:190)
        at org.apache.beam.runners.core.SimplePushbackSideInputDoFnRunner.processElementInReadyWindows(SimplePushbackSideInputDoFnRunner.java:79)
        at org.apache.beam.runners.direct.ParDoEvaluator.processElement(ParDoEvaluator.java:244)
        at org.apache.beam.runners.direct.DoFnLifecycleManagerRemovingTransformEvaluator.processElement(DoFnLifecycleManagerRemovingTransformEvaluator.java:54)
        at org.apache.beam.runners.direct.DirectTransformExecutor.processElements(DirectTransformExecutor.java:165)
        at org.apache.beam.runners.direct.DirectTransformExecutor.run(DirectTransformExecutor.java:129)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ParseUriTest.testStubUri:431 ExceptionClass/Map/ParMultiDo(Anonymous).output:
Expected: iterable with items ["com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException"] in any order
     but: no item matches: "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException" in ["com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$UnknownPingVersionException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$StubUri$InvalidIntegerException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException", "com.mozilla.telemetry.decoder.ParseUri$UnexpectedPathElementsException"]
[INFO]
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for ingestion 0.1-SNAPSHOT:
[INFO]
[INFO] ingestion .......................................... SUCCESS [  4.967 s]
[INFO] ingestion-core ..................................... SUCCESS [ 10.264 s]
[INFO] ingestion-beam ..................................... FAILURE [ 56.228 s]
[INFO] ingestion-sink ..................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
</pre>
</details>

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents

- [FIDEDI-1338](https://mozilla-hub.atlassian.net/browse/FIDEDI-1338) ≈ [bug 1990965](bugzilla.mozilla.org/show_bug.cgi?id=1990965) tracks the overall change.
- [D266503](https://phabricator.services.mozilla.com/D266503) adds the installer-side code to use this.
- (not filed yet) changes the schema to account for this field.

<details>
<summary><h2>Merging Guidelines</h2></summary>

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy)
for details.
</details>