### PR TITLE
SVCSE 3801

### DIFF
--- a/ingestion-edge/tests/unit/flush_manager/test_delete_complete.py
+++ b/ingestion-edge/tests/unit/flush_manager/test_delete_complete.py
@@ -26,7 +26,10 @@ def test_delete_complete_jobs(api: MagicMock, batch_api: MagicMock):
                         resource_version=f"{i}",
                     ),
                     status=V1JobStatus(
-                        conditions=[V1JobCondition(status="", type="Complete")]
+                        conditions=[
+                            V1JobCondition(status="True", type="SuccessCriteriaMet"),
+                            V1JobCondition(status="True", type="Complete"),
+                        ]
                     ),
                 )
                 for i in range(3)
@@ -38,7 +41,10 @@ def test_delete_complete_jobs(api: MagicMock, batch_api: MagicMock):
                     deletion_timestamp=datetime.utcnow(),
                 ),
                 status=V1JobStatus(
-                    conditions=[V1JobCondition(status="", type="Complete")]
+                    conditions=[
+                        V1JobCondition(status="True", type="SuccessCriteriaMet"),
+                        V1JobCondition(status="True", type="Complete"),
+                    ],
                 ),
             ),
             # don't delete because not complete
@@ -54,7 +60,10 @@ def test_delete_complete_jobs(api: MagicMock, batch_api: MagicMock):
             V1Job(
                 metadata=V1ObjectMeta(name="cron-1"),
                 status=V1JobStatus(
-                    conditions=[V1JobCondition(status="", type="Complete")]
+                    conditions=[
+                        V1JobCondition(status="True", type="SuccessCriteriaMet"),
+                        V1JobCondition(status="True", type="Complete"),
+                    ]
                 ),
             ),
         ]
@@ -113,7 +122,10 @@ def test_delete_complete_jobs_raises_server_error(api: MagicMock, batch_api: Mag
                     name="flush-pv-1", uid="uid-flush-pv-1", resource_version="1"
                 ),
                 status=V1JobStatus(
-                    conditions=[V1JobCondition(status="", type="Complete")]
+                    conditions=[
+                        V1JobCondition(status="True", type="SuccessCriteriaMet"),
+                        V1JobCondition(status="True", type="Complete"),
+                    ],
                 ),
             ),
         ]


### PR DESCRIPTION
## Description
See https://mozilla-hub.atlassian.net/browse/SVCSE-3801 for motivation.

In k8s 1.32 or thereabout completed jobs have an additional `condition` added to their `conditions` that looks like this:

```yaml
job:
  # ...
  status:
    completionTime: "2025-10-03T17:02:53Z"
    conditions:
    - lastProbeTime: "2025-10-03T17:02:53Z"
      lastTransitionTime: "2025-10-03T17:02:53Z"
      message: Reached expected number of succeeded pods
      reason: CompletionsReached
      status: "True"
      type: SuccessCriteriaMet
    - lastProbeTime: "2025-10-03T17:02:53Z"
      lastTransitionTime: "2025-10-03T17:02:53Z"
      message: Reached expected number of succeeded pods
      reason: CompletionsReached
      status: "True"
      type: Complete
```

Since we previously only checked the first condition, we were failing to fully clean up the old jobs/PVs and thus were burning some money on disks that should have been deprovisioned.

I'll add some explicit monitoring for unused disks but I'm not sure how we'd have caught this given the way our tests are constructured currently. We'd probably have to carefuly read the k8s release notes based on our GKE upgrade schedule (though see https://mozilla-hub.atlassian.net/browse/SVCSE-3111) and even then this would probably not have been caught:

https://github.com/kubernetes/enhancements/issues/3998
https://kubernetes.io/blog/2025/05/15/kubernetes-1-33-jobs-success-policy-goes-ga/

In our mocked tests we aren't setting `status` to an actual value which is technically required: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/job-v1/#JobStatus. I fixed that for the `Completed` `type` where it's actually important for our specific use case, but I left it unset in other status objects.

The first commit updates the tests to the new behavior and the second commit fixes the tests. I also tested this in stage, which is something only former-DSRE can do autonomously. In the past for investigations like this DE e.g. :relud have been granted the same level of access to perform these tests in stage but in this case I elected to do the testing myself for time management reasons.

## Related Tickets & Documents

- SVCSE-3801

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy)
for details.
