### PR TITLE
[DENG-10434] Remove ip_reputation usage

### DIFF
--- a/docs/architecture/decoder_service_specification.md
+++ b/docs/architecture/decoder_service_specification.md
@@ -82,7 +82,6 @@ required group attributes {
   optional string dnt                        // header from client
   optional string x_pingsender_version       // header from client
   optional string x_debug_id                 // header from client
-  optional string x_foxsec_ip_reputation     // header from iprepd
   optional string x_lb_tags                  // header from load balancer
   optional string x_source_tags              // header from client
   optional string x_telemetry_agent          // header from client

--- a/docs/architecture/decoder_service_specification.md
+++ b/docs/architecture/decoder_service_specification.md
@@ -82,6 +82,7 @@ required group attributes {
   optional string dnt                        // header from client
   optional string x_pingsender_version       // header from client
   optional string x_debug_id                 // header from client
+  optional string x_foxsec_ip_reputation     // header from iprepd (deprecated, https://mozilla-hub.atlassian.net/browse/DENG-10434)
   optional string x_lb_tags                  // header from load balancer
   optional string x_source_tags              // header from client
   optional string x_telemetry_agent          // header from client

--- a/docs/architecture/edge_service_specification.md
+++ b/docs/architecture/edge_service_specification.md
@@ -52,7 +52,6 @@ required group attributes {
   optional string x_pipeline_proxy     // time that the AWS->GCP tee received the message, ignored, example: "2018-03-12T21:02:18.123456Z"
   optional string x_telemetry_agent    // example: "Glean/0.40.0 (Kotlin on Android)"
   optional string x_source_tags        // example: "automation, other"
-  optional string x_foxsec_ip_reputation // example: "95"
   optional string x_lb_tags            // example: "TLSv1.3, 009C"
 }
 ```

--- a/docs/architecture/edge_service_specification.md
+++ b/docs/architecture/edge_service_specification.md
@@ -52,6 +52,7 @@ required group attributes {
   optional string x_pipeline_proxy     // time that the AWS->GCP tee received the message, ignored, example: "2018-03-12T21:02:18.123456Z"
   optional string x_telemetry_agent    // example: "Glean/0.40.0 (Kotlin on Android)"
   optional string x_source_tags        // example: "automation, other"
+  optional string x_foxsec_ip_reputation // example: "95" (deprecated, https://mozilla-hub.atlassian.net/browse/DENG-10434)
   optional string x_lb_tags            // example: "TLSv1.3, 009C"
 }
 ```

--- a/docs/ingestion-edge/index.md
+++ b/docs/ingestion-edge/index.md
@@ -57,7 +57,7 @@ environment variables:
   on the filesystem where `QUEUE_PATH` is mounted below which `/__heartbeat__`
   will fail, defaults to `0` which disables the check
 - `METADATA_HEADERS`: a JSON list of headers to preserve as PubSub message
-  attributes, defaults to `["Content-Length", "Date", "DNT", "User-Agent", "X-Forwarded-For", "X-Pingsender-Version", "X-Pipeline-Proxy", "X-Debug-ID", "X-Telemetry-Agent", "X-Source-Tags", "X-Foxsec-IP-Reputation", "X-LB-Tags"]`;
+  attributes, defaults to `["Content-Length", "Date", "DNT", "User-Agent", "X-Forwarded-For", "X-Pingsender-Version", "X-Pipeline-Proxy", "X-Debug-ID", "X-Telemetry-Agent", "X-Source-Tags", "X-LB-Tags"]`;
   the message attribute name will be the header name in lowercase and with `-`
   converted to `_`
 - `PUBLISH_TIMEOUT_SECONDS`: a float indicating the maximum number of seconds

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/contextualservices/ParseReportingUrl.java
@@ -84,12 +84,8 @@ public class ParseReportingUrl extends
   private static final String PARAM_ANDROID = "Android";
 
   // Values for the click-status API parameter
-  public static final String CLICK_STATUS_ABUSE = "64";
   public static final String CLICK_STATUS_GHOST = "65";
   public static final String IMPRESSION_STATUS_SUSPICIOUS = "invalid";
-
-  // Threshold for IP reputation considered likely abuse.
-  private static final int IP_REPUTATION_THRESHOLD = 70;
 
   public static ParseReportingUrl of(String urlAllowList) {
     return new ParseReportingUrl(urlAllowList);
@@ -340,18 +336,6 @@ public class ParseReportingUrl extends
 
     builtUrl.addQueryParam(BuildReportingUrl.PARAM_PRODUCT_VERSION, "firefox_" + userAgentVersion);
 
-    String ipReputationString = attributes.get(Attribute.X_FOXSEC_IP_REPUTATION);
-    Integer ipReputation = null;
-    try {
-      ipReputation = Integer.parseInt(ipReputationString);
-    } catch (NumberFormatException ignore) {
-      // pass
-    }
-
-    if (ipReputation != null && ipReputation < IP_REPUTATION_THRESHOLD) {
-      PerDocTypeCounter.inc(attributes, "rejected_low_ip_reputation");
-      builtUrl.addQueryParam(BuildReportingUrl.PARAM_CLICK_STATUS, CLICK_STATUS_ABUSE);
-    }
   }
 
   private static void addAdditionalDimensionsForTopSites(BuildReportingUrl builtUrl,

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/Constant.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/Constant.java
@@ -68,7 +68,6 @@ public class Constant {
     public static final String VERSION = "version";
     public static final String X_DEBUG_ID = "x_debug_id";
     public static final String X_FORWARDED_FOR = "x_forwarded_for";
-    public static final String X_FOXSEC_IP_REPUTATION = "x_foxsec_ip_reputation";
     public static final String X_LB_TAGS = "x_lb_tags";
     public static final String X_PINGSENDER_VERSION = "x_pingsender_version";
     public static final String X_SOURCE_TAGS = "x_source_tags";

--- a/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/transform/NestedMetadata.java
+++ b/ingestion-core/src/main/java/com/mozilla/telemetry/ingestion/core/transform/NestedMetadata.java
@@ -39,9 +39,8 @@ public class NestedMetadata {
 
   private static final String HEADER = "header";
   private static final List<String> HEADER_ATTRIBUTES = ImmutableList //
-      .of(Attribute.DATE, Attribute.DNT, Attribute.X_DEBUG_ID, Attribute.X_FOXSEC_IP_REPUTATION,
-          Attribute.X_LB_TAGS, Attribute.X_PINGSENDER_VERSION, Attribute.X_SOURCE_TAGS,
-          Attribute.X_TELEMETRY_AGENT);
+      .of(Attribute.DATE, Attribute.DNT, Attribute.X_DEBUG_ID, Attribute.X_LB_TAGS,
+          Attribute.X_PINGSENDER_VERSION, Attribute.X_SOURCE_TAGS, Attribute.X_TELEMETRY_AGENT);
 
   private static final List<String> URI_ATTRIBUTES = ImmutableList //
       .of(Attribute.URI, Attribute.APP_NAME, Attribute.APP_VERSION, Attribute.APP_UPDATE_CHANNEL,

--- a/ingestion-core/src/test/java/com/mozilla/telemetry/ingestion/core/transform/NestedMetadataTest.java
+++ b/ingestion-core/src/test/java/com/mozilla/telemetry/ingestion/core/transform/NestedMetadataTest.java
@@ -69,7 +69,6 @@ public class NestedMetadataTest {
   public void testHeadersFromAttributes() throws Exception {
     Map<String, String> attributes = ImmutableMap.<String, String>builder().put("dnt", "1") //
         .put("sample_id", "18") //
-        .put("x_foxsec_ip_reputation", "95") //
         .put("x_lb_tags", "TLSv1.3, 009C") //
         .put("x_source_tags", "automation, perf") //
         .put("x_debug_id", "mysession") //
@@ -78,7 +77,6 @@ public class NestedMetadataTest {
     ObjectNode headers = NestedMetadata.headersFromAttributes(attributes);
     ObjectNode expected = mapToObjectNode(ImmutableMap.of("dnt", "1", //
         "x_debug_id", "mysession", //
-        "x_foxsec_ip_reputation", "95", //
         "x_lb_tags", "TLSv1.3, 009C", //
         "x_source_tags", "automation, perf", //
         "x_telemetry_agent", "Glean/0.40.0 (Kotlin on Android)"));

--- a/ingestion-edge/metadata_headers.json
+++ b/ingestion-edge/metadata_headers.json
@@ -7,7 +7,6 @@
     "X-Pingsender-Version",
     "X-Pipeline-Proxy",
     "X-Debug-ID",
-    "X-Foxsec-IP-Reputation",
     "X-LB-Tags",
     "X-Source-Tags",
     "X-Telemetry-Agent"


### PR DESCRIPTION
## Description

Removing all references to the deprecated `X-Foxsec-IP-Reputation` header.  I confirmed that the `rejected_low_ip_reputation` counter doesn't show up in the last two ctxsvc-reporter jobs that span the last month.

## Related Tickets & Documents

- [DENG-10434](https://mozilla-hub.atlassian.net/browse/DENG-10434)

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.


[DENG-10434]: https://mozilla-hub.atlassian.net/browse/DENG-10434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ