### PR TITLE
Bug 2042210 - Block `org-global-` namespaces

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -171,6 +171,7 @@ public class MessageScrubber {
       .put("org-global-g", "2024379") //
       .put("org-global-wxc", "2037560") //
       .put("com-xiaobei-browser", "2039427") //
+      .put("org-global-", "2042210") //
       .build();
 
   private static final Map<String, String> IGNORED_TELEMETRY_DOCTYPES = ImmutableMap


### PR DESCRIPTION
## Description

Noticed this from bigeye and it's pretty high-volume so doing this before the platform health check.  Using `org-global-*` because this has appeared a few times and I'm sure we'll never want that namespace prefix.  Keeping the old filters for posterity.

## Related Tickets & Documents

- https://bugzilla.mozilla.org/show_bug.cgi?id=2042210

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.
