### PR TITLE
Filter out invalid doc versions in predecompress_submission_bytes counter

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/DecompressPayload.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/transforms/DecompressPayload.java
@@ -64,10 +64,11 @@ public class DecompressPayload
         try {
           Map<String, String> attributes = message.getAttributeMap();
 
-          // valid doc types and namespaces shouldn't have % or url-encoded characters
+          // valid namespaces, doc types, and versions shouldn't have % or url-encoded characters.
           boolean validUri = attributes != null
               && !attributes.getOrDefault("document_namespace", "").contains("%")
-              && !attributes.getOrDefault("document_type", "").contains("%");
+              && !attributes.getOrDefault("document_type", "").contains("%")
+              && !attributes.getOrDefault("document_version", "").contains("%");
           PerDocTypeCounter.inc(validUri ? attributes : null, "predecompress_submission_bytes",
               message.getPayload().length);
 


### PR DESCRIPTION
## Description

There are still a lot of garbage metrics because of the doc version ([current job](https://console.cloud.google.com/dataflow/jobs/us-west1/2026-07-20_20_14_40-15755647418290455725;step=;graphView=0?project=moz-fx-data-beam-prod-11f7&pageState=(%22dfTime%22:(%22d%22:%22PT6H%22))))

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.
