### PR TITLE
chore(beam): Ignore `com-ziniao-smanager` namespace (bug 2032228)

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -160,6 +160,7 @@ public class MessageScrubber {
       .put("org-lilo-mobile-android2020", "2013260") //
       .put("co-searcha-bistre", "2013260") //
       .put("com-buxue-student", "2024382") //
+      .put("com-ziniao-smanager", "2032228") //
       .build();
 
   private static final Map<String, String> IGNORED_NAMESPACE_PREFIXES = ImmutableMap


### PR DESCRIPTION
## Description
We've now received over 10k pings for the unknown `com-ziniao-smanager` namespace, so this adds that namespace to the ignore list.

## Related Tickets & Documents
- [Bug 2032228](https://bugzilla.mozilla.org/show_bug.cgi?id=2032228): missing namespace `com-ziniao-smanager`

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.
