### PR TITLE
feat(ingestion-beam): support Artifact registry for schemas artifact

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/options/SinkOptions.java
@@ -42,7 +42,9 @@ public interface SinkOptions extends PipelineOptions {
 
   void setOutputType(OutputType value);
 
-  @Description("Path (local or gs://) to a .tar.gz file containing json schemas and bq schemas"
+  @Description("Path (local, gs://, or an Artifact Registry file resource name of the form"
+      + " projects/PROJECT/locations/LOCATION/repositories/REPOSITORY/files/FILE) to a .tar.gz"
+      + " file containing json schemas and bq schemas"
       + " per docType; the json schemas are used by the Decoder to validate payload structure and"
       + " the bq schemas are used by the BigQuery sink to coerce the payload types to fit the "
       + " destination table; the BigQuery sink will fall back to using the BigQuery API to fetch"

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/ArtifactRegistryInputStream.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/ArtifactRegistryInputStream.java
@@ -6,10 +6,10 @@ import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.UrlEscapers;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Opens a file in an Artifact Registry generic repository given its resource name
@@ -38,6 +38,7 @@ public class ArtifactRegistryInputStream {
    */
   public static InputStream open(String location) throws IOException {
     GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+    // Scopes are only required when authenticating via a service account key.
     if (credentials.createScopedRequired()) {
       credentials = credentials.createScoped(SCOPE);
     }
@@ -51,11 +52,10 @@ public class ArtifactRegistryInputStream {
   /**
    * Convert a file resource name to its media download URL, url-encoding the file id segment.
    */
+  @VisibleForTesting
   static String toDownloadUrl(String resourceName) {
-    int idStart = resourceName.indexOf(FILES_SEGMENT) + FILES_SEGMENT.length();
-    String fileId = resourceName.substring(idStart);
-    String encodedFileId = URLEncoder.encode(fileId, StandardCharsets.UTF_8).replace("+", "%20");
-    return DOWNLOAD_PREFIX + resourceName.substring(0, idStart) + encodedFileId
-        + ":download?alt=media";
+    String[] parts = resourceName.split(FILES_SEGMENT, 2);
+    String encodedFileId = UrlEscapers.urlPathSegmentEscaper().escape(parts[1]);
+    return DOWNLOAD_PREFIX + parts[0] + FILES_SEGMENT + encodedFileId + ":download?alt=media";
   }
 }

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/ArtifactRegistryInputStream.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/ArtifactRegistryInputStream.java
@@ -1,0 +1,61 @@
+package com.mozilla.telemetry.util;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Opens a file in an Artifact Registry generic repository given its resource name
+ * ({@code projects/.../repositories/REPOSITORY/files/FILE}), authenticating with Application
+ * Default Credentials.
+ *
+ * @see <a href="https://docs.cloud.google.com/artifact-registry/docs/generic#api_1">Artifact
+ *     Registry generic repository API</a>
+ */
+public class ArtifactRegistryInputStream {
+
+  private static final String DOWNLOAD_PREFIX = "https://artifactregistry.googleapis.com/download/v1/";
+  private static final String SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+  private static final String FILES_SEGMENT = "/files/";
+
+  /**
+   * Returns true if {@code path} is an Artifact Registry file resource name.
+   */
+  public static boolean handles(String path) {
+    return path.startsWith("projects/") && path.contains("/repositories/")
+        && path.contains(FILES_SEGMENT);
+  }
+
+  /**
+   * Open the file named by Artifact Registry resource name {@code location}.
+   */
+  public static InputStream open(String location) throws IOException {
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+    if (credentials.createScopedRequired()) {
+      credentials = credentials.createScoped(SCOPE);
+    }
+    HttpRequestFactory requestFactory = new NetHttpTransport()
+        .createRequestFactory(new HttpCredentialsAdapter(credentials));
+    HttpResponse response = requestFactory.buildGetRequest(new GenericUrl(toDownloadUrl(location)))
+        .execute();
+    return response.getContent();
+  }
+
+  /**
+   * Convert a file resource name to its media download URL, url-encoding the file id segment.
+   */
+  static String toDownloadUrl(String resourceName) {
+    int idStart = resourceName.indexOf(FILES_SEGMENT) + FILES_SEGMENT.length();
+    String fileId = resourceName.substring(idStart);
+    String encodedFileId = URLEncoder.encode(fileId, StandardCharsets.UTF_8).replace("+", "%20");
+    return DOWNLOAD_PREFIX + resourceName.substring(0, idStart) + encodedFileId
+        + ":download?alt=media";
+  }
+}

--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/util/BeamFileInputStream.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/util/BeamFileInputStream.java
@@ -11,6 +11,9 @@ public class BeamFileInputStream {
    * Open {@code path} using beam's {@link FileSystems}.
    */
   public static InputStream open(String path) throws IOException {
+    if (ArtifactRegistryInputStream.handles(path)) {
+      return ArtifactRegistryInputStream.open(path);
+    }
     return Channels
         .newInputStream(FileSystems.open(FileSystems.matchSingleFileSpec(path).resourceId()));
   }

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/util/ArtifactRegistryInputStreamTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/util/ArtifactRegistryInputStreamTest.java
@@ -1,0 +1,36 @@
+package com.mozilla.telemetry.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ArtifactRegistryInputStreamTest {
+
+  private static final String RESOURCE_NAME = "projects/moz-fx-dev-whd-svcse-4252"
+      + "/locations/us-west1/repositories/artifacts-generic"
+      + "/files/schemas:ad36a04dc:schemas.tar.gz";
+
+  @Test
+  public void testHandlesArtifactRegistryResourceNames() {
+    assertTrue(ArtifactRegistryInputStream.handles(RESOURCE_NAME));
+  }
+
+  @Test
+  public void testDoesNotHandleOtherLocations() {
+    assertFalse(ArtifactRegistryInputStream.handles("gs://my-bucket/schemas.tar.gz"));
+    assertFalse(ArtifactRegistryInputStream.handles("/local/path/schemas.tar.gz"));
+    assertFalse(ArtifactRegistryInputStream
+        .handles("https://github.com/mozilla-services/mozilla-pipeline-schemas/archive/x.tar.gz"));
+  }
+
+  @Test
+  public void testToDownloadUrlEncodesFileId() {
+    assertEquals(
+        "https://artifactregistry.googleapis.com/download/v1/projects/moz-fx-dev-whd-svcse-4252"
+            + "/locations/us-west1/repositories/artifacts-generic"
+            + "/files/schemas%3Aad36a04dc%3Aschemas.tar.gz:download?alt=media",
+        ArtifactRegistryInputStream.toDownloadUrl(RESOURCE_NAME));
+  }
+}

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/util/ArtifactRegistryInputStreamTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/util/ArtifactRegistryInputStreamTest.java
@@ -26,11 +26,11 @@ public class ArtifactRegistryInputStreamTest {
   }
 
   @Test
-  public void testToDownloadUrlEncodesFileId() {
+  public void testToDownloadUrlEncodesSlashesInFileId() {
     assertEquals(
-        "https://artifactregistry.googleapis.com/download/v1/projects/moz-fx-dev-whd-svcse-4252"
-            + "/locations/us-west1/repositories/artifacts-generic"
-            + "/files/schemas%3Aad36a04dc%3Aschemas.tar.gz:download?alt=media",
-        ArtifactRegistryInputStream.toDownloadUrl(RESOURCE_NAME));
+        "https://artifactregistry.googleapis.com/download/v1/projects/p/locations/us"
+            + "/repositories/r/files/pkg:v:sub%2Fdir%2Ffile.tar.gz:download?alt=media",
+        ArtifactRegistryInputStream.toDownloadUrl(
+            "projects/p/locations/us/repositories/r/files/pkg:v:sub/dir/file.tar.gz"));
   }
 }


### PR DESCRIPTION
## Description

This change adds support for beam to read the schemas artifact from https://docs.cloud.google.com/artifact-registry/docs/generic. This won't be used in a production capacity immediately but will be available whenever it makes sense during cutover proceedings.

Project used for testing: https://console.cloud.google.com/artifacts?referrer=search&project=moz-fx-dev-whd-svcse-4252
[specific artifact used for testing](https://console.cloud.google.com/dataflow/jobs/us-west1/2026-06-24_11_23_39-9097569230955389778;graphView=0?project=moz-fx-data-beam-nonprod-b5f4&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22))), schemas artifact created via:

```bash
  gcloud storage cp \
    gs://moz-fx-data-prod-dataflow/schemas/202606240213_3262f0782.tar.gz \
    /tmp/schemas.tar.gz
  gcloud artifacts generic upload \
    --project=moz-fx-dev-whd-svcse-4252 \
    --location=us \
    --repository=mozilla-pipeline-schemas-generic-artifacts \
    --package=schemas \
    --version=3262f0782 \
    --source=/tmp/schemas.tar.gz
```

[Successful dataflow job using this code](https://console.cloud.google.com/dataflow/jobs/us-west1/2026-06-24_11_23_39-9097569230955389778;graphView=0?project=moz-fx-data-beam-nonprod-b5f4&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22))), which was built and tested via:
1. disable beam jobs in Jenkins
2. run beam-build targetting this branch
3. re-run beam-build from main so reset the version propagated
4. enable and build beam-stage from https://github.com/mozilla-services/cloudops-infra/compare/SVCSE-4252-testing?expand=1 which hard-codes the new code
5. re-enable beam-stage and beam-prod

Side note: this template build process will move to GHA in the repo as part of the GCPv2 migration.

There was an [error](https://mozilla.slack.com/archives/CF32SJCDS/p1782321256867169) but that was related to my testing an old version of the code that used a different URI for the artifact. https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/artifact_registry_file#name-2 is the identifier I ended up using since it flows naturally from IaC.

## Related Tickets & Documents

- [SVCSE-4252](https://mozilla-hub.atlassian.net/browse/SVCSE-4252)
- https://github.com/mozilla/dataservices-infra/pull/2037

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.


[SVCSE-4252]: https://mozilla-hub.atlassian.net/browse/SVCSE-4252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ