### PR TITLE
refactor(ingestion-beam): simplify Decoder pipeline and dedupe log-entry geo lookups

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -16,7 +16,6 @@ import com.mozilla.telemetry.transforms.LimitPayloadSize;
 import com.mozilla.telemetry.transforms.NormalizeAttributes;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
@@ -55,50 +54,49 @@ public class Decoder extends Sink {
     final Pipeline pipeline = Pipeline.create(options);
     final List<PCollection<PubsubMessage>> failureCollections = new ArrayList<>();
 
-    // We wrap pipeline in Optional for more convenience in chaining together transforms.
-    Optional.of(pipeline)
+    // We apply ParseUri without failures here, and add failures later, so that ParseProxy
+    // can use pipeline metadata to adjust what IP to use for geo lookups.
+    PCollection<PubsubMessage> messages = pipeline //
+        .apply(options.getInputType().read(options)) //
+        .apply("ParseUri", ParseUri.withoutFailures());
 
-        // Input
-        .map(p -> p //
-            .apply(options.getInputType().read(options)) //
-            // We apply ParseUri without failures here, and add failures later, so that parseProxy
-            // can use pipeline metadata to adjust what IP to use for geo lookups.
-            .apply("ParseUri", ParseUri.withoutFailures()) //
-            // We apply ParseProxy and GeoCityLookup and GeoIspLookup first so that IP
-            // address is already removed before any message gets routed to error output; see
-            // https://github.com/mozilla/gcp-ingestion/issues/1096
-            .apply(ParseProxy.of(options.getSchemasLocation())) //
-            .apply(GeoIspLookup.of(options.getGeoIspDatabase())) //
-            .apply(GeoCityLookup.of(options.getGeoCityDatabase(), options.getGeoCityFilter())) //
-            .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())
-                .withClientCompressionRecorded()))
+    // For structured telemetry pings submitted via Cloud Logging, extract the IP from the
+    // LogEntry payload into the x_forwarded_for attribute so the geo lookups below can use it.
+    if (options.getLogIngestionEnabled()) {
+      messages = messages.apply(ExtractIpFromLogEntry.of());
+    }
 
-        // Special case: parsing structured telemetry pings submitted from Cloud Logging.
-        .map(p -> options.getLogIngestionEnabled() ? p //
-            // We first extract IP address from the log entry and remove it from the payload
-            // for consistency with the standard flow.
-            .apply(ExtractIpFromLogEntry.of()) //
-            .apply(GeoIspLookup.of(options.getGeoIspDatabase())) //
-            .apply(GeoCityLookup.of(options.getGeoCityDatabase(), options.getGeoCityFilter())) //
-            // Now we can parse the log entry and route failures to error output
-            .apply(ParseLogEntry.of())//
-            .failuresTo(failureCollections) : p)
+    // We apply ParseProxy, GeoIspLookup, and GeoCityLookup before any potential error
+    // routing so that the IP address is scrubbed before any message can be routed to
+    // error output; see https://github.com/mozilla/gcp-ingestion/issues/1096
+    messages = messages //
+        .apply(ParseProxy.of(options.getSchemasLocation())) //
+        .apply(GeoIspLookup.of(options.getGeoIspDatabase())) //
+        .apply(GeoCityLookup.of(options.getGeoCityDatabase(), options.getGeoCityFilter())) //
+        .apply(DecompressPayload.enabled(options.getDecompressInputPayloads())
+            .withClientCompressionRecorded());
 
-        // Add parse uri failures separately so that they don't prevent geo lookups
-        .map(p -> p //
-            .apply("ParseUriAddFailures", ParseUri.addFailures()).failuresTo(failureCollections))
+    // Parse the LogEntry envelope and route failures to the error output. Runs after the
+    // geo block so that failed messages carry geo attributes for parity with the standard flow.
+    if (options.getLogIngestionEnabled()) {
+      messages = messages.apply(ParseLogEntry.of()).failuresTo(failureCollections);
+    }
 
-        // Main output
-        .map(p -> p //
-            // See discussion in https://github.com/mozilla/gcp-ingestion/issues/776
-            .apply("LimitPayloadSize", LimitPayloadSize.toMB(8)).failuresTo(failureCollections) //
-            .apply("ParsePayload", ParsePayload.of(options.getSchemasLocation())) //
-            .failuresTo(failureCollections) //
-            .apply(ParseUserAgent.of()) //
-            .apply(NormalizeAttributes.of()) //
-            .apply(SanitizeAttributes.of(options.getSchemasLocation())) //
-            .apply("AddMetadata", AddMetadata.of()).failuresTo(failureCollections) //
-            .apply(options.getOutputType().write(options)).failuresTo(failureCollections));
+    // Add ParseUri failures separately so that they don't prevent geo lookups.
+    messages = messages //
+        .apply("ParseUriAddFailures", ParseUri.addFailures()).failuresTo(failureCollections);
+
+    // Main output
+    messages //
+        // See discussion in https://github.com/mozilla/gcp-ingestion/issues/776
+        .apply("LimitPayloadSize", LimitPayloadSize.toMB(8)).failuresTo(failureCollections) //
+        .apply("ParsePayload", ParsePayload.of(options.getSchemasLocation()))
+        .failuresTo(failureCollections) //
+        .apply(ParseUserAgent.of()) //
+        .apply(NormalizeAttributes.of()) //
+        .apply(SanitizeAttributes.of(options.getSchemasLocation())) //
+        .apply("AddMetadata", AddMetadata.of()).failuresTo(failureCollections) //
+        .apply(options.getOutputType().write(options)).failuresTo(failureCollections);
 
     // Error output
     PCollectionList.of(failureCollections) //


### PR DESCRIPTION
Follow up to https://github.com/mozilla/gcp-ingestion/pull/2857#discussion_r3059004061

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.
