### PR TITLE
[Bug 2039430] Scrub unwanted combination of namespace and doctype (firefox-desktop-background-defaultagent)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,9 @@ jobs:
           if ! command -v gpgv >/dev/null 2>&1; then
             apt-get update && apt-get install -y gpgv
           fi
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+          # Codecov's keybase.io identity was removed; fetch the uploader signing key
+          # (fingerprint 27034E7FDB850E0BBC2C62FF806BB28AED779869) from a keyserver instead.
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x27034E7FDB850E0BBC2C62FF806BB28AED779869" | gpg --no-default-keyring --keyring trustedkeys.gpg --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.values.KV;
 
 /**
  * This class is called in {@link ParsePayload} to check for known signatures of potentially
@@ -163,6 +164,15 @@ public class MessageScrubber {
       .put("com-ziniao-smanager", "2032228") //
       .put("com-codeedge-childrenfence", "2034078") //
       .put("coverage", "SVCSE-4447") //
+      .build();
+
+  private static final Map<KV<String, String>, String> IGNORED_NAMESPACES_AND_DOCTYPES = ImmutableMap
+      .<KV<String, String>, String>builder()
+      .put(KV.of("firefox-desktop-background-defaultagent", "new-profile"), "2039430") //
+      .put(KV.of("firefox-desktop-background-defaultagent", "use-counters"), "2039430") //
+      .put(KV.of("firefox-desktop-background-defaultagent", "crash"), "2039430") //
+      .put(KV.of("firefox-desktop-background-defaultagent", "pageload"), "2039430") //
+      .put(KV.of("firefox-desktop-background-defaultagent", "temp-fog-initial-state"), "2039430") //
       .build();
 
   private static final Map<String, String> IGNORED_NAMESPACE_PREFIXES = ImmutableMap
@@ -332,6 +342,12 @@ public class MessageScrubber {
           throw new UnwantedDataException(IGNORED_NAMESPACE_PREFIXES.get(prefix));
         }
       }
+    }
+
+    // Check for unwanted document types for a specific namespace.
+    final KV<String, String> namespaceAndDocType = KV.of(namespace, docType);
+    if (IGNORED_NAMESPACES_AND_DOCTYPES.containsKey(namespaceAndDocType)) {
+      throw new UnwantedDataException(IGNORED_NAMESPACES_AND_DOCTYPES.get(namespaceAndDocType));
     }
 
     if (ParseUri.TELEMETRY.equals(namespace) && IGNORED_TELEMETRY_DOCTYPES.containsKey(docType)) {


### PR DESCRIPTION
## Description

This adds some logic to scrub a combination of namespace and doctypes. Needed for https://bugzilla.mozilla.org/show_bug.cgi?id=2039430 in which `firefox-desktop-background-defaultagent` is sending some unwanted pings

## Related Tickets & Documents

- https://bugzilla.mozilla.org/show_bug.cgi?id=2039430

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.
