### PR TITLE
feat(ingestion-edge): allow flush-manager to run under restricted PSS and inherit node scheduling

### DIFF
--- a/ingestion-edge/bin/pytest-all
+++ b/ingestion-edge/bin/pytest-all
@@ -8,5 +8,5 @@ fi
 
 if ${REQUIRE_CODE_COVERAGE:-false}; then PYTEST_ADDOPTS+=" --cov-fail-under=100"; fi
 
-"$(dirname "$0")"/pytest --cov=./ingestion_edge/ --junitxml=test-results/pytest.xml && \
+"$(dirname "$0")"/pytest --cov=./ingestion_edge/ --cov-report=term-missing --junitxml=test-results/pytest.xml && \
   "$(dirname "$0")"/lint --junitxml=test-results/lint.xml

--- a/ingestion-edge/bin/pytest-all
+++ b/ingestion-edge/bin/pytest-all
@@ -6,7 +6,7 @@ if [ "$#" -gt 0 ]; then
     exit 1
 fi
 
-if ${REQUIRE_CODE_COVERAGE:-false}; then PYTEST_ADDOPTS+=" --cov-fail-under=100"; fi
+if ${REQUIRE_CODE_COVERAGE:-true}; then PYTEST_ADDOPTS+=" --cov-fail-under=100"; fi
 
 "$(dirname "$0")"/pytest --cov=./ingestion_edge/ --cov-report=term-missing --junitxml=test-results/pytest.xml && \
   "$(dirname "$0")"/lint --junitxml=test-results/lint.xml

--- a/ingestion-edge/bin/pytest-all
+++ b/ingestion-edge/bin/pytest-all
@@ -6,7 +6,7 @@ if [ "$#" -gt 0 ]; then
     exit 1
 fi
 
-if ${REQUIRE_CODE_COVERAGE:-true}; then PYTEST_ADDOPTS+=" --cov-fail-under=100"; fi
+if ${REQUIRE_CODE_COVERAGE:-false}; then PYTEST_ADDOPTS+=" --cov-fail-under=100"; fi
 
 "$(dirname "$0")"/pytest --cov=./ingestion_edge/ --junitxml=test-results/pytest.xml && \
   "$(dirname "$0")"/lint --junitxml=test-results/lint.xml

--- a/ingestion-edge/ingestion_edge/flush_manager.py
+++ b/ingestion-edge/ingestion_edge/flush_manager.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from functools import partial
 from multiprocessing.pool import ThreadPool
 from time import sleep
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 import json
 import os
 
@@ -129,7 +129,7 @@ parser.add_argument(
     default=[],
     type=json.loads,
     help="Tolerations for flush job pods as a JSON list of toleration objects with "
-    "snake_case keys (e.g. '[{\"key\": \"tenant\", \"operator\": \"Equal\", "
+    'snake_case keys (e.g. \'[{"key": "tenant", "operator": "Equal", '
     '"value": "ingestion-edge", "effect": "NoExecute"}]\'). Defaults to none. Set '
     "to match the workload's tolerations so drain Jobs are not evicted from tainted "
     "node pools.",
@@ -212,8 +212,8 @@ def _create_flush_job(
     namespace: str,
     service_account_name: str,
     restricted_security_context: bool = False,
-    node_selector: Dict[str, str] = None,
-    tolerations: List[dict] = None,
+    node_selector: Optional[Dict[str, str]] = None,
+    tolerations: Optional[List[dict]] = None,
 ) -> V1Job:
     logger.info(f"creating job: {name}")
     container_security_context = None
@@ -308,8 +308,8 @@ def flush_released_pvs(
     namespace: str,
     service_account_name: str,
     restricted_security_context: bool = False,
-    node_selector: Dict[str, str] = None,
-    tolerations: List[dict] = None,
+    node_selector: Optional[Dict[str, str]] = None,
+    tolerations: Optional[List[dict]] = None,
 ):
     """
     Flush persistent volumes.
@@ -421,8 +421,8 @@ def flush_released_pvs_and_delete_complete_jobs(
     namespace: str,
     service_account_name: str,
     restricted_security_context: bool = False,
-    node_selector: Dict[str, str] = None,
-    tolerations: List[dict] = None,
+    node_selector: Optional[Dict[str, str]] = None,
+    tolerations: Optional[List[dict]] = None,
 ):
     """Flush released persistent volumes then delete complete jobs.
 

--- a/ingestion-edge/ingestion_edge/flush_manager.py
+++ b/ingestion-edge/ingestion_edge/flush_manager.py
@@ -49,6 +49,12 @@ ALREADY_EXISTS = "AlreadyExists"
 CONFLICT = "Conflict"
 NOT_FOUND = "Not Found"
 
+# V1Toleration's __init__ accepts snake_case names (e.g. toleration_seconds),
+# but Kubernetes YAML/JSON conventionally uses camelCase (tolerationSeconds).
+# Map the wire-format names to Python attribute names so --tolerations JSON
+# can use either convention.
+_TOLERATION_KEY_MAP = {v: k for k, v in V1Toleration.attribute_map.items()}
+
 DEFAULT_IMAGE_VERSION = "latest"
 try:
     with open("version.json") as fp:
@@ -128,10 +134,11 @@ parser.add_argument(
     "--tolerations",
     default=[],
     type=json.loads,
-    help="Tolerations for flush job pods as a JSON list of toleration objects with "
-    'snake_case keys (e.g. \'[{"key": "tenant", "operator": "Equal", '
-    '"value": "ingestion-edge", "effect": "NoExecute"}]\'). Defaults to none. Set '
-    "to match the workload's tolerations so drain Jobs are not evicted from tainted "
+    help="Tolerations for flush job pods as a JSON list of toleration objects "
+    '(e.g. \'[{"key": "tenant", "operator": "Equal", "value": '
+    '"ingestion-edge", "effect": "NoExecute"}]\'). Keys may be snake_case '
+    "or camelCase (matching Kubernetes YAML). Defaults to none. Set to match "
+    "the workload's tolerations so drain Jobs are not evicted from tainted "
     "node pools.",
 )
 
@@ -224,6 +231,9 @@ def _create_flush_job(
             capabilities=V1Capabilities(drop=["ALL"]),
             seccomp_profile=V1SeccompProfile(type="RuntimeDefault"),
         )
+        # UID/GID 10001 matches the default non-root user baked into the
+        # mozcloud helm chart (mozilla/helm-charts). Keep in sync so the
+        # Job pod's fsGroup can chgrp the mounted PV.
         pod_security_context = V1PodSecurityContext(
             run_as_non_root=True,
             run_as_user=10001,
@@ -231,7 +241,10 @@ def _create_flush_job(
             fs_group=10001,
             seccomp_profile=V1SeccompProfile(type="RuntimeDefault"),
         )
-    toleration_objs = [V1Toleration(**t) for t in tolerations or ()] or None
+    toleration_objs = [
+        V1Toleration(**{_TOLERATION_KEY_MAP.get(k, k): v for k, v in t.items()})
+        for t in tolerations or ()
+    ] or None
     try:
         return batch_api.create_namespaced_job(
             namespace=namespace,

--- a/ingestion-edge/ingestion_edge/flush_manager.py
+++ b/ingestion-edge/ingestion_edge/flush_manager.py
@@ -231,9 +231,7 @@ def _create_flush_job(
             fs_group=10001,
             seccomp_profile=V1SeccompProfile(type="RuntimeDefault"),
         )
-    toleration_objs = (
-        [V1Toleration(**t) for t in tolerations] if tolerations else None
-    )
+    toleration_objs = [V1Toleration(**t) for t in tolerations or ()] or None
     try:
         return batch_api.create_namespaced_job(
             namespace=namespace,

--- a/ingestion-edge/ingestion_edge/flush_manager.py
+++ b/ingestion-edge/ingestion_edge/flush_manager.py
@@ -14,6 +14,7 @@ from kubernetes.config import load_incluster_config
 from kubernetes.client import (
     BatchV1Api,
     CoreV1Api,
+    V1Capabilities,
     V1Container,
     V1DeleteOptions,
     V1EnvVar,
@@ -28,10 +29,13 @@ from kubernetes.client import (
     V1PersistentVolumeClaimVolumeSource,
     V1PersistentVolumeSpec,
     V1Pod,
+    V1PodSecurityContext,
     V1PodSpec,
     V1PodTemplateSpec,
     V1Preconditions,
     V1ResourceRequirements,
+    V1SeccompProfile,
+    V1SecurityContext,
     V1Volume,
     V1VolumeMount,
 )
@@ -102,6 +106,14 @@ parser.add_argument(
     type=int,
     help="Number of seconds to wait for persistent volume claims to remain detached "
     "before deleting",
+)
+parser.add_argument(
+    "--enable-restricted-security-context",
+    action="store_true",
+    help="Add a securityContext to flush job pods that satisfies the Pod Security "
+    "Standard 'restricted' policy. Required on clusters that enforce PSS restricted "
+    "(e.g. GKE shared clusters); disabled by default for backwards compatibility with "
+    "clusters that don't enforce PSS and run containers as root.",
 )
 
 
@@ -180,8 +192,24 @@ def _create_flush_job(
     name: str,
     namespace: str,
     service_account_name: str,
+    restricted_security_context: bool = False,
 ) -> V1Job:
     logger.info(f"creating job: {name}")
+    container_security_context = None
+    pod_security_context = None
+    if restricted_security_context:
+        container_security_context = V1SecurityContext(
+            allow_privilege_escalation=False,
+            capabilities=V1Capabilities(drop=["ALL"]),
+            seccomp_profile=V1SeccompProfile(type="RuntimeDefault"),
+        )
+        pod_security_context = V1PodSecurityContext(
+            run_as_non_root=True,
+            run_as_user=10001,
+            run_as_group=10001,
+            fs_group=10001,
+            seccomp_profile=V1SeccompProfile(type="RuntimeDefault"),
+        )
     try:
         return batch_api.create_namespaced_job(
             namespace=namespace,
@@ -219,9 +247,11 @@ def _create_flush_job(
                                             if value
                                         },
                                     ),
+                                    security_context=container_security_context,
                                 )
                             ],
                             restart_policy="OnFailure",
+                            security_context=pod_security_context,
                             volumes=[
                                 V1Volume(
                                     name="queue",
@@ -253,6 +283,7 @@ def flush_released_pvs(
     image: str,
     namespace: str,
     service_account_name: str,
+    restricted_security_context: bool = False,
 ):
     """
     Flush persistent volumes.
@@ -277,7 +308,14 @@ def flush_released_pvs(
                 pvc = _create_pvc(api, name, namespace, pv)
                 _bind_pvc(api, pv, pvc)
             _create_flush_job(
-                batch_api, command, env, image, name, namespace, service_account_name
+                batch_api,
+                command,
+                env,
+                image,
+                name,
+                namespace,
+                service_account_name,
+                restricted_security_context,
             )
 
 
@@ -354,13 +392,21 @@ def flush_released_pvs_and_delete_complete_jobs(
     image: str,
     namespace: str,
     service_account_name: str,
+    restricted_security_context: bool = False,
 ):
     """Flush released persistent volumes then delete complete jobs.
 
     Run sequentially to avoid race conditions.
     """
     flush_released_pvs(
-        api, batch_api, command, env, image, namespace, service_account_name
+        api,
+        batch_api,
+        command,
+        env,
+        image,
+        namespace,
+        service_account_name,
+        restricted_security_context,
     )
     delete_complete_jobs(api, batch_api, namespace)
 
@@ -506,6 +552,7 @@ def main():
             args.image,
             args.namespace,
             args.service_account_name,
+            args.enable_restricted_security_context,
         ),
         partial(
             delete_detached_pvcs,

--- a/ingestion-edge/ingestion_edge/flush_manager.py
+++ b/ingestion-edge/ingestion_edge/flush_manager.py
@@ -36,6 +36,7 @@ from kubernetes.client import (
     V1ResourceRequirements,
     V1SeccompProfile,
     V1SecurityContext,
+    V1Toleration,
     V1Volume,
     V1VolumeMount,
 )
@@ -115,6 +116,24 @@ parser.add_argument(
     "(e.g. GKE shared clusters); disabled by default for backwards compatibility with "
     "clusters that don't enforce PSS and run containers as root.",
 )
+parser.add_argument(
+    "--node-selector",
+    default={},
+    type=json.loads,
+    help="nodeSelector for flush job pods as a JSON object (e.g. "
+    '\'{"tenant": "ingestion-edge"}\'). Defaults to no selector. Set to match the '
+    "workload's nodeSelector so drain Jobs schedule on the same node pool.",
+)
+parser.add_argument(
+    "--tolerations",
+    default=[],
+    type=json.loads,
+    help="Tolerations for flush job pods as a JSON list of toleration objects with "
+    "snake_case keys (e.g. '[{\"key\": \"tenant\", \"operator\": \"Equal\", "
+    '"value": "ingestion-edge", "effect": "NoExecute"}]\'). Defaults to none. Set '
+    "to match the workload's tolerations so drain Jobs are not evicted from tainted "
+    "node pools.",
+)
 
 
 @dataclass(frozen=True)
@@ -193,6 +212,8 @@ def _create_flush_job(
     namespace: str,
     service_account_name: str,
     restricted_security_context: bool = False,
+    node_selector: Dict[str, str] = None,
+    tolerations: List[dict] = None,
 ) -> V1Job:
     logger.info(f"creating job: {name}")
     container_security_context = None
@@ -210,6 +231,9 @@ def _create_flush_job(
             fs_group=10001,
             seccomp_profile=V1SeccompProfile(type="RuntimeDefault"),
         )
+    toleration_objs = (
+        [V1Toleration(**t) for t in tolerations] if tolerations else None
+    )
     try:
         return batch_api.create_namespaced_job(
             namespace=namespace,
@@ -263,6 +287,8 @@ def _create_flush_job(
                                 )
                             ],
                             service_account_name=service_account_name,
+                            node_selector=node_selector or None,
+                            tolerations=toleration_objs,
                         )
                     )
                 ),
@@ -284,6 +310,8 @@ def flush_released_pvs(
     namespace: str,
     service_account_name: str,
     restricted_security_context: bool = False,
+    node_selector: Dict[str, str] = None,
+    tolerations: List[dict] = None,
 ):
     """
     Flush persistent volumes.
@@ -316,6 +344,8 @@ def flush_released_pvs(
                 namespace,
                 service_account_name,
                 restricted_security_context,
+                node_selector,
+                tolerations,
             )
 
 
@@ -393,6 +423,8 @@ def flush_released_pvs_and_delete_complete_jobs(
     namespace: str,
     service_account_name: str,
     restricted_security_context: bool = False,
+    node_selector: Dict[str, str] = None,
+    tolerations: List[dict] = None,
 ):
     """Flush released persistent volumes then delete complete jobs.
 
@@ -407,6 +439,8 @@ def flush_released_pvs_and_delete_complete_jobs(
         namespace,
         service_account_name,
         restricted_security_context,
+        node_selector,
+        tolerations,
     )
     delete_complete_jobs(api, batch_api, namespace)
 
@@ -553,6 +587,8 @@ def main():
             args.namespace,
             args.service_account_name,
             args.enable_restricted_security_context,
+            args.node_selector,
+            args.tolerations,
         ),
         partial(
             delete_detached_pvcs,

--- a/ingestion-edge/tests/unit/flush_manager/test_create_job.py
+++ b/ingestion-edge/tests/unit/flush_manager/test_create_job.py
@@ -282,6 +282,66 @@ def test_flush_released_pvs_without_restricted_security_context(
     pod_spec = body.spec.template.spec
     assert pod_spec.security_context is None
     assert pod_spec.containers[0].security_context is None
+    assert pod_spec.node_selector is None
+    assert pod_spec.tolerations is None
+
+
+def test_flush_released_pvs_with_node_selector_and_tolerations(
+    api: MagicMock, batch_api: MagicMock
+):
+    """Node selector and tolerations propagate to the Job PodSpec."""
+    api.list_persistent_volume.return_value = V1PersistentVolumeList(
+        items=[
+            V1PersistentVolume(
+                metadata=V1ObjectMeta(name="pv-0"),
+                spec=V1PersistentVolumeSpec(
+                    claim_ref=V1ObjectReference(
+                        name="queue-web-0", namespace="namespace"
+                    ),
+                    persistent_volume_reclaim_policy="Retain",
+                ),
+                status=V1PersistentVolumeStatus(phase="Released"),
+            ),
+        ]
+    )
+
+    def create_pvc(namespace, body):
+        body.metadata.uid = "uid-" + body.metadata.name
+        body.metadata.resource_version = "1"
+        return body
+
+    api.create_namespaced_persistent_volume_claim.side_effect = create_pvc
+    batch_api.list_namespaced_job.return_value = V1JobList(items=[])
+
+    flush_released_pvs(
+        api,
+        batch_api,
+        ["command"],
+        [],
+        "image",
+        "namespace",
+        "service-account-name",
+        node_selector={"tenant": "ingestion-edge"},
+        tolerations=[
+            {
+                "key": "tenant",
+                "operator": "Equal",
+                "value": "ingestion-edge",
+                "effect": "NoExecute",
+            }
+        ],
+    )
+
+    batch_api.create_namespaced_job.assert_called_once()
+    body = batch_api.create_namespaced_job.call_args.kwargs["body"]
+    pod_spec = body.spec.template.spec
+    assert pod_spec.node_selector == {"tenant": "ingestion-edge"}
+    assert len(pod_spec.tolerations) == 1
+    toleration = pod_spec.tolerations[0]
+    assert toleration.key == "tenant"
+    assert toleration.operator == "Equal"
+    assert toleration.value == "ingestion-edge"
+    assert toleration.effect == "NoExecute"
 
 
 def test_create_pvc_raises_server_error(api: MagicMock, batch_api: MagicMock):

--- a/ingestion-edge/tests/unit/flush_manager/test_create_job.py
+++ b/ingestion-edge/tests/unit/flush_manager/test_create_job.py
@@ -195,6 +195,95 @@ def test_create_flush_job_raises_server_error(api: MagicMock, batch_api: MagicMo
     batch_api.list_namespaced_job.called_once_with("namespace")
 
 
+def test_flush_released_pvs_with_restricted_security_context(
+    api: MagicMock, batch_api: MagicMock
+):
+    api.list_persistent_volume.return_value = V1PersistentVolumeList(
+        items=[
+            V1PersistentVolume(
+                metadata=V1ObjectMeta(name="pv-0"),
+                spec=V1PersistentVolumeSpec(
+                    claim_ref=V1ObjectReference(
+                        name="queue-web-0", namespace="namespace"
+                    ),
+                    persistent_volume_reclaim_policy="Retain",
+                ),
+                status=V1PersistentVolumeStatus(phase="Released"),
+            ),
+        ]
+    )
+
+    def create_pvc(namespace, body):
+        body.metadata.uid = "uid-" + body.metadata.name
+        body.metadata.resource_version = "1"
+        return body
+
+    api.create_namespaced_persistent_volume_claim.side_effect = create_pvc
+    batch_api.list_namespaced_job.return_value = V1JobList(items=[])
+
+    flush_released_pvs(
+        api,
+        batch_api,
+        ["command"],
+        [],
+        "image",
+        "namespace",
+        "service-account-name",
+        restricted_security_context=True,
+    )
+
+    batch_api.create_namespaced_job.assert_called_once()
+    body = batch_api.create_namespaced_job.call_args.kwargs["body"]
+    pod_spec = body.spec.template.spec
+    assert pod_spec.security_context.run_as_non_root is True
+    assert pod_spec.security_context.run_as_user == 10001
+    assert pod_spec.security_context.run_as_group == 10001
+    assert pod_spec.security_context.fs_group == 10001
+    assert pod_spec.security_context.seccomp_profile.type == "RuntimeDefault"
+    container_sc = pod_spec.containers[0].security_context
+    assert container_sc.allow_privilege_escalation is False
+    assert container_sc.capabilities.drop == ["ALL"]
+    assert container_sc.seccomp_profile.type == "RuntimeDefault"
+
+
+def test_flush_released_pvs_without_restricted_security_context(
+    api: MagicMock, batch_api: MagicMock
+):
+    """Default behavior: no securityContext, preserves v1 cluster compatibility."""
+    api.list_persistent_volume.return_value = V1PersistentVolumeList(
+        items=[
+            V1PersistentVolume(
+                metadata=V1ObjectMeta(name="pv-0"),
+                spec=V1PersistentVolumeSpec(
+                    claim_ref=V1ObjectReference(
+                        name="queue-web-0", namespace="namespace"
+                    ),
+                    persistent_volume_reclaim_policy="Retain",
+                ),
+                status=V1PersistentVolumeStatus(phase="Released"),
+            ),
+        ]
+    )
+
+    def create_pvc(namespace, body):
+        body.metadata.uid = "uid-" + body.metadata.name
+        body.metadata.resource_version = "1"
+        return body
+
+    api.create_namespaced_persistent_volume_claim.side_effect = create_pvc
+    batch_api.list_namespaced_job.return_value = V1JobList(items=[])
+
+    flush_released_pvs(
+        api, batch_api, ["command"], [], "image", "namespace", "service-account-name"
+    )
+
+    batch_api.create_namespaced_job.assert_called_once()
+    body = batch_api.create_namespaced_job.call_args.kwargs["body"]
+    pod_spec = body.spec.template.spec
+    assert pod_spec.security_context is None
+    assert pod_spec.containers[0].security_context is None
+
+
 def test_create_pvc_raises_server_error(api: MagicMock, batch_api: MagicMock):
     api.list_persistent_volume.return_value = V1PersistentVolumeList(
         items=[

--- a/ingestion-edge/tests/unit/flush_manager/test_create_job.py
+++ b/ingestion-edge/tests/unit/flush_manager/test_create_job.py
@@ -344,6 +344,60 @@ def test_flush_released_pvs_with_node_selector_and_tolerations(
     assert toleration.effect == "NoExecute"
 
 
+def test_flush_released_pvs_accepts_camelcase_toleration_keys(
+    api: MagicMock, batch_api: MagicMock
+):
+    """Toleration dicts with camelCase keys (matching K8s YAML) are accepted."""
+    api.list_persistent_volume.return_value = V1PersistentVolumeList(
+        items=[
+            V1PersistentVolume(
+                metadata=V1ObjectMeta(name="pv-0"),
+                spec=V1PersistentVolumeSpec(
+                    claim_ref=V1ObjectReference(
+                        name="queue-web-0", namespace="namespace"
+                    ),
+                    persistent_volume_reclaim_policy="Retain",
+                ),
+                status=V1PersistentVolumeStatus(phase="Released"),
+            ),
+        ]
+    )
+
+    def create_pvc(namespace, body):
+        body.metadata.uid = "uid-" + body.metadata.name
+        body.metadata.resource_version = "1"
+        return body
+
+    api.create_namespaced_persistent_volume_claim.side_effect = create_pvc
+    batch_api.list_namespaced_job.return_value = V1JobList(items=[])
+
+    flush_released_pvs(
+        api,
+        batch_api,
+        ["command"],
+        [],
+        "image",
+        "namespace",
+        "service-account-name",
+        tolerations=[
+            {
+                "key": "tenant",
+                "operator": "Exists",
+                "effect": "NoExecute",
+                "tolerationSeconds": 30,
+            }
+        ],
+    )
+
+    batch_api.create_namespaced_job.assert_called_once()
+    body = batch_api.create_namespaced_job.call_args.kwargs["body"]
+    toleration = body.spec.template.spec.tolerations[0]
+    assert toleration.key == "tenant"
+    assert toleration.operator == "Exists"
+    assert toleration.effect == "NoExecute"
+    assert toleration.toleration_seconds == 30
+
+
 def test_create_pvc_raises_server_error(api: MagicMock, batch_api: MagicMock):
     api.list_persistent_volume.return_value = V1PersistentVolumeList(
         items=[


### PR DESCRIPTION
## Description

Adds opt-in flags to `flush_manager.py` so drain Jobs work correctly on GKE shared clusters that enforce PodSecurity `restricted:latest` and use taints to isolate tenant workloads:

- `--enable-restricted-security-context`: adds a pod- and container-level `securityContext` that satisfies PSS `restricted`.
- `--node-selector` (JSON dict): sets `nodeSelector` on the drain Job's PodSpec.
- `--tolerations` (JSON list of snake_case toleration dicts): sets `tolerations` on the drain Job's PodSpec.

### securityContext applied when `--enable-restricted-security-context` is set

```
container:
  allowPrivilegeEscalation: false
  capabilities:
    drop: [ALL]
  seccompProfile:
    type: RuntimeDefault
pod:
  runAsNonRoot: true
  runAsUser: 10001
  runAsGroup: 10001
  fsGroup: 10001
  seccompProfile:
    type: RuntimeDefault
```

## Motivation

On GKE shared clusters that enforce PSS `restricted:latest` (e.g. `dataservices-high` used by the SVCSE-4142 ingestion-edge v2 deployment), the current Job template is rejected by the admission controller with:

```
Error creating: pods "flush-pvc-..." is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false, unrestricted capabilities, runAsNonRoot != true, seccompProfile
```

Drain never runs, causing Released PVs / orphan PVCs to accumulate. Observed during Phase 3 of the SVCSE-4142 cutover with ~300 orphan PVCs.

Once PSS admission is satisfied, Jobs still need to schedule onto the same tainted node pool as the StatefulSet they drain. On `dataservices-high`, the `ingestion-edge-1` node pool carries `tenant=ingestion-edge:NoExecute`. Without matching `tolerations` (and a matching `nodeSelector` so the scheduler doesn't just pick any node), the Jobs would fall through to the untainted default pool: it would appear to work (StorageClass is `WaitForFirstConsumer` zonal `pd-balanced`, and the default pool spans the same zones), but silently cross the tenant isolation boundary. If the default pool ever loses a zone or gains its own taint, Jobs go Pending and the SVCSE-4142 symptom returns with no alarm.

## Behavior on v1 (defaults)

All three flags default to off / empty:
- `--enable-restricted-security-context` defaults to `False`
- `--node-selector` defaults to `{}` -> PodSpec.nodeSelector is `None`
- `--tolerations` defaults to `[]` -> PodSpec.tolerations is `None`

v1's cloudops-infra cluster doesn't enforce PSS, runs containers as root, and has no scheduling constraints on the ingestion-edge node pool. Not opting into any of the flags keeps existing v1 behavior identical.

## Behavior on v2 (opt in)

The v2 chart's flush-manager container will pass all three flags in its args (follow-up PR in `dataservices-infra`), sourcing `--node-selector` and `--tolerations` from the same YAML anchors the StatefulSet uses so they stay in sync by construction:

```yaml
--enable-restricted-security-context
--node-selector={"tenant": "ingestion-edge"}
--tolerations=[{"key": "tenant", "operator": "Equal", "value": "ingestion-edge", "effect": "NoExecute"}]
```

Drain Jobs then start under `restricted:latest`, schedule onto `ingestion-edge-1`, and drain telemetry data on the same isolated node pool as the workload that queued it.

## Related Tickets & Documents

- SVCSE-4142
- SVCSE-3814 (related: alerting for this exact class of failure)
- SVCSE-4440 (related: namespace-scoped PVC-scan loop; would provide reconciliation for orphans that predate this fix)