### PR TITLE
Scrub missing namespaces prefixes com-xiaobei-browser and firefox-desktop-background-defaultagent

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -170,7 +170,6 @@ public class MessageScrubber {
       .put("org-global-g", "2024379") //
       .put("org-global-wxc", "2037560") //
       .put("com-xiaobei-browser", "2039427") //
-      .put("firefox-desktop-background-defaultagent", "2039430") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -169,6 +169,8 @@ public class MessageScrubber {
       .put("com-feifan", "2010623") //
       .put("org-global-g", "2024379") //
       .put("org-global-wxc", "2037560") //
+      .put("com-xiaobei-browser", "2039427") //
+      .put("firefox-desktop-background-defaultagent", "2039430") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap


### PR DESCRIPTION
## Description

During platform health check, some document namespaces appear to be missing.

Following the runbook to remove them as they don't appear to be a Mozilla product.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents

- https://bugzilla.mozilla.org/show_bug.cgi?id=2039427
- https://bugzilla.mozilla.org/show_bug.cgi?id=2039429

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.
