### PR TITLE
[DENG-11464] Drop third-party-module pings with unsanitized dll paths

### DIFF
--- a/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
+++ b/ingestion-beam/src/main/java/com/mozilla/telemetry/decoder/MessageScrubber.java
@@ -324,6 +324,9 @@ public class MessageScrubber {
         && "new-metric-capture-emulation".equals(docType)) {
       throw new MessageShouldBeDroppedException("1817821");
     }
+    if (bug11464Affected(namespace, docType, json)) {
+      throw new MessageShouldBeDroppedException("DENG-11464");
+    }
 
     if (bug1712850Affected(attributes)) {
       if (json.hasNonNull("search_query") || json.hasNonNull("matched_keywords")) {
@@ -553,6 +556,37 @@ public class MessageScrubber {
   static boolean bug1712850Affected(Map<String, String> attributes) {
     return "contextual-services".equals(attributes.get(Attribute.DOCUMENT_NAMESPACE))
         && "quicksuggest-impression".equals(attributes.get(Attribute.DOCUMENT_TYPE));
+  }
+
+  // A resolved DLL name in a third-party-modules ping should either be a bare file name or a path
+  // rooted at one of these environment variables. Anything else that still contains a path
+  // separator is treated as an unsanitized path. See DENG-11464.
+  private static final Set<String> DENG_11464_ALLOWED_DLL_PATH_PREFIXES = ImmutableSet
+      .of("%programfiles%\\", "%programfiles% (x86)\\", "%systemroot%\\", "%temp%\\");
+
+  private static boolean bug11464Affected(String namespace, String docType, ObjectNode json) {
+    if (!ParseUri.TELEMETRY.equals(namespace) || !"third-party-modules".equals(docType)) {
+      return false;
+    }
+    boolean windows = Optional
+        .ofNullable(json.path("environment").path("system").path("os").path("name").textValue())
+        .filter(name -> name.startsWith("Windows")).isPresent();
+    if (!windows) {
+      return false;
+    }
+    return Streams.stream(json.path("payload").path("modules").elements()) //
+        .map(module -> module.path("resolvedDllName")) //
+        .filter(JsonNode::isTextual) //
+        .map(JsonNode::textValue) //
+        .anyMatch(MessageScrubber::isUnsanitizedDllPath);
+  }
+
+  private static boolean isUnsanitizedDllPath(String resolvedDllName) {
+    if (resolvedDllName.indexOf('\\') < 0) {
+      return false;
+    }
+    String lower = resolvedDllName.toLowerCase();
+    return DENG_11464_ALLOWED_DLL_PATH_PREFIXES.stream().noneMatch(lower::startsWith);
   }
 
   // See bug 1733118 for discussion of affected versions, etc.

--- a/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
+++ b/ingestion-beam/src/test/java/com/mozilla/telemetry/decoder/MessageScrubberTest.java
@@ -199,6 +199,53 @@ public class MessageScrubberTest {
   }
 
   @Test
+  public void testShouldScrubThirdPartyModulesDeng11464() throws Exception {
+    Map<String, String> attributes = Maps.newHashMap(
+        ImmutableMap.<String, String>builder().put(Attribute.DOCUMENT_NAMESPACE, "telemetry")
+            .put(Attribute.DOCUMENT_TYPE, "third-party-modules").build());
+
+    // A module whose resolved DLL name is a full path that isn't rooted at an allowed
+    // environment variable leaks the local username and should be dropped.
+    ObjectNode leaked = Json.readObjectNode(("{\n" //
+        + "  \"environment\": { \"system\": { \"os\": { \"name\": \"Windows_NT\" } } },\n" //
+        + "  \"payload\": { \"modules\": [\n" //
+        + "    { \"resolvedDllName\": \"%SystemRoot%\\\\System32\\\\ntdll.dll\" },\n" //
+        + "    { \"resolvedDllName\": \"C:\\\\Users\\\\johndoe\\\\evil.dll\" }\n" //
+        + "  ] }\n" //
+        + "}").getBytes(StandardCharsets.UTF_8));
+    assertThrows(MessageShouldBeDroppedException.class,
+        () -> MessageScrubber.scrub(attributes, leaked));
+
+    // Bare file names and paths rooted at the allowed environment variables are fine.
+    ObjectNode sanitized = Json.readObjectNode(("{\n" //
+        + "  \"environment\": { \"system\": { \"os\": { \"name\": \"Windows_NT\" } } },\n" //
+        + "  \"payload\": { \"modules\": [\n" //
+        + "    { \"resolvedDllName\": \"ntdll.dll\" },\n" //
+        + "    { \"resolvedDllName\": \"%ProgramFiles%\\\\Mozilla Firefox\\\\xul.dll\" },\n" //
+        + "    { \"resolvedDllName\": \"%ProgramFiles% (x86)\\\\foo\\\\bar.dll\" },\n" //
+        + "    { \"resolvedDllName\": \"%SystemRoot%\\\\System32\\\\ntdll.dll\" },\n" //
+        + "    { \"resolvedDllName\": \"%TEMP%\\\\baz.dll\" }\n" //
+        + "  ] }\n" //
+        + "}").getBytes(StandardCharsets.UTF_8));
+    MessageScrubber.scrub(attributes, sanitized);
+
+    // A leaked path on a non-Windows OS is out of scope for this rule.
+    ObjectNode nonWindows = Json.readObjectNode(("{\n" //
+        + "  \"environment\": { \"system\": { \"os\": { \"name\": \"Linux\" } } },\n" //
+        + "  \"payload\": { \"modules\": [\n" //
+        + "    { \"resolvedDllName\": \"C:\\\\Users\\\\johndoe\\\\evil.dll\" }\n" //
+        + "  ] }\n" //
+        + "}").getBytes(StandardCharsets.UTF_8));
+    MessageScrubber.scrub(attributes, nonWindows);
+
+    // The rule only applies to telemetry third-party-modules pings.
+    Map<String, String> otherDocType = Maps.newHashMap(
+        ImmutableMap.<String, String>builder().put(Attribute.DOCUMENT_NAMESPACE, "telemetry")
+            .put(Attribute.DOCUMENT_TYPE, "not-third-party-modules").build());
+    MessageScrubber.scrub(otherDocType, leaked);
+  }
+
+  @Test
   public void testShouldScrubBhrBug1562011() throws Exception {
     ObjectNode ping = Json.readObjectNode(("{\n" //
         + "  \"payload\": {\n" //


### PR DESCRIPTION
## Description

See https://mozilla-hub.atlassian.net/browse/DENG-11464

This drops third party module pings with unsanitized dll paths. Only affects older Windows versions.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

## Merging Guidelines

### Changes affecting ingestion-edge

Code updates are always safe to merge since production code updates are always
deployed manually.

### Changes affecting ingestion-sink

Code updates are always safe to merge since production code updates are always
deployed manually. See [these instructions](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27921000/Ingestion+Sink#IngestionSink-Toupdatethecodeversion)
for updating the code version.

### Changes affecting ingestion-beam (including ingestion-core)

- Only merge changes to `main` that you want to propagate to production automatically
- Check [pipeline latency](https://yardstick.mozilla.org/d/bZHv1mUMk/pipeline-latency?orgId=1&from=now-6h&to=now) before merging, particularly if:
  - The merge will occur within 2 hours of the UTC date change, or
  - You are merging multiple PRs in quick suggestion

See the full [code deployment policy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922303/Ingestion+Beam#Prod-Code-Deployment-Policy) for details.
