### PR TITLE
DENG-9533 - Validate required attributes on direct Pub/Sub messages

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -116,3 +116,4 @@ cloudops-infra
 LogEntry
 LogEntry-wrapped
 parameterized
+publishTime

--- a/docs/architecture/decoder_service_specification.md
+++ b/docs/architecture/decoder_service_specification.md
@@ -26,9 +26,11 @@ is set):
   LogEntry-wrapped messages to `structured-logging`.
 - Direct Pub/Sub - enabled with `--directPubsubEnabled=true`. Server-side
   publishers write Glean ping JSON (optionally gzipped) as message body, with
-  ping metadata fields as message attributes: `document_namespace`,
-  `document_type`, `document_version`, `document_id`. Optional attributes: `user_agent`,
-  `x_forwarded_for`.
+  ping metadata fields as message attributes. Required attributes:
+  `document_namespace`, `document_type`, `document_version`, `document_id`;
+  messages missing any of these are routed to the error topic. Optional
+  attributes: `user_agent`, `x_forwarded_for`. `submission_timestamp` is
+  stamped by the decoder from Pub/Sub's publishTime if not already set.
 
 ## Data Flow
 

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/Decoder.java
@@ -88,9 +88,10 @@ public class Decoder extends Sink {
         // Special case: structured telemetry pings published directly to Pub/Sub.
         // The publisher sets document_*, user_agent, and x_forwarded_for as message attributes,
         // so routing/proxy/geo all run on the main stage. We need to stamp
-        // submission_timestamp from publishTime.
+        // submission_timestamp from publishTime and reject messages missing required attributes.
         .map(p -> options.getDirectPubsubEnabled() ? p //
-            .apply("StampSubmissionTimestamp", StampSubmissionTimestamp.of()) : p)
+            .apply("StampSubmissionTimestamp", StampSubmissionTimestamp.of()) //
+            .failuresTo(failureCollections) : p)
 
         // Add parse uri failures separately so that they don't prevent geo lookups
         .map(p -> p //

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/StampSubmissionTimestamp.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/StampSubmissionTimestamp.java
@@ -1,46 +1,93 @@
 package com.mozilla.telemetry.decoder;
 
+import com.google.common.collect.ImmutableList;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
+import com.mozilla.telemetry.transforms.FailureMessage;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.WithFailures;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TupleTagList;
 import org.joda.time.Instant;
 
 /**
- * Stamps submission_timestamp on direct-Pub/Sub messages using Pub/Sub's publishTime.
+ * Prepares direct-Pub/Sub messages for the main decoder stage:
+ * stamps {@code submission_timestamp} from Pub/Sub's publishTime and rejects
+ * messages missing any of the metadata attributes the publisher is expected to set
+ * ({@code document_id}, {@code document_namespace}, {@code document_type},
+ * {@code document_version}).
  *
- * <p>Edge-published messages already carry submission_timestamp, so this short-circuits.
- * On reprocessing, the previously-stamped attribute survives and the short-circuit also
- * applies, preserving the original timestamp across republishes.
+ * <p>Edge-published messages already carry {@code submission_timestamp} and stamping
+ * short-circuits in that case. On reprocessing, the previously-stamped attribute survives
+ * and the short-circuit also applies, preserving the original timestamp across republishes.
+ *
+ * <p>This mirrors the validation that {@link ParseLogEntry} applies for log-ingestion input,
+ * so both alternative ingestion paths fail with a clear, transform-specific error rather than
+ * a downstream {@code SchemaNotFoundException} (or, for {@code document_id}, silent success).
  */
-public class StampSubmissionTimestamp
-    extends PTransform<PCollection<PubsubMessage>, PCollection<PubsubMessage>> {
+public class StampSubmissionTimestamp extends
+    PTransform<PCollection<PubsubMessage>, WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage>> {
 
   public static StampSubmissionTimestamp of() {
     return new StampSubmissionTimestamp();
   }
 
-  @Override
-  public PCollection<PubsubMessage> expand(PCollection<PubsubMessage> input) {
-    return input.apply(ParDo.of(new Fn()));
+  /** Thrown when a direct-Pub/Sub message is missing a required attribute. */
+  public static class MissingAttributeException extends RuntimeException {
+
+    MissingAttributeException(String attribute) {
+      super("Direct-Pub/Sub message is missing required attribute: " + attribute);
+    }
   }
 
-  static class Fn extends DoFn<PubsubMessage, PubsubMessage> {
+  private static final List<String> REQUIRED_ATTRIBUTES = ImmutableList.of(
+      Attribute.DOCUMENT_NAMESPACE, Attribute.DOCUMENT_TYPE, Attribute.DOCUMENT_VERSION,
+      Attribute.DOCUMENT_ID);
+
+  final TupleTag<PubsubMessage> outputTag = new TupleTag<>() {
+  };
+  final TupleTag<PubsubMessage> failureTag = new TupleTag<>() {
+  };
+
+  @Override
+  public WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage> expand(
+      PCollection<PubsubMessage> input) {
+    PCollectionTuple tuple = input
+        .apply(ParDo.of(new Fn()).withOutputTags(outputTag, TupleTagList.of(failureTag)));
+    return WithFailures.Result.of(tuple.get(outputTag), tuple.get(failureTag));
+  }
+
+  class Fn extends DoFn<PubsubMessage, PubsubMessage> {
 
     @ProcessElement
     public void processElement(@Element PubsubMessage message, @Timestamp Instant timestamp,
-        OutputReceiver<PubsubMessage> out) {
-      if (message.getAttribute(Attribute.SUBMISSION_TIMESTAMP) != null) {
-        out.output(message);
-        return;
+        MultiOutputReceiver out) {
+      try {
+        for (String attribute : REQUIRED_ATTRIBUTES) {
+          String value = message.getAttribute(attribute);
+          if (value == null || value.isEmpty()) {
+            throw new MissingAttributeException(attribute);
+          }
+        }
+
+        if (message.getAttribute(Attribute.SUBMISSION_TIMESTAMP) != null) {
+          out.get(outputTag).output(message);
+          return;
+        }
+        Map<String, String> attributes = new HashMap<>(message.getAttributeMap());
+        attributes.put(Attribute.SUBMISSION_TIMESTAMP, timestamp.toString());
+        out.get(outputTag).output(new PubsubMessage(message.getPayload(), attributes));
+      } catch (MissingAttributeException e) {
+        out.get(failureTag)
+            .output(FailureMessage.of(StampSubmissionTimestamp.class.getSimpleName(), message, e));
       }
-      Map<String, String> attributes = new HashMap<>(message.getAttributeMap());
-      attributes.put(Attribute.SUBMISSION_TIMESTAMP, timestamp.toString());
-      out.output(new PubsubMessage(message.getPayload(), attributes));
     }
   }
 }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/DecoderMainTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/DecoderMainTest.java
@@ -204,6 +204,40 @@ public class DecoderMainTest extends TestWithDeterministicJson {
         Matchers.equalTo("gzip"));
   }
 
+  /**
+   * Direct-Pub/Sub messages missing any required routing attribute must be rejected to error
+   * output rather than passed through. This complements the unit test in
+   * {@code StampSubmissionTimestampTest} by exercising the full pipeline wiring.
+   */
+  @Test
+  public void testDirectPubsubMissingRequiredAttributeGoesToError() throws Exception {
+    String outputPath = outputFolder.getRoot().getAbsolutePath();
+    String resourceDir = Resources.getResource("testdata/decoder-integration").getPath();
+    String input = resourceDir + "/directpubsub-invalid.ndjson";
+    String output = outputPath + "/out/out";
+    String errorOutput = outputPath + "/error/error";
+
+    Decoder.main(new String[] { "--inputFileFormat=json", "--inputType=file", "--input=" + input,
+        "--outputFileFormat=json", "--outputType=file", "--output=" + output,
+        "--errorOutputType=file", "--errorOutput=" + errorOutput, "--includeStackTrace=false",
+        "--outputFileCompression=UNCOMPRESSED", "--errorOutputFileCompression=UNCOMPRESSED",
+        "--geoCityDatabase=src/test/resources/cityDB/GeoIP2-City-Test.mmdb",
+        "--geoIspDatabase=src/test/resources/ispDB/GeoIP2-ISP-Test.mmdb",
+        "--schemasLocation=schemas.tar.gz", "--directPubsubEnabled=true" });
+
+    List<String> outputLines = Lines.files(output + "*.ndjson");
+    List<String> errorOutputLines = Lines.files(errorOutput + "*.ndjson");
+
+    assertThat("No invalid messages should reach main output", outputLines, Matchers.empty());
+    assertThat("Each invalid message must be routed to error output", errorOutputLines,
+        Matchers.hasSize(4));
+    for (String line : errorOutputLines) {
+      PubsubMessage errorMessage = Json.readPubsubMessage(line);
+      assertThat("Failure must be attributed to StampSubmissionTimestamp",
+          errorMessage.getAttribute("error_type"), Matchers.equalTo("StampSubmissionTimestamp"));
+    }
+  }
+
   @Test
   public void testIdempotence() throws Exception {
     String outputPath = outputFolder.getRoot().getAbsolutePath();

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/StampSubmissionTimestampTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/StampSubmissionTimestampTest.java
@@ -2,15 +2,19 @@ package com.mozilla.telemetry.decoder;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import com.mozilla.telemetry.ingestion.core.Constant.Attribute;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessageWithAttributesCoder;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestStream;
+import org.apache.beam.sdk.transforms.WithFailures;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TimestampedValue;
 import org.joda.time.Instant;
@@ -26,23 +30,29 @@ public class StampSubmissionTimestampTest {
       .getBytes(StandardCharsets.UTF_8);
   private static final Instant PUBLISH_TIME = Instant.parse("2026-01-15T12:34:56.789Z");
 
-  @Test
-  public void stampsTimestampWhenMissing() {
-    PubsubMessage input = new PubsubMessage(BODY,
-        ImmutableMap.of(Attribute.DOCUMENT_NAMESPACE, "ads-backend", Attribute.DOCUMENT_TYPE,
-            "request-stats", Attribute.DOCUMENT_VERSION, "1", Attribute.DOCUMENT_ID,
-            "6c702690-02a7-4e81-b4cb-550a1ce10a22"));
+  private static final Map<String, String> ALL_REQUIRED = ImmutableMap.of(
+      Attribute.DOCUMENT_NAMESPACE, "ads-backend", Attribute.DOCUMENT_TYPE, "request-stats",
+      Attribute.DOCUMENT_VERSION, "1", Attribute.DOCUMENT_ID,
+      "6c702690-02a7-4e81-b4cb-550a1ce10a22");
 
+  private WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage> applyTransform(
+      PubsubMessage input) {
     TestStream<PubsubMessage> stream = TestStream.create(PubsubMessageWithAttributesCoder.of())
         .advanceWatermarkTo(PUBLISH_TIME).addElements(TimestampedValue.of(input, PUBLISH_TIME))
         .advanceWatermarkToInfinity();
+    return pipeline.apply(stream).apply(StampSubmissionTimestamp.of());
+  }
 
-    PCollection<PubsubMessage> output = pipeline.apply(stream).apply(StampSubmissionTimestamp.of());
+  @Test
+  public void stampsTimestampWhenMissing() {
+    PubsubMessage input = new PubsubMessage(BODY, ALL_REQUIRED);
 
-    PAssert.thatSingleton(output).satisfies(message -> {
+    WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage> result = applyTransform(input);
+
+    PAssert.that(result.failures()).empty();
+    PAssert.thatSingleton(result.output()).satisfies(message -> {
       assertEquals("submission_timestamp must be stamped from element timestamp",
           PUBLISH_TIME.toString(), message.getAttribute(Attribute.SUBMISSION_TIMESTAMP));
-      // Non-timestamp attributes pass through unchanged.
       assertEquals("ads-backend", message.getAttribute(Attribute.DOCUMENT_NAMESPACE));
       assertEquals("request-stats", message.getAttribute(Attribute.DOCUMENT_TYPE));
       assertEquals("1", message.getAttribute(Attribute.DOCUMENT_VERSION));
@@ -58,22 +68,74 @@ public class StampSubmissionTimestampTest {
   @Test
   public void preservesExistingTimestamp() {
     String preStamped = "2025-12-01T00:00:00.000Z";
-    PubsubMessage input = new PubsubMessage(BODY,
-        ImmutableMap.of(Attribute.DOCUMENT_NAMESPACE, "ads-backend", Attribute.DOCUMENT_TYPE,
-            "request-stats", Attribute.DOCUMENT_VERSION, "1", Attribute.DOCUMENT_ID,
-            "6c702690-02a7-4e81-b4cb-550a1ce10a22", Attribute.SUBMISSION_TIMESTAMP, preStamped));
+    Map<String, String> attrs = new HashMap<>(ALL_REQUIRED);
+    attrs.put(Attribute.SUBMISSION_TIMESTAMP, preStamped);
+    PubsubMessage input = new PubsubMessage(BODY, attrs);
 
-    TestStream<PubsubMessage> stream = TestStream.create(PubsubMessageWithAttributesCoder.of())
-        .advanceWatermarkTo(PUBLISH_TIME).addElements(TimestampedValue.of(input, PUBLISH_TIME))
-        .advanceWatermarkToInfinity();
+    WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage> result = applyTransform(input);
 
-    PCollection<PubsubMessage> output = pipeline.apply(stream).apply(StampSubmissionTimestamp.of());
-
-    PAssert.thatSingleton(output).satisfies(message -> {
-      // Pre-existing submission_timestamp must be preserved (reprocessing / Edge case).
+    PAssert.that(result.failures()).empty();
+    PAssert.thatSingleton(result.output()).satisfies(message -> {
       assertEquals("submission_timestamp must not be overwritten", preStamped,
           message.getAttribute(Attribute.SUBMISSION_TIMESTAMP));
       assertArrayEquals("Body bytes must be preserved exactly", BODY, message.getPayload());
+      return null;
+    });
+
+    pipeline.run();
+  }
+
+  private void assertMissingAttributeIsRejected(String attribute) {
+    Map<String, String> attrs = new HashMap<>(ALL_REQUIRED);
+    attrs.remove(attribute);
+    PubsubMessage input = new PubsubMessage(BODY, attrs);
+
+    WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage> result = applyTransform(input);
+
+    PAssert.that(result.output()).empty();
+    PAssert.thatSingleton(result.failures()).satisfies(message -> {
+      assertArrayEquals("Body must be preserved on failure", BODY, message.getPayload());
+      assertEquals("StampSubmissionTimestamp", message.getAttribute("error_type"));
+      String errorMessage = message.getAttribute("error_message");
+      assertTrue("error_message must reference the missing attribute (" + attribute + "), got: "
+          + errorMessage, errorMessage.contains(attribute));
+      return null;
+    });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void routesMissingDocumentIdToFailures() {
+    assertMissingAttributeIsRejected(Attribute.DOCUMENT_ID);
+  }
+
+  @Test
+  public void routesMissingDocumentNamespaceToFailures() {
+    assertMissingAttributeIsRejected(Attribute.DOCUMENT_NAMESPACE);
+  }
+
+  @Test
+  public void routesMissingDocumentTypeToFailures() {
+    assertMissingAttributeIsRejected(Attribute.DOCUMENT_TYPE);
+  }
+
+  @Test
+  public void routesMissingDocumentVersionToFailures() {
+    assertMissingAttributeIsRejected(Attribute.DOCUMENT_VERSION);
+  }
+
+  @Test
+  public void routesEmptyDocumentIdToFailures() {
+    Map<String, String> attrs = new HashMap<>(ALL_REQUIRED);
+    attrs.put(Attribute.DOCUMENT_ID, "");
+    PubsubMessage input = new PubsubMessage(BODY, attrs);
+
+    WithFailures.Result<PCollection<PubsubMessage>, PubsubMessage> result = applyTransform(input);
+
+    PAssert.that(result.output()).empty();
+    PAssert.thatSingleton(result.failures()).satisfies(message -> {
+      assertEquals("StampSubmissionTimestamp", message.getAttribute("error_type"));
       return null;
     });
 

--- a/ingestion-beam/src/test/resources/testdata/decoder-integration/directpubsub-invalid.ndjson
+++ b/ingestion-beam/src/test/resources/testdata/decoder-integration/directpubsub-invalid.ndjson
@@ -1,0 +1,4 @@
+{"attributeMap":{"document_namespace":"test","document_type":"test","document_version":"1"},"payload":"e30="}
+{"attributeMap":{"document_type":"test","document_version":"1","document_id":"4c3a0767-d84a-4d02-8a92-fa54a3376052"},"payload":"e30="}
+{"attributeMap":{"document_namespace":"test","document_version":"1","document_id":"5c3a0767-d84a-4d02-8a92-fa54a3376053"},"payload":"e30="}
+{"attributeMap":{"document_namespace":"test","document_type":"test","document_id":"6c3a0767-d84a-4d02-8a92-fa54a3376054"},"payload":"e30="}


### PR DESCRIPTION
## Description

Follow up to https://github.com/mozilla/gcp-ingestion/pull/2857 to guard against missing ping metadata attributes. This is unlikely assuming publishers use our template, but better be sure it's handled properly here.\

## Related Tickets & Documents

- DENG-9533


## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.
