### PR TITLE
Scrub missing namespaces org-global-wxc62106 and more

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -162,6 +162,10 @@ public class MessageScrubber {
       .put("com-buxue-student", "2024382") //
       .put("com-ziniao-smanager", "2032228") //
       .put("com-codeedge-childrenfence", "2034078") //
+      .put("org-global-wxc62106", "2037560") //
+      .put("org-global-wxc6223", "2037588") //
+      .put("org-global-wxc6275", "2037589") //
+      .put("org-global-wxc6221", "2037590") //
       .build();
 
   private static final Map<String, String> IGNORED_NAMESPACE_PREFIXES = ImmutableMap


### PR DESCRIPTION
## Description

During platform health check, some document namespaces appear to be missing.

Following the runbook to remove them as they don't appear to be a Mozilla product.

## Related Tickets & Documents

- https://bugzilla.mozilla.org/show_bug.cgi?id=2037560
- https://bugzilla.mozilla.org/show_bug.cgi?id=2037588
- https://bugzilla.mozilla.org/show_bug.cgi?id=2037589
- https://bugzilla.mozilla.org/show_bug.cgi?id=2037590



<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.
