### PR TITLE
fix: split build-and-push into per-project workflows with path filters

### DIFF
--- a/.github/workflows/build-and-push-edge.yaml
+++ b/.github/workflows/build-and-push-edge.yaml
@@ -1,9 +1,12 @@
-name: Build and Push
+name: Build and Push ingestion-edge
 
 on:
   push:
     branches:
       - main
+    paths:
+      - "ingestion-edge/**"
+      - ".github/workflows/build-and-push-edge.yaml"
 
 jobs:
   ingestion-edge:
@@ -17,17 +20,4 @@ jobs:
       project_id: moz-fx-ingestion-edge-prod
       image_build_context: ./ingestion-edge
       dockerfile_path: ./ingestion-edge/Dockerfile
-      should_tag_latest: true
-
-  ingestion-sink:
-    permissions:
-      contents: read
-      id-token: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@main
-    with:
-      image_name: ingestion-sink
-      gar_name: ingestion-sink-prod
-      project_id: moz-fx-ingestion-sink-prod
-      image_build_context: ./
-      dockerfile_path: ./ingestion-sink/Dockerfile
       should_tag_latest: true

--- a/.github/workflows/build-and-push-sink.yaml
+++ b/.github/workflows/build-and-push-sink.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - "checkstyle/**"
       - "ingestion-sink/**"
       - "ingestion-core/**"
       - "pom.xml"

--- a/.github/workflows/build-and-push-sink.yaml
+++ b/.github/workflows/build-and-push-sink.yaml
@@ -1,0 +1,25 @@
+name: Build and Push ingestion-sink
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "ingestion-sink/**"
+      - "ingestion-core/**"
+      - "pom.xml"
+      - ".github/workflows/build-and-push-sink.yaml"
+
+jobs:
+  ingestion-sink:
+    permissions:
+      contents: read
+      id-token: write
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@main
+    with:
+      image_name: ingestion-sink
+      gar_name: ingestion-sink-prod
+      project_id: moz-fx-ingestion-sink-prod
+      image_build_context: ./
+      dockerfile_path: ./ingestion-sink/Dockerfile
+      should_tag_latest: true


### PR DESCRIPTION
## Summary

Split the single `build-and-push.yaml` workflow into two separate workflows with path filters so that only the relevant image is rebuilt when code changes:

- **`build-and-push-edge.yaml`**: triggers only on `ingestion-edge/**` changes
- **`build-and-push-sink.yaml`**: triggers on `ingestion-sink/**`, `ingestion-core/**`, `pom.xml`, and `checkstyle/**` changes

Previously, any commit to main triggered image builds for both projects, causing unnecessary rebuilds and rolling restarts in both ingestion-edge and ingestion-sink.

## Path filters

| Workflow | Triggers on |
|---|---|
| edge | `ingestion-edge/**`, workflow file |
| sink | `ingestion-sink/**`, `ingestion-core/**`, `pom.xml`, `checkstyle/**`, workflow file |

The sink paths include `ingestion-core/` and root `pom.xml` because the sink Dockerfile uses the repo root as build context and compiles against `ingestion-core`.

Fixes [SVCSE-4419](https://mozilla-hub.atlassian.net/browse/SVCSE-4419)

[SVCSE-4419]: https://mozilla-hub.atlassian.net/browse/SVCSE-4419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ